### PR TITLE
fix: cloning large repo's failed with `fatal: early EOF`

### DIFF
--- a/internal/strategy/git/proxy.go
+++ b/internal/strategy/git/proxy.go
@@ -1,59 +1,20 @@
 package git
 
 import (
-	"io"
 	"log/slog"
 	"net/http"
 
-	"github.com/block/cachew/internal/httputil"
 	"github.com/block/cachew/internal/logging"
 )
 
 // forwardToUpstream forwards a request to the upstream Git server.
 func (s *Strategy) forwardToUpstream(w http.ResponseWriter, r *http.Request, host, pathValue string) {
-	ctx := r.Context()
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(r.Context())
 
-	upstreamURL := "https://" + host + "/" + pathValue
-	if r.URL.RawQuery != "" {
-		upstreamURL += "?" + r.URL.RawQuery
-	}
-
-	logger.DebugContext(ctx, "Forwarding to upstream",
+	logger.DebugContext(r.Context(), "Forwarding to upstream",
 		slog.String("method", r.Method),
-		slog.String("upstream_url", upstreamURL))
+		slog.String("host", host),
+		slog.String("path", pathValue))
 
-	upstreamReq, err := http.NewRequestWithContext(ctx, r.Method, upstreamURL, r.Body)
-	if err != nil {
-		httputil.ErrorResponse(w, r, http.StatusInternalServerError, "failed to create upstream request")
-		return
-	}
-
-	// Copy relevant headers
-	for _, header := range []string{"Content-Type", "Content-Length", "Content-Encoding", "Accept", "Accept-Encoding", "Git-Protocol"} {
-		if v := r.Header.Get(header); v != "" {
-			upstreamReq.Header.Set(header, v)
-		}
-	}
-
-	resp, err := s.httpClient.Do(upstreamReq)
-	if err != nil {
-		logger.ErrorContext(ctx, "Upstream request failed", slog.String("error", err.Error()))
-		httputil.ErrorResponse(w, r, http.StatusBadGateway, "upstream request failed")
-		return
-	}
-	defer resp.Body.Close()
-
-	// Copy response headers
-	for key, values := range resp.Header {
-		for _, value := range values {
-			w.Header().Add(key, value)
-		}
-	}
-
-	w.WriteHeader(resp.StatusCode)
-
-	if _, err := io.Copy(w, resp.Body); err != nil {
-		logger.ErrorContext(ctx, "Failed to stream upstream response", slog.String("error", err.Error()))
-	}
+	s.proxy.ServeHTTP(w, r)
 }


### PR DESCRIPTION
This only manifested with `--bare --mirror` because the clones are so large, due to including all refs.

Also switched to using `httputil.ReverseProxy`, which is more robust.

```
~/dev/cachew $ rm -rf git-source ; time git clone --bare --mirror http://127.0.0.1:8080/git/github.com/git/git.git git-source
Cloning into bare repository 'git-source'...
remote: Enumerating objects: 807474, done.
remote: Counting objects: 100% (8533/8533), done.
remote: Compressing objects: 100% (7947/7947), done.
error: RPC failed; curl 18 transfer closed with outstanding read data remaining
error: 297 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
git clone --bare --mirror http://127.0.0.1:8080/git/github.com/git/git.git   5.26s user 1.17s system 21% cpu 30.509 total
```

Once the cache is populated, cloning git takes half the time:

```
~/dev/cachew $ rm -rf git-source ; time git clone http://127.0.0.1:8080/git/github.com/git/git.git git-source
Cloning into 'git-source'...
remote: Enumerating objects: 403536, done.
remote: Counting objects: 100% (756/756), done.
remote: Compressing objects: 100% (363/363), done.
remote: Total 403536 (delta 532), reused 498 (delta 393), pack-reused 402780 (from 4)
Receiving objects: 100% (403536/403536), 282.29 MiB | 19.06 MiB/s, done.
Resolving deltas: 100% (305003/305003), done.
git clone http://127.0.0.1:8080/git/github.com/git/git.git git-source  18.61s user 2.65s system 96% cpu 21.940 total
~/dev/cachew $ rm -rf git-source ; time git clone http://127.0.0.1:8080/git/github.com/git/git.git git-source
Cloning into 'git-source'...
remote: Enumerating objects: 403536, done.
remote: Counting objects: 100% (403536/403536), done.
remote: Compressing objects: 100% (95986/95986), done.
remote: Total 403536 (delta 305001), reused 403485 (delta 304954), pack-reused 0 (from 0)
Receiving objects: 100% (403536/403536), 282.15 MiB | 117.21 MiB/s, done.
Resolving deltas: 100% (305001/305001), done.
git clone http://127.0.0.1:8080/git/github.com/git/git.git git-source  18.11s user 2.34s system 206% cpu 9.916 total
```