### PR TITLE
fix: Regression in test behaviour

### DIFF
--- a/internal/strategy/gomod/gomod_test.go
+++ b/internal/strategy/gomod/gomod_test.go
@@ -58,33 +58,25 @@ func newMockGoModServer(t *testing.T) *mockGoModServer {
 	return m
 }
 
-func createModuleZip(modulePath, version string) string {
+func createModuleZip(t *testing.T, modulePath, version string) string {
+	t.Helper()
 	var buf bytes.Buffer
 	w := zip.NewWriter(&buf)
 
 	prefix := modulePath + "@" + version + "/"
 
 	f, err := w.Create(prefix + "go.mod")
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 	_, err = f.Write([]byte("module " + modulePath + "\n\ngo 1.21\n"))
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
 	f2, err := w.Create(prefix + "main.go")
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 	_, err = f2.Write([]byte("package main\n\nfunc main() {}\n"))
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
-	if err := w.Close(); err != nil {
-		panic(err)
-	}
+	err = w.Close()
+	assert.NoError(t, err)
 
 	return buf.String()
 }
@@ -137,7 +129,7 @@ func (m *mockGoModServer) handleRequest(w http.ResponseWriter, r *http.Request) 
 				version := strings.TrimSuffix(versionPart, ".zip")
 				resp = mockResponse{
 					status:  http.StatusOK,
-					content: createModuleZip(modulePath, version),
+					content: createModuleZip(m.t, modulePath, version),
 				}
 				found = true
 			}


### PR DESCRIPTION
# What?

Fixes the gomod test behaviour to not panic during the test execution.

# Why?

Regression accidentally re-introduced in https://github.com/block/cachew/pull/56