### PR TITLE
fix: prevent mutex leak in Repository.Fetch

### DIFF
--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -387,6 +387,7 @@ func (r *Repository) Fetch(ctx context.Context) error {
 	}
 
 	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	config := DefaultGitTuningConfig()
 
@@ -405,8 +406,6 @@ func (r *Repository) Fetch(ctx context.Context) error {
 	}
 
 	r.lastFetch = time.Now()
-	r.mu.Unlock()
-
 	return nil
 }
 


### PR DESCRIPTION
## Problem

In `Repository.Fetch()`, the mutex `r.mu` is acquired with `Lock()` but has early returns on error paths that don't unlock it:

```go
r.mu.Lock()
// ...
if err != nil {
    return errors.Wrap(err, "...")  // ❌ Returns without Unlock()
}
```

This causes a **mutex leak** - if `Fetch()` fails, the mutex stays locked forever, and any subsequent operation on that repository will hang indefinitely.

## Solution

Add `defer r.mu.Unlock()` immediately after `Lock()` to ensure the mutex is always released, even on error paths:

```go
r.mu.Lock()
defer r.mu.Unlock()  // ✅ Always unlocks
```

## Testing

- ✅ All tests pass
- ✅ Build succeeds