### PR TITLE
fix: Use git mirror clones to expose branches correctly

### DIFF
--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -37,7 +37,7 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 	host := r.PathValue("host")
 	pathValue := r.PathValue("path")
 
-	// Insert /.git before the git protocol paths to match the filesystem layout
+	// Extract git operation from path (for bare repositories, no /.git subdirectory)
 	var gitOperation string
 	var repoPathWithSuffix string
 
@@ -50,7 +50,7 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 	}
 
 	repoPath := strings.TrimSuffix(repoPathWithSuffix, ".git")
-	backendPath := "/" + host + "/" + repoPath + "/.git" + gitOperation
+	backendPath := "/" + host + "/" + repoPath + gitOperation
 
 	logger.DebugContext(r.Context(), "Serving with git http-backend",
 		slog.String("original_path", r.URL.Path),

--- a/internal/strategy/git/bundle.go
+++ b/internal/strategy/git/bundle.go
@@ -35,9 +35,9 @@ func (s *Strategy) generateAndUploadBundle(ctx context.Context, repo *gitclone.R
 
 	err = errors.Wrap(repo.WithReadLock(func() error {
 		var stderr bytes.Buffer
-		// Use --branches --remotes to include all branches but exclude tags (which can be massive)
+		// Use --all to include all refs (branches and tags) for mirror repositories
 		// #nosec G204 - repo.Path() is controlled by us
-		cmd := exec.CommandContext(ctx, "git", "-C", repo.Path(), "bundle", "create", "-", "--branches", "--remotes")
+		cmd := exec.CommandContext(ctx, "git", "-C", repo.Path(), "bundle", "create", "-", "--all")
 		cmd.Stdout = w
 		cmd.Stderr = &stderr
 


### PR DESCRIPTION
Workstations couldn't see new remote branches after git fetch because cachew's mirrors stored refs as refs/remotes/origin/* instead of refs/heads/*. Using git clone --mirror creates bare repositories with the correct ref structure that git clients expect, allowing branches to be properly fetched and checked out.


Also see [thread](https://sq-block.slack.com/archives/C0A1J67K2LR/p1770952407902739?thread_ts=1770943707.589499&cid=C0A1J67K2LR).

Previously git checkout wasn't able to switch to git branches
<img width="855" height="301" alt="Screenshot 2026-02-12 at 7 25 03 PM" src="https://github.com/user-attachments/assets/180b4d2e-f58d-45bd-8aa1-13676b2f1db4" />

<img width="811" height="296" alt="Screenshot 2026-02-12 at 7 34 49 PM" src="https://github.com/user-attachments/assets/cbef970b-534f-48e0-9371-5ad07caac013" />


Now cachew stores the refs in the correct path (`refs/head`) instead of `` and `git checkout` works

<img width="802" height="920" alt="Screenshot 2026-02-12 at 7 35 51 PM" src="https://github.com/user-attachments/assets/43a0aedf-953c-4e57-9e16-5a8c07794b2e" />
