### PR TITLE
refactor: switch to --mirror bare clones (#123)

### DIFF
--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -82,9 +82,8 @@ func TestManager_GetOrCreate_ExistingClone(t *testing.T) {
 	assert.NoError(t, err)
 
 	repoPath := filepath.Join(tmpDir, "github.com", "user", "repo")
-	gitDir := filepath.Join(repoPath, ".git")
-	assert.NoError(t, os.MkdirAll(gitDir, 0o755))
-	assert.NoError(t, os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+	assert.NoError(t, os.MkdirAll(repoPath, 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(repoPath, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
 
 	upstreamURL := "https://github.com/user/repo"
 	repo, err := manager.GetOrCreate(context.Background(), upstreamURL)
@@ -138,9 +137,8 @@ func TestManager_DiscoverExisting(t *testing.T) {
 	}
 
 	for _, repoPath := range repos {
-		gitDir := filepath.Join(repoPath, ".git")
-		assert.NoError(t, os.MkdirAll(gitDir, 0o755))
-		assert.NoError(t, os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+		assert.NoError(t, os.MkdirAll(repoPath, 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(repoPath, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
 	}
 
 	discovered, err := manager.DiscoverExisting(context.Background())

--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -38,7 +38,6 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 	host := r.PathValue("host")
 	pathValue := r.PathValue("path")
 
-	// Insert /.git before the git protocol paths to match the filesystem layout
 	var gitOperation string
 	var repoPathWithSuffix string
 
@@ -51,7 +50,7 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 	}
 
 	repoPath := strings.TrimSuffix(repoPathWithSuffix, ".git")
-	backendPath := "/" + host + "/" + repoPath + "/.git" + gitOperation
+	backendPath := "/" + host + "/" + repoPath + gitOperation
 
 	logger.DebugContext(r.Context(), "Serving with git http-backend",
 		slog.String("original_path", r.URL.Path),

--- a/internal/strategy/git/git_test.go
+++ b/internal/strategy/git/git_test.go
@@ -135,15 +135,13 @@ func TestNewWithExistingCloneOnDisk(t *testing.T) {
 	_, ctx := logging.Configure(context.Background(), logging.Config{})
 	tmpDir := t.TempDir()
 
-	// Create a fake clone directory on disk before initializing strategy
-	// For regular clones, we need a .git subdirectory with HEAD file
+	// Create a fake bare clone directory on disk before initializing strategy
 	clonePath := filepath.Join(tmpDir, "github.com", "org", "repo")
-	gitDir := filepath.Join(clonePath, ".git")
-	err := os.MkdirAll(gitDir, 0o750)
+	err := os.MkdirAll(clonePath, 0o750)
 	assert.NoError(t, err)
 
-	// Create HEAD file to make it look like a valid git repo
-	headPath := filepath.Join(gitDir, "HEAD")
+	// Create HEAD file to make it look like a valid bare git repo
+	headPath := filepath.Join(clonePath, "HEAD")
 	err = os.WriteFile(headPath, []byte("ref: refs/heads/main\n"), 0o640)
 	assert.NoError(t, err)
 

--- a/internal/strategy/git/integration_test.go
+++ b/internal/strategy/git/integration_test.go
@@ -112,11 +112,10 @@ func TestIntegrationGitCloneViaProxy(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, info.IsDir())
 
-	// Verify it has a .git directory (regular clone)
-	gitDir := filepath.Join(clonePath, ".git")
-	gitInfo, err := os.Stat(gitDir)
+	// Verify it has a HEAD file (bare mirror clone)
+	headFile := filepath.Join(clonePath, "HEAD")
+	_, err = os.Stat(headFile)
 	assert.NoError(t, err)
-	assert.True(t, gitInfo.IsDir())
 }
 
 // TestIntegrationGitFetchViaProxy tests fetching updates through the proxy.


### PR DESCRIPTION
Replace regular clones with git clone --mirror for bare repo layout. Update repo detection, fetch, ref comparison, and http-backend path construction accordingly.