### PR TITLE
chore: faster fmt

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,7 +28,8 @@ lint:
 # Format code
 fmt:
     just --unstable --fmt
-    golangci-lint fmt
+    git ls-files | grep '\.go$' | xargs gosimports -local github.com/block -w
+    go fmt ./...
     go mod tidy
 
 # ============================================================================


### PR DESCRIPTION
golangci-lint is slower than running the formatters directlry