### PR TITLE
feat(scheduler): add priority queue support

### DIFF
--- a/internal/jobscheduler/jobs.go
+++ b/internal/jobscheduler/jobs.go
@@ -16,9 +16,10 @@ import (
 )
 
 type Config struct {
-	Concurrency         int    `hcl:"concurrency" help:"The maximum number of concurrent jobs to run (0 means number of cores)." default:"4"`
-	MaxCloneConcurrency int    `hcl:"max-clone-concurrency" help:"Maximum number of concurrent clone jobs. Remaining worker slots are reserved for fetch/repack/snapshot jobs. 0 means no limit." default:"0"`
-	SchedulerDB         string `hcl:"scheduler-db" help:"Path to the scheduler state database." default:"${CACHEW_STATE}/scheduler.db"`
+	Concurrency         int      `hcl:"concurrency" help:"The maximum number of concurrent jobs to run (0 means number of cores)." default:"4"`
+	MaxCloneConcurrency int      `hcl:"max-clone-concurrency" help:"Maximum number of concurrent clone jobs. Remaining worker slots are reserved for fetch/repack/snapshot jobs. 0 means no limit." default:"0"`
+	SchedulerDB         string   `hcl:"scheduler-db" help:"Path to the scheduler state database." default:"${CACHEW_STATE}/scheduler.db"`
+	PriorityQueues      []string `hcl:"priority-queues,optional" help:"Queue name prefixes that should be dequeued before other jobs. Matches if the queue starts with any prefix."`
 }
 
 type queueJob struct {
@@ -80,6 +81,7 @@ type RootScheduler struct {
 	active              map[string]string // queue -> job id
 	activeClones        int
 	maxCloneConcurrency int
+	priorityQueues      []string
 	cancel              context.CancelFunc
 	store               ScheduleStore
 	metrics             *schedulerMetrics
@@ -122,6 +124,7 @@ func New(ctx context.Context, config Config) (*RootScheduler, error) {
 		workAvailable:       make(chan bool, 1024),
 		active:              make(map[string]string),
 		maxCloneConcurrency: maxClones,
+		priorityQueues:      config.PriorityQueues,
 		store:               store,
 		metrics:             m,
 	}
@@ -265,27 +268,55 @@ func isCloneJob(id string) bool {
 	return strings.HasSuffix(id, "clone") || strings.HasSuffix(id, "deferred-mirror-restore")
 }
 
-// Take the next job for any queue that is not already running a job.
+// takeNextJob selects the next eligible job. Priority queue jobs are preferred over non-priority jobs;
+// within the same priority tier, jobs are dequeued in submission order (FIFO).
 func (q *RootScheduler) takeNextJob() (queueJob, bool) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
+	idx := -1
 	for i, job := range q.queue {
-		if _, active := q.active[job.queue]; active {
+		if !q.isEligibleLocked(job) {
 			continue
 		}
-		if q.maxCloneConcurrency > 0 && isCloneJob(job.id) && q.activeClones >= q.maxCloneConcurrency {
-			continue
+		if q.isPriority(job.queue) {
+			idx = i
+			break
 		}
-		q.queue = append(q.queue[:i], q.queue[i+1:]...)
-		q.workAvailable <- true
-		q.active[job.queue] = job.id
-		if isCloneJob(job.id) {
-			q.activeClones++
+		if idx == -1 {
+			idx = i
 		}
-		q.recordGaugesLocked()
-		return job, true
 	}
-	return queueJob{}, false
+	if idx == -1 {
+		return queueJob{}, false
+	}
+	job := q.queue[idx]
+	q.queue = append(q.queue[:idx], q.queue[idx+1:]...)
+	q.workAvailable <- true
+	q.active[job.queue] = job.id
+	if isCloneJob(job.id) {
+		q.activeClones++
+	}
+	q.recordGaugesLocked()
+	return job, true
+}
+
+func (q *RootScheduler) isEligibleLocked(job queueJob) bool {
+	if _, active := q.active[job.queue]; active {
+		return false
+	}
+	if q.maxCloneConcurrency > 0 && isCloneJob(job.id) && q.activeClones >= q.maxCloneConcurrency {
+		return false
+	}
+	return true
+}
+
+func (q *RootScheduler) isPriority(queue string) bool {
+	for _, prefix := range q.priorityQueues {
+		if strings.HasPrefix(queue, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // recordGaugesLocked updates gauge metrics. Must be called with q.lock held.

--- a/internal/jobscheduler/jobs_test.go
+++ b/internal/jobscheduler/jobs_test.go
@@ -460,6 +460,66 @@ func FuzzJobScheduler(f *testing.F) {
 	})
 }
 
+func TestJobSchedulerPriorityQueues(t *testing.T) {
+	_, ctx := logging.Configure(context.Background(), logging.Config{Level: slog.LevelError})
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Single worker so jobs execute sequentially, making order deterministic.
+	scheduler := newTestScheduler(ctx, t, jobscheduler.Config{
+		Concurrency:    1,
+		PriorityQueues: []string{"https://github.com/important/"},
+	})
+
+	var (
+		mu    sync.Mutex
+		order []string
+	)
+
+	// Block the single worker so all subsequent submits queue up.
+	blockerStarted := make(chan struct{})
+	blocker := make(chan struct{})
+	scheduler.Submit("blocker", "block", func(_ context.Context) error {
+		close(blockerStarted)
+		<-blocker
+		return nil
+	})
+	<-blockerStarted
+
+	// Submit non-priority first, then priority. Priority should execute first after the blocker.
+	scheduler.Submit("https://github.com/random/repo", "job", func(_ context.Context) error {
+		mu.Lock()
+		order = append(order, "random")
+		mu.Unlock()
+		return nil
+	})
+	scheduler.Submit("https://github.com/important/monorepo", "job", func(_ context.Context) error {
+		mu.Lock()
+		order = append(order, "important")
+		mu.Unlock()
+		return nil
+	})
+	scheduler.Submit("https://github.com/other/thing", "job", func(_ context.Context) error {
+		mu.Lock()
+		order = append(order, "other")
+		mu.Unlock()
+		return nil
+	})
+
+	// Release the blocker.
+	close(blocker)
+
+	eventually(t, 2*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) == 3
+	}, "all jobs should complete")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "important", order[0], "priority job should execute first, got: %v", order)
+}
+
 func TestJobSchedulerCloneConcurrencyLimit(t *testing.T) {
 	_, ctx := logging.Configure(context.Background(), logging.Config{Level: slog.LevelError})
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
## Summary

Add a `priority-queues` config option to the scheduler. Jobs whose queue name matches a priority prefix are dequeued before non-priority jobs, while maintaining FIFO order within each tier.

## Motivation

When cachew is under load (e.g., a burst of cold clone requests), important repositories like monorepos can get stuck behind a queue of less critical work. This change lets operators ensure high-value repos are always serviced first.

## Configuration

```hcl
scheduler {
  priority-queues = ["https://github.com/org/monorepo"]
}
```

Queue names are upstream URLs, so the values are intuitive. Multiple prefixes can be specified.

## Design

The `takeNextJob` scan does a single pass: it tracks the first eligible non-priority job as a fallback, but immediately selects the first eligible priority job if found. This preserves the existing O(n) scan cost with no additional data structures.

Existing behaviour is unchanged when `priority-queues` is empty (the default).