### PR TITLE
fix: Remove clone-depth from clonemanager

### DIFF
--- a/cachew.hcl
+++ b/cachew.hcl
@@ -10,7 +10,6 @@
 
 git {
   mirror-root = "./state/git-mirrors"
-  clone-depth = 1000
   bundle-interval = "24h"
 }
 

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -71,7 +71,6 @@ type Config struct {
 	RootDir          string
 	FetchInterval    time.Duration
 	RefCheckInterval time.Duration
-	CloneDepth       int
 	GitConfig        GitTuningConfig
 }
 
@@ -286,15 +285,13 @@ func (r *Repository) executeClone(ctx context.Context, config Config) error {
 	}
 
 	// #nosec G204 - r.upstreamURL and r.path are controlled by us
-	args := []string{"clone"}
-	if config.CloneDepth > 0 {
-		args = append(args, "--depth", strconv.Itoa(config.CloneDepth))
+	args := []string{
+		"clone",
+		"-c", "http.postBuffer=" + strconv.Itoa(config.GitConfig.PostBuffer),
+		"-c", "http.lowSpeedLimit=" + strconv.Itoa(config.GitConfig.LowSpeedLimit),
+		"-c", "http.lowSpeedTime=" + strconv.Itoa(int(config.GitConfig.LowSpeedTime.Seconds())),
+		r.upstreamURL, r.path,
 	}
-	args = append(args,
-		"-c", "http.postBuffer="+strconv.Itoa(config.GitConfig.PostBuffer),
-		"-c", "http.lowSpeedLimit="+strconv.Itoa(config.GitConfig.LowSpeedLimit),
-		"-c", "http.lowSpeedTime="+strconv.Itoa(int(config.GitConfig.LowSpeedTime.Seconds())),
-		r.upstreamURL, r.path)
 
 	cmd, err := gitCommand(ctx, r.upstreamURL, args...)
 	if err != nil {

--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -18,7 +18,6 @@ func TestNewManager(t *testing.T) {
 		RootDir:          tmpDir,
 		FetchInterval:    15 * time.Minute,
 		RefCheckInterval: 10 * time.Second,
-		CloneDepth:       0,
 		GitConfig:        DefaultGitTuningConfig(),
 	}
 

--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -89,7 +89,6 @@ func (s *Strategy) ensureRefsUpToDate(ctx context.Context, repo *gitclone.Reposi
 		RootDir:          s.config.MirrorRoot,
 		FetchInterval:    s.config.FetchInterval,
 		RefCheckInterval: s.config.RefCheckInterval,
-		CloneDepth:       s.config.CloneDepth,
 		GitConfig:        gitclone.DefaultGitTuningConfig(),
 	}
 	if err := repo.EnsureRefsUpToDate(ctx, gitcloneConfig); err != nil {

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -31,7 +31,6 @@ type Config struct {
 	FetchInterval    time.Duration `hcl:"fetch-interval,optional" help:"How often to fetch from upstream in minutes." default:"15m"`
 	RefCheckInterval time.Duration `hcl:"ref-check-interval,optional" help:"How long to cache ref checks." default:"10s"`
 	BundleInterval   time.Duration `hcl:"bundle-interval,optional" help:"How often to generate bundles. 0 disables bundling." default:"0"`
-	CloneDepth       int           `hcl:"clone-depth,optional" help:"Depth for shallow clones. 0 means full clone." default:"0"`
 }
 
 type Strategy struct {
@@ -63,7 +62,6 @@ func New(ctx context.Context, config Config, scheduler jobscheduler.Scheduler, c
 		RootDir:          config.MirrorRoot,
 		FetchInterval:    config.FetchInterval,
 		RefCheckInterval: config.RefCheckInterval,
-		CloneDepth:       config.CloneDepth,
 		GitConfig:        gitclone.DefaultGitTuningConfig(),
 	})
 	if err != nil {
@@ -244,7 +242,6 @@ func (s *Strategy) startClone(ctx context.Context, repo *gitclone.Repository) {
 		RootDir:          s.config.MirrorRoot,
 		FetchInterval:    s.config.FetchInterval,
 		RefCheckInterval: s.config.RefCheckInterval,
-		CloneDepth:       s.config.CloneDepth,
 		GitConfig:        gitclone.DefaultGitTuningConfig(),
 	}
 
@@ -292,7 +289,6 @@ func (s *Strategy) backgroundFetch(ctx context.Context, repo *gitclone.Repositor
 		RootDir:          s.config.MirrorRoot,
 		FetchInterval:    s.config.FetchInterval,
 		RefCheckInterval: s.config.RefCheckInterval,
-		CloneDepth:       s.config.CloneDepth,
 		GitConfig:        gitclone.DefaultGitTuningConfig(),
 	}
 


### PR DESCRIPTION
# What?

Removes clone-depth from the clone manager.

# Why?

Currently the clone-depth setting doesn't actually work. But more importantly than that, we tend to need the full-clone available anyway and properly handling the shallow-clones will involves a fair amount of edge-case handling that I don't think we're ready for yet.