### PR TITLE
fix: Update GitHubBaseURL's default as http://127.0.0.1:8080/github.com

### DIFF
--- a/cmd/cachewd/main.go
+++ b/cmd/cachewd/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	scheduler := jobscheduler.New(ctx, globalConfig.SchedulerConfig)
 
-	cr, sr := newRegistries(globalConfig.URL, scheduler, managerProvider, tokenManagerProvider)
+	cr, sr := newRegistries(scheduler, managerProvider, tokenManagerProvider)
 
 	// Commands
 	switch { //nolint:gocritic
@@ -105,7 +105,7 @@ func main() {
 	kctx.FatalIfErrorf(err)
 }
 
-func newRegistries(cachewURL string, scheduler jobscheduler.Scheduler, cloneManagerProvider gitclone.ManagerProvider, tokenManagerProvider githubapp.TokenManagerProvider) (*cache.Registry, *strategy.Registry) {
+func newRegistries(scheduler jobscheduler.Scheduler, cloneManagerProvider gitclone.ManagerProvider, tokenManagerProvider githubapp.TokenManagerProvider) (*cache.Registry, *strategy.Registry) {
 	cr := cache.NewRegistry()
 	cache.RegisterMemory(cr)
 	cache.RegisterDisk(cr)
@@ -115,7 +115,7 @@ func newRegistries(cachewURL string, scheduler jobscheduler.Scheduler, cloneMana
 	strategy.RegisterAPIV1(sr)
 	strategy.RegisterArtifactory(sr)
 	strategy.RegisterGitHubReleases(sr, tokenManagerProvider)
-	strategy.RegisterHermit(sr, cachewURL)
+	strategy.RegisterHermit(sr)
 	strategy.RegisterHost(sr)
 	git.Register(sr, scheduler, cloneManagerProvider, tokenManagerProvider)
 	gomod.Register(sr, cloneManagerProvider)

--- a/internal/strategy/hermit_test.go
+++ b/internal/strategy/hermit_test.go
@@ -30,7 +30,7 @@ func setupHermitTest(t *testing.T) (*http.ServeMux, context.Context, cache.Cache
 	t.Cleanup(func() { memCache.Close() })
 
 	mux := http.NewServeMux()
-	_, err = strategy.NewHermit(ctx, "http://github.com", strategy.HermitConfig{GitHubBaseURL: "http://localhost:8080"}, nil, memCache, mux)
+	_, err = strategy.NewHermit(ctx, strategy.HermitConfig{GitHubBaseURL: "http://localhost:8080"}, nil, memCache, mux)
 	assert.NoError(t, err)
 
 	return mux, ctx, memCache


### PR DESCRIPTION
### Context

We don't want to use `sq.prod` or cachew's mesh url given the request might flip-flop into a different instance given istio's dns.
We would want to service hermit strategy using the gh-releases strategy in the same host so setting the default GitHubBaseURL as `http://127.0.0.1:8080/github.com`, with the option to override it if we want. For us we would just use the default and not override it.

### Testing

Tested locally with running cachew in docker using

```
just docker build && docker run --rm -it \
  -p 8080:8080 \
  -v ~/.scripts/github/blox-cache.2026-02-03.private-key.pem:/app/github-app-key.pem:ro \
  -e CACHEW_GITHUB_APP_APP_ID="2666596" \
  -e CACHEW_GITHUB_APP_PRIVATE_KEY_PATH="/app/github-app-key.pem" \
  cachew:local
```

Now hermit strategy correctly points to localhost:8080 without using cachew_url.

<img width="1439" height="721" alt="Screenshot 2026-02-10 at 5 08 25 PM" src="https://github.com/user-attachments/assets/f4713a6a-158f-4c23-8d8a-a9be0eabd7e8" />
<img width="1719" height="1208" alt="Screenshot 2026-02-10 at 5 08 32 PM" src="https://github.com/user-attachments/assets/240537b3-59bf-41bb-8c7b-7242108e9503" />
