### PR TITLE
feat: add .tar.zst extension to snapshot URL

### DIFF
--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -170,7 +170,7 @@ func (s *Strategy) handleRequest(w http.ResponseWriter, r *http.Request) {
 		slog.String("host", host),
 		slog.String("path", pathValue))
 
-	if strings.HasSuffix(pathValue, "/snapshot") {
+	if strings.HasSuffix(pathValue, "/snapshot.tar.zst") {
 		s.handleSnapshotRequest(w, r, host, pathValue)
 		return
 	}
@@ -345,7 +345,7 @@ func ExtractRepoPath(pathValue string) string {
 	return repoPath
 }
 
-func (s *Strategy) serveCachedArtifact(w http.ResponseWriter, r *http.Request, host, pathValue, artifact string) {
+func (s *Strategy) serveCachedArtifact(w http.ResponseWriter, r *http.Request, host, pathValue, urlSuffix, artifact string) {
 	ctx := r.Context()
 	logger := logging.FromContext(ctx)
 
@@ -353,7 +353,7 @@ func (s *Strategy) serveCachedArtifact(w http.ResponseWriter, r *http.Request, h
 		slog.String("host", host),
 		slog.String("path", pathValue))
 
-	pathValue = strings.TrimSuffix(pathValue, "/"+artifact)
+	pathValue = strings.TrimSuffix(pathValue, "/"+urlSuffix)
 	repoPath := ExtractRepoPath(pathValue)
 	upstreamURL := "https://" + host + "/" + repoPath
 	cacheKey := cache.NewKey(upstreamURL + "." + artifact)

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -80,5 +80,5 @@ func (s *Strategy) scheduleSnapshotJobs(repo *gitclone.Repository) {
 }
 
 func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request, host, pathValue string) {
-	s.serveCachedArtifact(w, r, host, pathValue, "snapshot")
+	s.serveCachedArtifact(w, r, host, pathValue, "snapshot.tar.zst", "snapshot")
 }

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -55,10 +55,10 @@ func TestSnapshotHTTPEndpoint(t *testing.T) {
 	assert.NotZero(t, handler)
 
 	// Test successful snapshot request
-	req := httptest.NewRequest(http.MethodGet, "/git/github.com/org/repo/snapshot", nil)
+	req := httptest.NewRequest(http.MethodGet, "/git/github.com/org/repo/snapshot.tar.zst", nil)
 	req = req.WithContext(ctx)
 	req.SetPathValue("host", "github.com")
-	req.SetPathValue("path", "org/repo/snapshot")
+	req.SetPathValue("path", "org/repo/snapshot.tar.zst")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -68,10 +68,10 @@ func TestSnapshotHTTPEndpoint(t *testing.T) {
 	assert.Equal(t, snapshotData, w.Body.Bytes())
 
 	// Test snapshot not found
-	req = httptest.NewRequest(http.MethodGet, "/git/github.com/org/nonexistent/snapshot", nil)
+	req = httptest.NewRequest(http.MethodGet, "/git/github.com/org/nonexistent/snapshot.tar.zst", nil)
 	req = req.WithContext(ctx)
 	req.SetPathValue("host", "github.com")
-	req.SetPathValue("path", "org/nonexistent/snapshot")
+	req.SetPathValue("path", "org/nonexistent/snapshot.tar.zst")
 	w = httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)


### PR DESCRIPTION
Snapshot endpoint changes from /snapshot to /snapshot.tar.zst so
the URL clearly indicates the file type being served.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
