### PR TITLE
fix: ensure clones support --filter

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,7 +29,7 @@ lint:
 fmt:
     just --unstable --fmt
     git ls-files | grep '\.go$' | xargs gosimports -local github.com/block -w
-    go fmt ./...
+    git ls-files | grep '\.go$' | xargs dirname | uniq | sed 's,^,./,' | xargs go fmt
     go mod tidy
 
 # ============================================================================

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-cachewd **/*.go !**/*_test.go debounce=2s ready=http:8080/_readiness=200: CACHEW_URL=http://localhost:8080 CACHEW_LOG_LEVEL=debug cachewd
+cachewd **/*.go !**/*_test.go !state/**/* debounce=2s ready=http:8080/_readiness=200: CACHEW_URL=http://localhost:8080 CACHEW_LOG_LEVEL=debug cachewd

--- a/cachew.hcl
+++ b/cachew.hcl
@@ -23,8 +23,8 @@ metrics {}
 
 
 git {
-  bundle-interval = "24h"
-  snapshot-interval = "24h"
+  #bundle-interval = "24h"
+  #snapshot-interval = "24h"
 }
 
 host "https://w3.org" {}

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -365,6 +365,13 @@ func (r *Repository) executeClone(ctx context.Context) error {
 		return errors.Wrapf(err, "fetch all branches: %s", string(output))
 	}
 
+	// Enable partial clone support (e.g. --filter=blob:none) when serving via git http-backend.
+	cmd = exec.CommandContext(ctx, "git", "-C", r.path, "config", "uploadpack.allowFilter", "true") // #nosec G204
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "configure uploadpack.allowFilter: %s", string(output))
+	}
+
 	return nil
 }
 

--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/cgi" //nolint:gosec // CVE-2016-5386 only affects Go < 1.6.3
@@ -67,12 +68,26 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 			Env: []string{
 				"GIT_PROJECT_ROOT=" + absRoot,
 				"GIT_HTTP_EXPORT_ALL=1",
+				"GIT_HTTP_MAX_REQUEST_BUFFER=100M",
 				"PATH=" + os.Getenv("PATH"),
 			},
 		}
 
 		r2 := r.Clone(r.Context())
 		r2.URL.Path = backendPath
+
+		// Go's cgi.Handler rejects chunked request bodies with a 400.
+		// Buffer the body so we can set ContentLength and clear TransferEncoding.
+		if r2.ContentLength < 0 {
+			body, err := io.ReadAll(r2.Body)
+			if err != nil {
+				httputil.ErrorResponse(w, r, http.StatusInternalServerError, "failed to read request body")
+				return errors.Wrap(err, "read request body")
+			}
+			r2.Body = io.NopCloser(bytes.NewReader(body))
+			r2.ContentLength = int64(len(body))
+			r2.TransferEncoding = nil
+		}
 
 		handler.ServeHTTP(w, r2)
 


### PR DESCRIPTION
Go's CGI proxy didn't support chunked responses, so we buffer it to avoid chunking.