### PR TITLE
feat: Implement go mod proxy strategy

### DIFF
--- a/internal/strategy/gomod.go
+++ b/internal/strategy/gomod.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	Register("gomod", NewGoMod)
+	Register("gomod", "Caches Go module proxy requests.", NewGoMod)
 }
 
 // GoModConfig represents the configuration for the Go module proxy strategy.
@@ -55,7 +55,7 @@ type GoMod struct {
 var _ Strategy = (*GoMod)(nil)
 
 // NewGoMod creates a new Go module proxy strategy.
-func NewGoMod(ctx context.Context, scheduler jobscheduler.Scheduler, config GoModConfig, cache cache.Cache, mux Mux) (*GoMod, error) {
+func NewGoMod(ctx context.Context, config GoModConfig, scheduler jobscheduler.Scheduler, cache cache.Cache, mux Mux) (*GoMod, error) {
 	parsedURL, err := url.Parse(config.Proxy)
 	if err != nil {
 		return nil, fmt.Errorf("invalid proxy URL: %w", err)

--- a/internal/strategy/gomod_test.go
+++ b/internal/strategy/gomod_test.go
@@ -146,11 +146,11 @@ func setupGoModTest(t *testing.T) (*mockGoModServer, *http.ServeMux, context.Con
 	t.Cleanup(func() { _ = memCache.Close() })
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewGoMod(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.GoModConfig{
+	_, err = strategy.NewGoMod(ctx, strategy.GoModConfig{
 		Proxy:        mock.server.URL,
 		MutableTTL:   5 * time.Minute,
 		ImmutableTTL: 168 * time.Hour,
-	}, memCache, mux)
+	}, jobscheduler.New(ctx, jobscheduler.Config{}), memCache, mux)
 	assert.NoError(t, err)
 
 	return mock, mux, ctx


### PR DESCRIPTION
# What

Implements a caching strategy for the Go module proxy as described in https://proxy.golang.org/

# Why

To add support for caching go modules

# Tests

Implemented unit tests. In addition manual testing was performed as follows...

1. Create a `cachew.hcl`:
```hcl
memory {}

disk {
  root = "./state/cache"
}

gomod {
  proxy = "https://proxy.golang.org"
}
```

2. Run the proxy `./cachewd --config cachew.hcl`

3. Manual verification...

```bash
$ time curl http://localhost:8080/github.com/alecthomas/kong/@latest
{"Version":"v1.13.0","Time":"2025-11-12T21:31:44Z","Origin":{"VCS":"git","URL":"https://github.com/alecthomas/kong","Hash":"d8de683664a2581e93717b7e4e8f4b55e4beeff4","Ref":"refs/tags/v1.13.0"}}
real	0m0.179s
user	0m0.006s
sys	0m0.011s

$ time curl http://localhost:8080/github.com/alecthomas/kong/@latest
{"Version":"v1.13.0","Time":"2025-11-12T21:31:44Z","Origin":{"VCS":"git","URL":"https://github.com/alecthomas/kong","Hash":"d8de683664a2581e93717b7e4e8f4b55e4beeff4","Ref":"refs/tags/v1.13.0"}}
real	0m0.033s
user	0m0.006s
sys	0m0.013s
```