### PR TITLE
fix: don't hold lock for duration of initial clone

### DIFF
--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -270,9 +270,11 @@ func (r *Repository) Clone(ctx context.Context, config Config) error {
 		return nil
 	}
 	r.state = StateCloning
+	r.mu.Unlock()
 
 	err := r.executeClone(ctx, config)
 
+	r.mu.Lock()
 	if err != nil {
 		r.state = StateEmpty
 		r.mu.Unlock()


### PR DESCRIPTION
This prevented the client clone from proceeding, blocking until the background clone completed.

This was introduced in ecf5911388ddae663ad6eef480f266071c5bbfe4.