### PR TITLE
fix: use Kong config loader for HCL globals

### DIFF
--- a/cachew.hcl
+++ b/cachew.hcl
@@ -8,7 +8,7 @@
 # }
 
 url = "http://127.0.0.1:8080"
-logging {
+log {
   level = "debug"
 }
 

--- a/internal/config/kong.go
+++ b/internal/config/kong.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/alecthomas/hcl/v2"
+	"github.com/alecthomas/kong"
+)
+
+func KongLoader[GlobalConfig any](r io.Reader) (kong.Resolver, error) {
+	ast, err := hcl.Parse(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse HCL: %w", err)
+	}
+	return &kongResolver{flattenHCL(ast)}, nil
+}
+
+type kongResolver struct {
+	values map[string]any
+}
+
+var _ kong.Resolver = (*kongResolver)(nil)
+
+func (k *kongResolver) Resolve(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+	name := strings.ReplaceAll(flag.Name, "-", "_")
+	if v, ok := k.values[name]; ok {
+		return v, nil
+	}
+	if v, ok := k.values[flag.Name]; ok {
+		return v, nil
+	}
+	return nil, nil //nolint:nilnil
+}
+
+func (k *kongResolver) Validate(_ *kong.Application) error { return nil }
+
+// Convert HCL AST to a flattened map of key to value. Each hierarchy in the HCL joined by "-".
+//
+// eg.
+//
+//	block {
+//		value = "foo"
+//	}
+//
+//	block-with-label label {
+//		value = "foo"
+//	}
+//
+// Would flatten to:
+//
+//	block-value = "foo"
+//	block-with-label-label = "foo"
+func flattenHCL(node hcl.Node) map[string]any {
+	out := map[string]any{}
+	flattenNode(out, "", node)
+	return out
+}
+
+func flattenNode(out map[string]any, prefix string, node hcl.Node) {
+	switch node := node.(type) {
+	case *hcl.AST:
+		for _, entry := range node.Entries {
+			flattenNode(out, prefix, entry)
+		}
+
+	case *hcl.Block:
+		parts := make([]string, 0, 1+len(node.Labels))
+		parts = append(parts, node.Name)
+		parts = append(parts, node.Labels...)
+		key := strings.Join(parts, "-")
+		if prefix != "" {
+			key = prefix + "-" + key
+		}
+		for _, entry := range node.Body {
+			flattenNode(out, key, entry)
+		}
+
+	case *hcl.Attribute:
+		key := node.Key
+		if prefix != "" {
+			key = prefix + "-" + key
+		}
+		out[key] = hclValue(node.Value)
+	}
+}
+
+func hclValue(v hcl.Value) any {
+	switch v := v.(type) {
+	case *hcl.String:
+		return v.Str
+	case *hcl.Number:
+		if v.Float.IsInt() {
+			i, _ := v.Float.Int64()
+			return i
+		}
+		f, _ := v.Float.Float64()
+		return f
+	case *hcl.Bool:
+		return v.Bool
+	case *hcl.List:
+		out := make([]any, len(v.List))
+		for i, item := range v.List {
+			out[i] = hclValue(item)
+		}
+		return out
+	case *hcl.Map:
+		out := map[string]any{}
+		for _, entry := range v.Entries {
+			out[fmt.Sprintf("%v", hclValue(entry.Key))] = hclValue(entry.Value)
+		}
+		return out
+	case *hcl.Heredoc:
+		return v.GetHeredoc()
+	default:
+		return nil
+	}
+}

--- a/internal/config/kong_test.go
+++ b/internal/config/kong_test.go
@@ -1,0 +1,110 @@
+package config //nolint:testpackage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/hcl/v2"
+)
+
+func TestFlattenHCL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]any
+	}{
+		{
+			name:  "SimpleAttribute",
+			input: `value = "foo"`,
+			expected: map[string]any{
+				"value": "foo",
+			},
+		},
+		{
+			name: "Block",
+			input: `block {
+				value = "foo"
+			}`,
+			expected: map[string]any{
+				"block-value": "foo",
+			},
+		},
+		{
+			name: "BlockWithLabel",
+			input: `block-with-label label {
+				value = "foo"
+			}`,
+			expected: map[string]any{
+				"block-with-label-label-value": "foo",
+			},
+		},
+		{
+			name: "NestedBlocks",
+			input: `outer {
+				inner {
+					value = "foo"
+				}
+			}`,
+			expected: map[string]any{
+				"outer-inner-value": "foo",
+			},
+		},
+		{
+			name:  "NumberInt",
+			input: `count = 42`,
+			expected: map[string]any{
+				"count": int64(42),
+			},
+		},
+		{
+			name:  "NumberFloat",
+			input: `ratio = 3.14`,
+			expected: map[string]any{
+				"ratio": 3.14,
+			},
+		},
+		{
+			name:  "Bool",
+			input: `enabled = true`,
+			expected: map[string]any{
+				"enabled": true,
+			},
+		},
+		{
+			name:  "List",
+			input: `tags = ["a", "b", "c"]`,
+			expected: map[string]any{
+				"tags": []any{"a", "b", "c"},
+			},
+		},
+		{
+			name:  "Map",
+			input: `labels = {x: 1, y: 2}`,
+			expected: map[string]any{
+				"labels": map[string]any{"x": int64(1), "y": int64(2)},
+			},
+		},
+		{
+			name: "MultipleEntries",
+			input: `
+				name = "test"
+				block {
+					port = 8080
+				}
+			`,
+			expected: map[string]any{
+				"name":       "test",
+				"block-port": int64(8080),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, err := hcl.Parse(strings.NewReader(tt.input))
+			assert.NoError(t, err)
+			actual := flattenHCL(ast)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
`hcl.Unmarshal()` was overwriting envars/flags, with this approach the HCL is correctly integrated into the CLI parsing.

Also refactored main() into separate functions.