### PR TITLE
fix: bump up TTL for expiration test

### DIFF
--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -93,7 +93,7 @@ func testExpiration(t *testing.T, c cache.Cache) {
 
 	key := cache.NewKey("test-key")
 
-	writer, err := c.Create(ctx, key, nil, 10*time.Millisecond)
+	writer, err := c.Create(ctx, key, nil, time.Millisecond*250)
 	assert.NoError(t, err)
 
 	_, err = writer.Write([]byte("test data"))
@@ -106,7 +106,7 @@ func testExpiration(t *testing.T, c cache.Cache) {
 	assert.NoError(t, err)
 	assert.NoError(t, reader.Close())
 
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	_, _, err = c.Open(ctx, key)
 	assert.IsError(t, err, os.ErrNotExist)


### PR DESCRIPTION
This was intermittently failing for the S3 test, as the create+write+close would sometimes exceed 10 milliseconds, leading to the object expiring before the valid open could be called.