### PR TITLE
refactor: remove global cache registry

### DIFF
--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -19,8 +19,10 @@ import (
 	"github.com/block/cachew/internal/logging"
 )
 
-func init() {
+// RegisterDisk cache with the given registry.
+func RegisterDisk(r *Registry) {
 	Register(
+		r,
 		"disk",
 		"Caches objects on local disk, with a maximum size limit and LRU eviction",
 		NewDisk,

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -16,8 +16,9 @@ import (
 	"github.com/block/cachew/internal/logging"
 )
 
-func init() {
+func RegisterMemory(r *Registry) {
 	Register(
+		r,
 		"memory",
 		"Caches objects in memory, with a maximum size limit and LRU eviction",
 		NewMemory,

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -20,8 +20,9 @@ import (
 	"github.com/block/cachew/internal/logging"
 )
 
-func init() {
+func RegisterS3(r *Registry) {
 	Register(
+		r,
 		"s3",
 		"Caches objects in S3",
 		NewS3,


### PR DESCRIPTION
This isn't strictly necessary for the cache backends, but it is for strategies if we want to reuse objects between them, so I thought I'd start here.