### PR TITLE
refactor: use local hardlink clone for snapshot generation

### DIFF
--- a/internal/strategy/git/export_test.go
+++ b/internal/strategy/git/export_test.go
@@ -1,0 +1,11 @@
+package git
+
+import (
+	"context"
+
+	"github.com/block/cachew/internal/gitclone"
+)
+
+func (s *Strategy) GenerateAndUploadSnapshot(ctx context.Context, repo *gitclone.Repository) error {
+	return s.generateAndUploadSnapshot(ctx, repo)
+}

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -77,8 +77,10 @@ func New(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create clone manager")
 	}
-	if err := os.RemoveAll(filepath.Join(cloneManager.Config().MirrorRoot, ".spools")); err != nil {
-		return nil, errors.Wrap(err, "clean up stale spools")
+	for _, dir := range []string{".spools", ".snapshots"} {
+		if err := os.RemoveAll(filepath.Join(cloneManager.Config().MirrorRoot, dir)); err != nil {
+			return nil, errors.Wrapf(err, "clean up stale %s", dir)
+		}
 	}
 
 	s := &Strategy{

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/errors"
@@ -14,20 +19,54 @@ import (
 	"github.com/block/cachew/internal/snapshot"
 )
 
+func snapshotDirForURL(mirrorRoot, upstreamURL string) string {
+	parsed, err := url.Parse(upstreamURL)
+	if err != nil {
+		return filepath.Join(mirrorRoot, ".snapshots", "unknown")
+	}
+	repoPath := strings.TrimSuffix(parsed.Path, ".git")
+	return filepath.Join(mirrorRoot, ".snapshots", parsed.Host, repoPath)
+}
+
 func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone.Repository) error {
 	logger := logging.FromContext(ctx)
 	upstream := repo.UpstreamURL()
 
 	logger.InfoContext(ctx, "Snapshot generation started", slog.String("upstream", upstream))
 
+	mirrorRoot := s.cloneManager.Config().MirrorRoot
+	snapshotDir := snapshotDirForURL(mirrorRoot, upstream)
+
+	// Clean any previous snapshot working directory.
+	if err := os.RemoveAll(snapshotDir); err != nil {
+		return errors.Wrap(err, "remove previous snapshot dir")
+	}
+	if err := os.MkdirAll(filepath.Dir(snapshotDir), 0o750); err != nil {
+		return errors.Wrap(err, "create snapshot parent dir")
+	}
+
+	// Local clone from the mirror — git hardlinks objects by default.
+	// #nosec G204 - repo.Path() and snapshotDir are controlled by us
+	cmd := exec.CommandContext(ctx, "git", "clone", repo.Path(), snapshotDir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(snapshotDir)
+		return errors.Wrapf(err, "git clone for snapshot: %s", string(output))
+	}
+
 	cacheKey := cache.NewKey(upstream + ".snapshot")
 	ttl := 7 * 24 * time.Hour
 	excludePatterns := []string{"*.lock"}
 
-	err := errors.Wrap(snapshot.Create(ctx, s.cache, cacheKey, repo.Path(), ttl, excludePatterns), "create snapshot")
+	err := snapshot.Create(ctx, s.cache, cacheKey, snapshotDir, ttl, excludePatterns)
+
+	// Always clean up the snapshot working directory.
+	if rmErr := os.RemoveAll(snapshotDir); rmErr != nil {
+		logger.WarnContext(ctx, "Failed to clean up snapshot dir", slog.String("error", rmErr.Error()))
+	}
+
 	if err != nil {
 		logger.ErrorContext(ctx, "Snapshot generation failed", slog.String("upstream", upstream), slog.String("error", err.Error()))
-		return err
+		return errors.Wrap(err, "create snapshot")
 	}
 
 	logger.InfoContext(ctx, "Snapshot generation completed", slog.String("upstream", upstream))


### PR DESCRIPTION
Instead of archiving the mirror bare repo directly, snapshot generation
now clones from the mirror into a temporary working directory first.
Git hardlinks objects for local clones, so there's no disk duplication.
Re-cloning before each snapshot guarantees a clean, compact object store
matching the mirror's repacked state.

Closes #127

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
