### PR TITLE
refactor: simplify gitclone

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,7 @@ linters:
     - funcorder # checks the order of functions, methods, and constructors
     - funlen # tool for detection of long functions
     - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoglobals
     - gochecksumtype # checks exhaustiveness on Go "sum types"
     - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues

--- a/cachew.hcl
+++ b/cachew.hcl
@@ -12,8 +12,11 @@ log {
   level = "debug"
 }
 
+git-clone {
+    mirror-root = "./state/git-mirrors"
+}
+
 git {
-  mirror-root = "./state/git-mirrors"
   bundle-interval = "24h"
   snapshot-interval = "24h"
 }

--- a/internal/cache/disk_metadb.go
+++ b/internal/cache/disk_metadb.go
@@ -10,6 +10,7 @@ import (
 	"go.etcd.io/bbolt"
 )
 
+//nolint:gochecknoglobals
 var (
 	ttlBucketName     = []byte("ttl")
 	headersBucketName = []byte("headers")

--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -28,7 +28,7 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 		return
 	}
 
-	absRoot, err := filepath.Abs(s.config.MirrorRoot)
+	absRoot, err := filepath.Abs(s.cloneManager.Config().MirrorRoot)
 	if err != nil {
 		httputil.ErrorResponse(w, r, http.StatusInternalServerError, "failed to get absolute path")
 		return
@@ -87,13 +87,7 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 }
 
 func (s *Strategy) ensureRefsUpToDate(ctx context.Context, repo *gitclone.Repository) error {
-	gitcloneConfig := gitclone.Config{
-		RootDir:          s.config.MirrorRoot,
-		FetchInterval:    s.config.FetchInterval,
-		RefCheckInterval: s.config.RefCheckInterval,
-		GitConfig:        gitclone.DefaultGitTuningConfig(),
-	}
-	if err := repo.EnsureRefsUpToDate(ctx, gitcloneConfig); err != nil {
+	if err := repo.EnsureRefsUpToDate(ctx); err != nil {
 		return errors.Wrap(err, "ensure refs up to date")
 	}
 	return nil

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/git"
@@ -23,10 +24,12 @@ func TestSnapshotHTTPEndpoint(t *testing.T) {
 	assert.NoError(t, err)
 	mux := newTestMux()
 
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+		MirrorRoot: tmpDir,
+	})
 	_, err = git.New(ctx, git.Config{
-		MirrorRoot:       tmpDir,
 		SnapshotInterval: 24 * time.Hour,
-	}, jobscheduler.New(ctx, jobscheduler.Config{}), memCache, mux)
+	}, jobscheduler.New(ctx, jobscheduler.Config{}), memCache, mux, cm)
 	assert.NoError(t, err)
 
 	// Create a fake snapshot in the cache
@@ -95,10 +98,12 @@ func TestSnapshotInterval(t *testing.T) {
 			assert.NoError(t, err)
 			mux := newTestMux()
 
+			cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+				MirrorRoot: tmpDir,
+			})
 			s, err := git.New(ctx, git.Config{
-				MirrorRoot:       tmpDir,
 				SnapshotInterval: tt.snapshotInterval,
-			}, jobscheduler.New(ctx, jobscheduler.Config{}), memCache, mux)
+			}, jobscheduler.New(ctx, jobscheduler.Config{}), memCache, mux, cm)
 			assert.NoError(t, err)
 			assert.NotZero(t, s)
 		})

--- a/internal/strategy/github_releases_test.go
+++ b/internal/strategy/github_releases_test.go
@@ -20,7 +20,7 @@ import (
 
 // httpTransportMutex ensures GitHub release tests don't run in parallel
 // since they modify the global http.DefaultTransport
-var httpTransportMutex sync.Mutex
+var httpTransportMutex sync.Mutex //nolint:gochecknoglobals
 
 type mockGitHubServer struct {
 	server            *httptest.Server

--- a/internal/strategy/gomod/gomod_test.go
+++ b/internal/strategy/gomod/gomod_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/strategy/gomod"
 )
@@ -174,10 +175,14 @@ func setupGoModTest(t *testing.T) (*mockGoModServer, *http.ServeMux, context.Con
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = memCache.Close() })
 
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+		MirrorRoot: t.TempDir(),
+	})
+	assert.NoError(t, err)
 	mux := http.NewServeMux()
 	_, err = gomod.New(ctx, gomod.Config{
 		Proxy: mock.server.URL,
-	}, memCache, mux)
+	}, memCache, mux, cm)
 	assert.NoError(t, err)
 
 	return mock, mux, ctx

--- a/internal/strategy/gomod/private_fetcher.go
+++ b/internal/strategy/gomod/private_fetcher.go
@@ -121,8 +121,7 @@ func (p *privateFetcher) ensureReady(ctx context.Context, repo *gitclone.Reposit
 		return nil
 	}
 
-	config := p.cloneManager.Config()
-	if err := repo.Clone(ctx, config); err != nil {
+	if err := repo.Clone(ctx); err != nil {
 		return errors.Wrap(err, "clone repository")
 	}
 

--- a/internal/strategy/hermit_test.go
+++ b/internal/strategy/hermit_test.go
@@ -18,7 +18,7 @@ import (
 
 // httpTransportMutexHermit ensures hermit tests don't run in parallel
 // since they modify the global http.DefaultTransport
-var httpTransportMutexHermit sync.Mutex
+var httpTransportMutexHermit sync.Mutex //nolint:gochecknoglobals
 
 func setupHermitTest(t *testing.T) (*http.ServeMux, context.Context, cache.Cache) {
 	t.Helper()


### PR DESCRIPTION
Moved gitclone.Manager shared config into top-level "git-clone" block. The clone manager is lazily constructed so that it will only be instantiated if something uses it.

I also simplified config use: we were requiring gitclone.Config as parameters to a bunch of methods for unknown reasons, when we can just include it in the Repository struct. I also removed configurable use of GitTuningConfig, as we only ever used defaults. If we need per-clone tuning later, we can figure it out.