### PR TITLE
feat: add global state directory config

### DIFF
--- a/cachew.hcl
+++ b/cachew.hcl
@@ -3,14 +3,13 @@
 #   target = "https://example.jfrog.io"
 # }
 
+state = "./state"
 url = "http://127.0.0.1:8080"
 log {
   level = "debug"
 }
 
-git-clone {
-    mirror-root = "./state/git-mirrors"
-}
+git-clone {}
 
 github-app {
   # Uncomment and add:
@@ -24,7 +23,8 @@ metrics {}
 
 git {
   #bundle-interval = "24h"
-  #snapshot-interval = "24h"
+  snapshot-interval = "1h"
+  repack-interval = "1h"
 }
 
 host "https://w3.org" {}
@@ -35,7 +35,6 @@ github-releases {
 }
 
 disk {
-  root = "./state/cache"
   limit-mb = 250000
   max-ttl = "8h"
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,7 +109,7 @@ func Load(
 	for _, node := range ast.Entries {
 		switch node := node.(type) {
 		case *hcl.Block:
-			c, err := cr.Create(ctx, node.Name, node)
+			c, err := cr.Create(ctx, node.Name, node, vars)
 			if errors.Is(err, cache.ErrNotFound) {
 				strategyCandidates = append(strategyCandidates, node)
 				continue

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -53,7 +53,7 @@ func DefaultGitTuningConfig() GitTuningConfig {
 }
 
 type Config struct {
-	MirrorRoot       string        `hcl:"mirror-root" help:"Directory to store git clones."`
+	MirrorRoot       string        `hcl:"mirror-root,optional" help:"Directory to store git clones." default:"${CACHEW_STATE}/git-mirrors"`
 	FetchInterval    time.Duration `hcl:"fetch-interval,optional" help:"How often to fetch from upstream in minutes." default:"15m"`
 	RefCheckInterval time.Duration `hcl:"ref-check-interval,optional" help:"How long to cache ref checks." default:"10s"`
 	Maintenance      bool          `hcl:"maintenance,optional" help:"Enable git maintenance scheduling for mirror repos." default:"false"`


### PR DESCRIPTION
Add a top-level `state` config field (default: `./state`) that gets
injected as CACHEW_STATE for expansion in plugin config defaults.
Mirror root and disk cache root now default to
`${CACHEW_STATE}/git-mirrors` and `${CACHEW_STATE}/cache`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
