### PR TITLE
feat: allow global configuration to be defined in HCL

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ linters:
     - depguard # checks if package imports are in a list of acceptable packages
     - dupl # tool for code clone detection
     - durationcheck # checks for two durations multiplied together
-    - embeddedstructfieldcheck # checks embedded types in structs
+    # - embeddedstructfieldcheck # checks embedded types in structs
     - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13

--- a/cachew.hcl
+++ b/cachew.hcl
@@ -7,6 +7,7 @@
 #   target = "https://example.jfrog.io"
 # }
 
+url = "http://127.0.0.1:8080"
 
 git {
   mirror-root = "./state/git-mirrors"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/block/cachew
 go 1.25.5
 
 require (
-	github.com/alecthomas/hcl/v2 v2.4.0
+	github.com/alecthomas/hcl/v2 v2.5.0
 	github.com/alecthomas/kong v1.13.0
 	github.com/goproxy/goproxy v0.25.0
 	github.com/lmittmann/tint v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ
 github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
 github.com/alecthomas/errors v0.9.1 h1:JNXtU30rtMNARCkW41OTZ4yL6Lyocq20xIJgIw2raqI=
 github.com/alecthomas/errors v0.9.1/go.mod h1:l8mjMEHMGUdIWPMNtvDyRYPVS1fQFXHFXc/iVCCLGkI=
-github.com/alecthomas/hcl/v2 v2.4.0 h1:j7sPnff/f6FLAPTZmpFzHS2ENwE/dHj6K40bRb9nk4g=
-github.com/alecthomas/hcl/v2 v2.4.0/go.mod h1:4UUp66q8ony5j8tm2bANErujUpZ3GgHBLgaKxTUQlQI=
+github.com/alecthomas/hcl/v2 v2.5.0 h1:0L0oGrZPHokiXaKtsEcLa3hBjfVrRLUUK3u5vXQSybg=
+github.com/alecthomas/hcl/v2 v2.5.0/go.mod h1:4UUp66q8ony5j8tm2bANErujUpZ3GgHBLgaKxTUQlQI=
 github.com/alecthomas/kong v1.13.0 h1:5e/7XC3ugvhP1DQBmTS+WuHtCbcv44hsohMgcvVxSrA=
 github.com/alecthomas/kong v1.13.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -67,6 +67,11 @@ func (r *Registry) Schema() *hcl.AST {
 	return ast
 }
 
+func (r *Registry) Exists(name string) bool {
+	_, ok := r.registry[name]
+	return ok
+}
+
 // Create a new cache instance from the given name and configuration.
 //
 // Will return "ErrNotFound" if the cache backend is not found.

--- a/internal/strategy/api.go
+++ b/internal/strategy/api.go
@@ -70,6 +70,11 @@ func (r *Registry) Schema() *hcl.AST {
 	return ast
 }
 
+func (r *Registry) Exists(name string) bool {
+	_, ok := r.registry[name]
+	return ok
+}
+
 // Create a new proxy strategy.
 //
 // Will return "ErrNotFound" if the strategy is not found.


### PR DESCRIPTION
Previously this had to always be passed by flag or envar, or duplicated in every provider. This allows us to push shared configuration out of the providers, such as eg. the cloner configuration.