### PR TITLE
refactor: pass job scheduler to strategies

### DIFF
--- a/cmd/cachewd/main.go
+++ b/cmd/cachewd/main.go
@@ -13,13 +13,15 @@ import (
 
 	"github.com/block/cachew/internal/config"
 	"github.com/block/cachew/internal/httputil"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 )
 
 var cli struct {
-	Config        *os.File       `hcl:"-" help:"Configuration file path." placeholder:"PATH" required:"" default:"cachew.hcl"`
-	Bind          string         `hcl:"bind" default:"127.0.0.1:8080" help:"Bind address for the server."`
-	LoggingConfig logging.Config `embed:"" prefix:"log-"`
+	Config          *os.File            `hcl:"-" help:"Configuration file path." placeholder:"PATH" required:"" default:"cachew.hcl"`
+	Bind            string              `hcl:"bind" default:"127.0.0.1:8080" help:"Bind address for the server."`
+	SchedulerConfig jobscheduler.Config `embed:"" prefix:"scheduler-"`
+	LoggingConfig   logging.Config      `embed:"" prefix:"log-"`
 }
 
 func main() {
@@ -30,7 +32,9 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	err := config.Load(ctx, cli.Config, mux, parseEnvars())
+	scheduler := jobscheduler.New(ctx, cli.SchedulerConfig)
+
+	err := config.Load(ctx, cli.Config, scheduler, mux, parseEnvars())
 	kctx.FatalIfErrorf(err)
 
 	logger.InfoContext(ctx, "Starting cachewd", slog.String("bind", cli.Bind))

--- a/internal/cache/remote_test.go
+++ b/internal/cache/remote_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/cache/cachetest"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy"
 )
@@ -26,7 +27,7 @@ func TestRemoteClient(t *testing.T) {
 		t.Cleanup(func() { memCache.Close() })
 
 		mux := http.NewServeMux()
-		_, err = strategy.NewAPIV1(ctx, struct{}{}, memCache, mux)
+		_, err = strategy.NewAPIV1(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), struct{}{}, memCache, mux)
 		assert.NoError(t, err)
 		ts := httptest.NewServer(mux)
 		t.Cleanup(ts.Close)

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 )
 
@@ -27,7 +28,7 @@ type APIV1 struct {
 	logger *slog.Logger
 }
 
