### PR TITLE
fix: periodically perform a fast check for new ref's

### DIFF
--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bufio"
 	"context"
 	"log/slog"
 	"net/http"
@@ -8,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/alecthomas/errors"
 
@@ -17,7 +20,8 @@ import (
 
 // serveFromBackend serves a Git request using git http-backend.
 func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, c *clone) {
-	logger := logging.FromContext(r.Context())
+	ctx := r.Context()
+	logger := logging.FromContext(ctx)
 
 	gitPath, err := exec.LookPath("git")
 	if err != nil {
@@ -92,21 +96,155 @@ func (s *Strategy) executeClone(ctx context.Context, c *clone) error {
 func (s *Strategy) executeFetch(ctx context.Context, c *clone) error {
 	logger := logging.FromContext(ctx)
 
+	// Try to acquire the semaphore
+	select {
+	case <-c.fetchSem:
+		// We acquired the semaphore, perform the fetch
+		defer func() {
+			// Release the semaphore
+			c.fetchSem <- struct{}{}
+		}()
+	case <-ctx.Done():
+		return errors.Wrap(ctx.Err(), "context cancelled before acquiring fetch semaphore")
+	default:
+		// Semaphore is held by another goroutine, wait for it
+		logger.DebugContext(ctx, "Fetch already in progress, waiting")
+		select {
+		case <-c.fetchSem:
+			// Fetch completed by another goroutine, release and return
+			c.fetchSem <- struct{}{}
+			return nil
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "context cancelled while waiting for fetch")
+		}
+	}
+
 	// #nosec G204 - c.path is controlled by us
 	// Configure git for large repositories to avoid network buffer issues
+	// Use 'remote update' for mirror clones to properly handle ref updates and pruning
 	cmd := exec.CommandContext(ctx, "git", "-C", c.path,
 		"-c", "http.postBuffer=524288000", // 500MB buffer
 		"-c", "http.lowSpeedLimit=1000", // 1KB/s minimum speed
 		"-c", "http.lowSpeedTime=600", // 10 minute timeout at low speed
-		"fetch", "--all")
+		"remote", "update", "--prune")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.ErrorContext(ctx, "git fetch failed",
+		logger.ErrorContext(ctx, "git remote update failed",
 			slog.String("error", err.Error()),
 			slog.String("output", string(output)))
-		return errors.Wrap(err, "git fetch")
+		return errors.Wrap(err, "git remote update")
 	}
 
-	logger.DebugContext(ctx, "git fetch succeeded", slog.String("output", string(output)))
+	logger.DebugContext(ctx, "git remote update succeeded", slog.String("output", string(output)))
 	return nil
+}
+
+// ensureRefsUpToDate checks if upstream has refs we don't have and fetches if needed.
+// Uses a short-lived cache to avoid excessive ls-remote calls.
+func (s *Strategy) ensureRefsUpToDate(ctx context.Context, c *clone) error {
+	logger := logging.FromContext(ctx)
+
+	c.mu.Lock()
+	// Check if we've done a recent ref check
+	if c.refCheckValid && time.Since(c.lastRefCheck) < s.config.RefCheckInterval {
+		c.mu.Unlock()
+		logger.DebugContext(ctx, "Skipping ref check, recently checked",
+			slog.Duration("since_last_check", time.Since(c.lastRefCheck)))
+		return nil
+	}
+	c.lastRefCheck = time.Now()
+	c.mu.Unlock()
+
+	logger.DebugContext(ctx, "Checking upstream for new refs",
+		slog.String("upstream", c.upstreamURL))
+
+	// Get local refs
+	localRefs, err := s.getLocalRefs(ctx, c)
+	if err != nil {
+		return errors.Wrap(err, "get local refs")
+	}
+
+	// Get upstream refs
+	upstreamRefs, err := s.getUpstreamRefs(ctx, c)
+	if err != nil {
+		return errors.Wrap(err, "get upstream refs")
+	}
+
+	// Check if upstream has any refs we don't have or refs that have been updated
+	// Skip peeled refs (refs ending in ^{}) as they're not real refs
+	needsFetch := false
+	for ref, upstreamSHA := range upstreamRefs {
+		// Skip peeled tag refs like refs/tags/v1.0.0^{}
+		if strings.HasSuffix(ref, "^{}") {
+			continue
+		}
+		localSHA, exists := localRefs[ref]
+		if !exists || localSHA != upstreamSHA {
+			logger.DebugContext(ctx, "Upstream ref differs from local",
+				slog.String("ref", ref),
+				slog.String("upstream_sha", upstreamSHA),
+				slog.String("local_sha", localSHA))
+			needsFetch = true
+			break
+		}
+	}
+
+	if !needsFetch {
+		c.mu.Lock()
+		c.refCheckValid = true
+		c.mu.Unlock()
+		logger.DebugContext(ctx, "No upstream changes detected")
+		return nil
+	}
+
+	logger.InfoContext(ctx, "Upstream has new or updated refs, fetching")
+	err = s.executeFetch(ctx, c)
+	if err == nil {
+		c.mu.Lock()
+		c.refCheckValid = true
+		c.mu.Unlock()
+	}
+	return err
+}
+
+// getLocalRefs returns a map of ref names to SHAs for the local clone.
+func (s *Strategy) getLocalRefs(ctx context.Context, c *clone) (map[string]string, error) {
+	// #nosec G204 - c.path is controlled by us
+	// Use --head to include HEAD symbolic ref
+	cmd := exec.CommandContext(ctx, "git", "-C", c.path, "show-ref", "--head")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrap(err, "git show-ref")
+	}
+
+	return ParseGitRefs(output), nil
+}
+
+// getUpstreamRefs returns a map of ref names to SHAs for the upstream repository.
+func (s *Strategy) getUpstreamRefs(ctx context.Context, c *clone) (map[string]string, error) {
+	// #nosec G204 - c.upstreamURL is controlled by us
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", c.upstreamURL)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrap(err, "git ls-remote")
+	}
+
+	return ParseGitRefs(output), nil
+}
+
+// ParseGitRefs parses the output of git show-ref or git ls-remote.
+// Format: <SHA> <ref>.
+func ParseGitRefs(output []byte) map[string]string {
+	refs := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			sha := parts[0]
+			ref := parts[1]
+			refs[ref] = sha
+		}
+	}
+	return refs
 }


### PR DESCRIPTION
At least every N seconds (10 by default), we'll poll the upstream git server to see if there are new refs we need to pull. If there are, we update the local mirror then serve.