### PR TITLE
feat: schedule periodic full repacks via job scheduler

### DIFF
--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -35,6 +35,7 @@ func Register(r *strategy.Registry, scheduler jobscheduler.Scheduler, cloneManag
 
 type Config struct {
 	SnapshotInterval time.Duration `hcl:"snapshot-interval,optional" help:"How often to generate tar.zstd snapshots. 0 disables snapshots." default:"0"`
+	RepackInterval   time.Duration `hcl:"repack-interval,optional" help:"How often to run full repack. 0 disables." default:"0"`
 }
 
 type Strategy struct {
@@ -99,6 +100,9 @@ func New(
 	for _, repo := range existing {
 		if s.config.SnapshotInterval > 0 {
 			s.scheduleSnapshotJobs(repo)
+		}
+		if s.config.RepackInterval > 0 {
+			s.scheduleRepackJobs(repo)
 		}
 	}
 
@@ -408,6 +412,9 @@ func (s *Strategy) startClone(ctx context.Context, repo *gitclone.Repository) {
 
 	if s.config.SnapshotInterval > 0 {
 		s.scheduleSnapshotJobs(repo)
+	}
+	if s.config.RepackInterval > 0 {
+		s.scheduleRepackJobs(repo)
 	}
 }
 

--- a/internal/strategy/git/repack.go
+++ b/internal/strategy/git/repack.go
@@ -1,0 +1,13 @@
+package git
+
+import (
+	"context"
+
+	"github.com/block/cachew/internal/gitclone"
+)
+
+func (s *Strategy) scheduleRepackJobs(repo *gitclone.Repository) {
+	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "repack-periodic", s.config.RepackInterval, func(ctx context.Context) error {
+		return repo.Repack(ctx)
+	})
+}

--- a/internal/strategy/git/repack_test.go
+++ b/internal/strategy/git/repack_test.go
@@ -1,0 +1,72 @@
+package git_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/internal/githubapp"
+	"github.com/block/cachew/internal/jobscheduler"
+	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/strategy/git"
+)
+
+func TestRepackInterval(t *testing.T) {
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name           string
+		repackInterval time.Duration
+	}{
+		{
+			name:           "Enabled",
+			repackInterval: 24 * time.Hour,
+		},
+		{
+			name:           "Disabled",
+			repackInterval: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := newTestMux()
+			cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+				MirrorRoot: filepath.Join(tmpDir, tt.name),
+			}, nil)
+			s, err := git.New(ctx, git.Config{
+				RepackInterval: tt.repackInterval,
+			}, jobscheduler.New(ctx, jobscheduler.Config{}), nil, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+			assert.NoError(t, err)
+			assert.NotZero(t, s)
+		})
+	}
+}
+
+func TestRepackScheduledForExistingRepos(t *testing.T) {
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	// Create a fake bare clone directory on disk before initializing strategy.
+	clonePath := filepath.Join(tmpDir, "github.com", "org", "repo")
+	err := os.MkdirAll(clonePath, 0o750)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(clonePath, "HEAD"), []byte("ref: refs/heads/main\n"), 0o640)
+	assert.NoError(t, err)
+
+	mux := newTestMux()
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+		MirrorRoot: tmpDir,
+	}, nil)
+	s, err := git.New(ctx, git.Config{
+		RepackInterval: 24 * time.Hour,
+	}, jobscheduler.New(ctx, jobscheduler.Config{}), nil, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+	assert.NotZero(t, s)
+}


### PR DESCRIPTION
## Summary
- Adds periodic full repack (`git repack -adb --write-midx --write-bitmap-index`) for mirror repos via the existing job scheduler
- Configurable via `repack-interval` on the git strategy (default `0` = disabled)
- Scheduled for both newly cloned and existing-on-startup repos, serialized per-repo with fetch/clone/snapshot jobs

Closes #126

## Test plan
- [x] Unit test for `Repository.Repack()` verifying pack file and multi-pack-index creation
- [x] Strategy tests for enabled/disabled config and scheduling with existing repos on disk
- [x] All existing tests pass
- [x] Linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)