-func NewAPIV1(ctx context.Context, _ struct{}, cache cache.Cache, mux Mux) (*APIV1, error) {
+func NewAPIV1(ctx context.Context, _ jobscheduler.Scheduler, _ struct{}, cache cache.Cache, mux Mux) (*APIV1, error) {
 	s := &APIV1{
 		logger: logging.FromContext(ctx),
 		cache:  cache,

--- a/internal/strategy/artifactory.go
+++ b/internal/strategy/artifactory.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/handler"
 )
@@ -52,7 +53,7 @@ type Artifactory struct {
 
 var _ Strategy = (*Artifactory)(nil)
 
-func NewArtifactory(ctx context.Context, config ArtifactoryConfig, cache cache.Cache, mux Mux) (*Artifactory, error) {
+func NewArtifactory(ctx context.Context, _ jobscheduler.Scheduler, config ArtifactoryConfig, cache cache.Cache, mux Mux) (*Artifactory, error) {
 	u, err := url.Parse(config.Target)
 	if err != nil {
 		return nil, fmt.Errorf("invalid target URL: %w", err)

--- a/internal/strategy/artifactory_test.go
+++ b/internal/strategy/artifactory_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy"
 )
@@ -63,7 +64,7 @@ func setupArtifactoryTest(t *testing.T, config strategy.ArtifactoryConfig) (*moc
 	t.Cleanup(func() { memCache.Close() })
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewArtifactory(ctx, config, memCache, mux)
+	_, err = strategy.NewArtifactory(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), config, memCache, mux)
 	assert.NoError(t, err)
 
 	return mock, mux, ctx
@@ -210,7 +211,7 @@ func TestArtifactoryString(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	artifactory, err := strategy.NewArtifactory(ctx, strategy.ArtifactoryConfig{
+	artifactory, err := strategy.NewArtifactory(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.ArtifactoryConfig{
 		Target: "https://ec2.example.jfrog.io",
 	}, memCache, mux)
 	assert.NoError(t, err)
@@ -225,7 +226,7 @@ func TestArtifactoryInvalidTargetURL(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewArtifactory(ctx, strategy.ArtifactoryConfig{
+	_, err = strategy.NewArtifactory(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.ArtifactoryConfig{
 		Target: "://invalid-url",
 	}, memCache, mux)
 	assert.Error(t, err)

--- a/internal/strategy/git/bundle_test.go
+++ b/internal/strategy/git/bundle_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/git"
 )
@@ -22,7 +23,7 @@ func TestBundleHTTPEndpoint(t *testing.T) {
 	assert.NoError(t, err)
 	mux := newTestMux()
 
-	_, err = git.New(ctx, git.Config{
+	_, err = git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), git.Config{
 		MirrorRoot:     tmpDir,
 		BundleInterval: 24 * time.Hour,
 	}, memCache, mux)
@@ -98,7 +99,7 @@ func TestBundleInterval(t *testing.T) {
 			assert.NoError(t, err)
 			mux := newTestMux()
 
-			s, err := git.New(ctx, git.Config{
+			s, err := git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), git.Config{
 				MirrorRoot:     tmpDir,
 				BundleInterval: tt.bundleInterval,
 			}, memCache, mux)

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alecthomas/errors"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy"
 )
@@ -62,7 +63,7 @@ type Strategy struct {
 	ctx        context.Context
 }
 
-func New(ctx context.Context, config Config, cache cache.Cache, mux strategy.Mux) (*Strategy, error) {
+func New(ctx context.Context, _ jobscheduler.Scheduler, config Config, cache cache.Cache, mux strategy.Mux) (*Strategy, error) {
 	logger := logging.FromContext(ctx)
 
 	if config.MirrorRoot == "" {

--- a/internal/strategy/git/git_test.go
+++ b/internal/strategy/git/git_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/git"
 )
@@ -64,7 +65,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mux := newTestMux()
-			s, err := git.New(ctx, tt.config, nil, mux)
+			s, err := git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), tt.config, nil, mux)
 			if tt.wantError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantError)
@@ -144,7 +145,7 @@ func TestNewWithExistingCloneOnDisk(t *testing.T) {
 	assert.NoError(t, err)
 
 	mux := newTestMux()
-	s, err := git.New(ctx, git.Config{
+	s, err := git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), git.Config{
 		MirrorRoot:    tmpDir,
 		FetchInterval: 15,
 	}, nil, mux)
@@ -167,7 +168,7 @@ func TestIntegrationWithMockUpstream(t *testing.T) {
 
 	// Create strategy - it will register handlers
 	mux := newTestMux()
-	_, err := git.New(ctx, git.Config{
+	_, err := git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), git.Config{
 		MirrorRoot:    tmpDir,
 		FetchInterval: 15,
 	}, nil, mux)

--- a/internal/strategy/git/integration_test.go
+++ b/internal/strategy/git/integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/git"
 )
@@ -53,7 +54,7 @@ func TestIntegrationGitCloneViaProxy(t *testing.T) {
 
 	// Create the git strategy
 	mux := http.NewServeMux()
-	strategy, err := git.New(ctx, git.Config{
+	strategy, err := git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), git.Config{
 		MirrorRoot:    clonesDir,
 		FetchInterval: 15,
 	}, nil, mux)
@@ -131,7 +132,7 @@ func TestIntegrationGitFetchViaProxy(t *testing.T) {
 	assert.NoError(t, err)
 
 	mux := http.NewServeMux()
-	_, err = git.New(ctx, git.Config{
+	_, err = git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), git.Config{
 		MirrorRoot:    clonesDir,
 		FetchInterval: 15,
 	}, nil, mux)
@@ -210,7 +211,7 @@ func TestIntegrationPushForwardsToUpstream(t *testing.T) {
 	defer upstreamServer.Close()
 
 	mux := http.NewServeMux()
-	_, err = git.New(ctx, git.Config{
+	_, err = git.New(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), git.Config{
 		MirrorRoot:    clonesDir,
 		FetchInterval: 15,
 	}, nil, mux)

--- a/internal/strategy/github_releases.go
+++ b/internal/strategy/github_releases.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/httputil"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/handler"
 )
@@ -33,7 +34,7 @@ type GitHubReleases struct {
 }
 
 // NewGitHubReleases creates a [Strategy] that fetches private (and public) release binaries from GitHub.
-func NewGitHubReleases(ctx context.Context, config GitHubReleasesConfig, cache cache.Cache, mux Mux) (*GitHubReleases, error) {
+func NewGitHubReleases(ctx context.Context, _ jobscheduler.Scheduler, config GitHubReleasesConfig, cache cache.Cache, mux Mux) (*GitHubReleases, error) {
 	s := &GitHubReleases{
 		config: config,
 		cache:  cache,

--- a/internal/strategy/github_releases_test.go
+++ b/internal/strategy/github_releases_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy"
 )
@@ -126,7 +127,7 @@ func setupTest(t *testing.T, config strategy.GitHubReleasesConfig) (*mockGitHubS
 	t.Cleanup(func() { memCache.Close() })
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewGitHubReleases(ctx, config, memCache, mux)
+	_, err = strategy.NewGitHubReleases(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), config, memCache, mux)
 	assert.NoError(t, err)
 
 	return mock, mux, ctx
@@ -241,7 +242,7 @@ func TestGitHubReleasesNoToken(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	gh, err := strategy.NewGitHubReleases(ctx, strategy.GitHubReleasesConfig{}, memCache, mux)
+	gh, err := strategy.NewGitHubReleases(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.GitHubReleasesConfig{}, memCache, mux)
 	assert.NoError(t, err)
 	assert.Equal(t, "github-releases", gh.String())
 }
@@ -253,7 +254,7 @@ func TestGitHubReleasesString(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	gh, err := strategy.NewGitHubReleases(ctx, strategy.GitHubReleasesConfig{
+	gh, err := strategy.NewGitHubReleases(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.GitHubReleasesConfig{
 		Token: "test-token",
 	}, memCache, mux)
 	assert.NoError(t, err)

--- a/internal/strategy/host.go
+++ b/internal/strategy/host.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/handler"
 )
@@ -40,7 +41,7 @@ type Host struct {
 
 var _ Strategy = (*Host)(nil)
 
-func NewHost(ctx context.Context, config HostConfig, cache cache.Cache, mux Mux) (*Host, error) {
+func NewHost(ctx context.Context, _ jobscheduler.Scheduler, config HostConfig, cache cache.Cache, mux Mux) (*Host, error) {
 	u, err := url.Parse(config.Target)
 	if err != nil {
 		return nil, fmt.Errorf("invalid target URL: %w", err)

--- a/internal/strategy/host_test.go
+++ b/internal/strategy/host_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy"
 )
@@ -31,7 +32,7 @@ func TestHostCaching(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewHost(ctx, strategy.HostConfig{Target: backend.URL}, memCache, mux)
+	_, err = strategy.NewHost(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.HostConfig{Target: backend.URL}, memCache, mux)
 	assert.NoError(t, err)
 
 	// Request path must include the host prefix from the target URL
@@ -68,7 +69,7 @@ func TestHostNonOKStatus(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewHost(ctx, strategy.HostConfig{Target: backend.URL}, memCache, mux)
+	_, err = strategy.NewHost(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.HostConfig{Target: backend.URL}, memCache, mux)
 	assert.NoError(t, err)
 
 	// Request path must include the host prefix from the target URL
@@ -94,7 +95,7 @@ func TestHostInvalidTargetURL(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewHost(ctx, strategy.HostConfig{Target: "://invalid"}, memCache, mux)
+	_, err = strategy.NewHost(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.HostConfig{Target: "://invalid"}, memCache, mux)
 	assert.Error(t, err)
 }
 
@@ -105,7 +106,7 @@ func TestHostString(t *testing.T) {
 	defer memCache.Close()
 
 	mux := http.NewServeMux()
-	host, err := strategy.NewHost(ctx, strategy.HostConfig{Target: "https://example.com/prefix"}, memCache, mux)
+	host, err := strategy.NewHost(ctx, jobscheduler.New(ctx, jobscheduler.Config{}), strategy.HostConfig{Target: "https://example.com/prefix"}, memCache, mux)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "host:example.com/prefix", host.String())


### PR DESCRIPTION
Not used in this PR, but git will be refactored to use it.

FYI @js-murph #43 will need to be rebased on top of this.