### PR TITLE
feat: always include a Last-Modified header in cache responses

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,15 +10,11 @@ test:
 
 # Lint code
 lint:
-    #!/bin/bash
-    golangci-lint run &
-    actionlint &
-    wait
+    golangci-lint run
+    actionlint
 
 # Format code
 fmt:
-    #!/bin/bash
-    just --unstable --fmt &
-    golangci-lint fmt &
-    go mod tidy &
-    wait
+    just --unstable --fmt
+    golangci-lint fmt
+    go mod tidy

--- a/cmd/cachewd/main.go
+++ b/cmd/cachewd/main.go
@@ -36,7 +36,8 @@ func main() {
 	ctx := context.Background()
 	logger, ctx := logging.Configure(ctx, cli.LoggingConfig)
 
-	switch {
+	// Commands
+	switch { //nolint:gocritic
 	case cli.Schema:
 		schema := config.Schema()
 		slices.SortStableFunc(schema.Entries, func(a, b hcl.Entry) int {
@@ -49,7 +50,7 @@ func main() {
 			err = quick.Highlight(os.Stdout, string(text), "terraform", "terminal256", "solarized")
 			kctx.FatalIfErrorf(err)
 		} else {
-			fmt.Printf("%s\n", text)
+			fmt.Printf("%s\n", text) //nolint:forbidigo
 		}
 		return
 	}

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -33,7 +33,7 @@ func Register[Config any, C Cache](id, description string, factory Factory[Confi
 	if err != nil {
 		panic(err)
 	}
-	block := schema.Entries[0].(*hcl.Block)
+	block := schema.Entries[0].(*hcl.Block) //nolint:errcheck // This seems spurious
 	block.Comments = hcl.CommentList{description}
 	registry[id] = registryEntry{
 		schema: block,
@@ -124,6 +124,7 @@ type Cache interface {
 	// Open an existing file in the cache.
 	//
 	// Expired files MUST NOT be returned.
+	// The returned headers MUST include a Last-Modified header.
 	// Must return os.ErrNotExist if the file does not exist.
 	Open(ctx context.Context, key Key) (io.ReadCloser, textproto.MIMEHeader, error)
 	// Create a new file in the cache.

--- a/internal/strategy/api.go
+++ b/internal/strategy/api.go
@@ -36,7 +36,7 @@ func Register[Config any, S Strategy](id, description string, factory Factory[Co
 	if err != nil {
 		panic(err)
 	}
-	block := schema.Entries[0].(*hcl.Block)
+	block := schema.Entries[0].(*hcl.Block) //nolint:errcheck // This seems spurious
 	block.Comments = hcl.CommentList{description}
 	registry[id] = registryEntry{
 		schema: block,

--- a/internal/strategy/gomod.go
+++ b/internal/strategy/gomod.go
@@ -55,7 +55,7 @@ type GoMod struct {
 var _ Strategy = (*GoMod)(nil)
 
 // NewGoMod creates a new Go module proxy strategy.
-func NewGoMod(ctx context.Context, config GoModConfig, scheduler jobscheduler.Scheduler, cache cache.Cache, mux Mux) (*GoMod, error) {
+func NewGoMod(ctx context.Context, config GoModConfig, _ jobscheduler.Scheduler, cache cache.Cache, mux Mux) (*GoMod, error) {
 	parsedURL, err := url.Parse(config.Proxy)
 	if err != nil {
 		return nil, fmt.Errorf("invalid proxy URL: %w", err)


### PR DESCRIPTION
The header may be automatically generated by the underlying storage (as with S3), or inserted by the cache implementation itself.

This, in conjunction with Cache.Stat(), will be used by the Git bundle/archive scheduling to determine when next to create bundles.