### PR TITLE
feat(scheduler): add cost-based job admission

### DIFF
--- a/internal/jobscheduler/jobs.go
+++ b/internal/jobscheduler/jobs.go
@@ -18,19 +18,23 @@ import (
 type Config struct {
 	Concurrency         int    `hcl:"concurrency" help:"The maximum number of concurrent jobs to run (0 means number of cores)." default:"4"`
 	MaxCloneConcurrency int    `hcl:"max-clone-concurrency" help:"Maximum number of concurrent clone jobs. Remaining worker slots are reserved for fetch/repack/snapshot jobs. 0 means no limit." default:"0"`
+	MaxCost             int    `hcl:"max-cost" help:"Maximum total cost of concurrently running jobs. Each job declares its own cost at submission. 0 means Concurrency * 4." default:"0"`
 	SchedulerDB         string `hcl:"scheduler-db" help:"Path to the scheduler state database." default:"${CACHEW_STATE}/scheduler.db"`
 }
 
-type queueJob struct {
-	id    string
-	queue string
-	run   func(ctx context.Context) error
+// Job describes a unit of work to submit to the scheduler.
+type Job struct {
+	Queue string
+	ID    string
+	Cost  int
+	Clone bool // Subject to MaxCloneConcurrency limits.
+	Run   func(ctx context.Context) error
 }
 
 func jobKey(queue, id string) string { return id + ":" + queue }
 
-func (j *queueJob) String() string                { return jobKey(j.queue, j.id) }
-func (j *queueJob) Run(ctx context.Context) error { return errors.WithStack(j.run(ctx)) }
+func (j *Job) String() string                { return jobKey(j.Queue, j.ID) }
+func (j *Job) run(ctx context.Context) error { return errors.WithStack(j.Run(ctx)) }
 
 // Scheduler runs background jobs concurrently across multiple serialised queues.
 //
@@ -43,14 +47,14 @@ type Scheduler interface {
 	//
 	// This is useful to avoid collisions across strategies.
 	WithQueuePrefix(prefix string) Scheduler
-	// Submit a job to the queue.
+	// Submit a job to the scheduler.
 	//
 	// Jobs run concurrently across queues, but never within a queue.
-	Submit(queue, id string, run func(ctx context.Context) error)
-	// SubmitPeriodicJob submits a job to the queue that runs immediately, and then periodically after the interval.
+	Submit(job Job)
+	// SubmitPeriodicJob submits a job that runs immediately, then repeats after the interval.
 	//
 	// Jobs run concurrently across queues, but never within a queue.
-	SubmitPeriodicJob(queue, id string, interval time.Duration, run func(ctx context.Context) error)
+	SubmitPeriodicJob(job Job, interval time.Duration)
 }
 
 type prefixedScheduler struct {
@@ -58,12 +62,14 @@ type prefixedScheduler struct {
 	scheduler Scheduler
 }
 
-func (p *prefixedScheduler) Submit(queue, id string, run func(ctx context.Context) error) {
-	p.scheduler.Submit(queue, p.prefix+id, run)
+func (p *prefixedScheduler) Submit(job Job) {
+	job.ID = p.prefix + job.ID
+	p.scheduler.Submit(job)
 }
 
-func (p *prefixedScheduler) SubmitPeriodicJob(queue, id string, interval time.Duration, run func(ctx context.Context) error) {
-	p.scheduler.SubmitPeriodicJob(queue, p.prefix+id, interval, run)
+func (p *prefixedScheduler) SubmitPeriodicJob(job Job, interval time.Duration) {
+	job.ID = p.prefix + job.ID
+	p.scheduler.SubmitPeriodicJob(job, interval)
 }
 
 func (p *prefixedScheduler) WithQueuePrefix(prefix string) Scheduler {
@@ -76,9 +82,13 @@ func (p *prefixedScheduler) WithQueuePrefix(prefix string) Scheduler {
 type RootScheduler struct {
 	workAvailable       chan bool
 	lock                sync.Mutex
-	queue               []queueJob
+	queue               []Job
 	active              map[string]string // queue -> job id
+	activeCost          int
+	activeCosts         map[string]int // queue -> cost of running job
+	maxCost             int
 	activeClones        int
+	activeCloneQueues   map[string]bool
 	maxCloneConcurrency int
 	cancel              context.CancelFunc
 	store               ScheduleStore
@@ -111,8 +121,11 @@ func New(ctx context.Context, config Config) (*RootScheduler, error) {
 	}
 	maxClones := config.MaxCloneConcurrency
 	if maxClones == 0 && config.Concurrency > 1 {
-		// Default: reserve at least half the workers for non-clone jobs.
 		maxClones = max(1, config.Concurrency/2)
+	}
+	maxCost := config.MaxCost
+	if maxCost == 0 {
+		maxCost = config.Concurrency * 4
 	}
 	m, err := newSchedulerMetrics()
 	if err != nil {
@@ -121,6 +134,9 @@ func New(ctx context.Context, config Config) (*RootScheduler, error) {
 	q := &RootScheduler{
 		workAvailable:       make(chan bool, 1024),
 		active:              make(map[string]string),
+		activeCosts:         make(map[string]int),
+		activeCloneQueues:   make(map[string]bool),
+		maxCost:             maxCost,
 		maxCloneConcurrency: maxClones,
 		store:               store,
 		metrics:             m,
@@ -147,20 +163,21 @@ func (q *RootScheduler) WithQueuePrefix(prefix string) Scheduler {
 	}
 }
 
-func (q *RootScheduler) Submit(queue, id string, run func(ctx context.Context) error) {
+func (q *RootScheduler) Submit(job Job) {
 	q.lock.Lock()
-	q.queue = append(q.queue, queueJob{queue: queue, id: id, run: run})
+	q.queue = append(q.queue, job)
 	q.metrics.queueDepth.Record(context.Background(), int64(len(q.queue)))
 	q.lock.Unlock()
 	q.workAvailable <- true
 }
 
-func (q *RootScheduler) SubmitPeriodicJob(queue, id string, interval time.Duration, run func(ctx context.Context) error) {
-	key := jobKey(queue, id)
+func (q *RootScheduler) SubmitPeriodicJob(job Job, interval time.Duration) {
+	key := jobKey(job.Queue, job.ID)
 	delay := q.periodicDelay(key, interval)
+	origRun := job.Run
 	submit := func() {
-		q.Submit(queue, id, func(ctx context.Context) error {
-			err := run(ctx)
+		job.Run = func(ctx context.Context) error {
+			err := origRun(ctx)
 			if q.store != nil {
 				if storeErr := q.store.SetLastRun(key, time.Now()); storeErr != nil {
 					logging.FromContext(ctx).WarnContext(ctx, "Failed to record job last run", "key", key, "error", storeErr)
@@ -168,10 +185,11 @@ func (q *RootScheduler) SubmitPeriodicJob(queue, id string, interval time.Durati
 			}
 			go func() {
 				time.Sleep(interval)
-				q.SubmitPeriodicJob(queue, id, interval, run)
+				q.SubmitPeriodicJob(job, interval)
 			}()
 			return errors.WithStack(err)
-		})
+		}
+		q.Submit(job)
 	}
 	if delay <= 0 {
 		submit()
@@ -210,7 +228,7 @@ func (q *RootScheduler) worker(ctx context.Context, id int) {
 			if !ok {
 				continue
 			}
-			jobAttrs := attribute.String("job.type", jobType(job.id))
+			jobAttrs := attribute.String("job.type", jobType(job.ID))
 			start := time.Now()
 			logger.InfoContext(ctx, "Starting job", "job", job)
 			err := job.run(ctx)
@@ -225,7 +243,7 @@ func (q *RootScheduler) worker(ctx context.Context, id int) {
 			statusAttr := attribute.String("status", status)
 			q.metrics.jobsTotal.Add(ctx, 1, metric.WithAttributes(jobAttrs, statusAttr))
 			q.metrics.jobDuration.Record(ctx, elapsed.Seconds(), metric.WithAttributes(jobAttrs, statusAttr))
-			q.markQueueInactive(job.queue)
+			q.markQueueInactive(job.Queue)
 			q.workAvailable <- true
 		}
 	}
@@ -252,40 +270,42 @@ func jobType(id string) string {
 func (q *RootScheduler) markQueueInactive(queue string) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	if isCloneJob(q.active[queue]) {
+	q.activeCost -= q.activeCosts[queue]
+	delete(q.activeCosts, queue)
+	if q.activeCloneQueues[queue] {
 		q.activeClones--
+		delete(q.activeCloneQueues, queue)
 	}
 	delete(q.active, queue)
 	q.recordGaugesLocked()
 }
 
-// isCloneJob returns true for job IDs that represent long-running clone operations
-// which should be subject to concurrency limits.
-func isCloneJob(id string) bool {
-	return strings.HasSuffix(id, "clone") || strings.HasSuffix(id, "deferred-mirror-restore")
-}
-
-// Take the next job for any queue that is not already running a job.
-func (q *RootScheduler) takeNextJob() (queueJob, bool) {
+func (q *RootScheduler) takeNextJob() (Job, bool) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	for i, job := range q.queue {
-		if _, active := q.active[job.queue]; active {
+		if _, active := q.active[job.Queue]; active {
 			continue
 		}
-		if q.maxCloneConcurrency > 0 && isCloneJob(job.id) && q.activeClones >= q.maxCloneConcurrency {
+		if q.activeCost > 0 && q.activeCost+job.Cost > q.maxCost {
+			continue
+		}
+		if job.Clone && q.maxCloneConcurrency > 0 && q.activeClones >= q.maxCloneConcurrency {
 			continue
 		}
 		q.queue = append(q.queue[:i], q.queue[i+1:]...)
 		q.workAvailable <- true
-		q.active[job.queue] = job.id
-		if isCloneJob(job.id) {
+		q.active[job.Queue] = job.ID
+		q.activeCost += job.Cost
+		q.activeCosts[job.Queue] = job.Cost
+		if job.Clone {
 			q.activeClones++
+			q.activeCloneQueues[job.Queue] = true
 		}
 		q.recordGaugesLocked()
 		return job, true
 	}
-	return queueJob{}, false
+	return Job{}, false
 }
 
 // recordGaugesLocked updates gauge metrics. Must be called with q.lock held.
@@ -293,5 +313,6 @@ func (q *RootScheduler) recordGaugesLocked() {
 	ctx := context.Background()
 	q.metrics.queueDepth.Record(ctx, int64(len(q.queue)))
 	q.metrics.activeWorkers.Record(ctx, int64(len(q.active)))
+	q.metrics.activeCost.Record(ctx, int64(q.activeCost))
 	q.metrics.activeClones.Record(ctx, int64(q.activeClones))
 }

--- a/internal/jobscheduler/jobs_test.go
+++ b/internal/jobscheduler/jobs_test.go
@@ -51,10 +51,10 @@ func TestJobSchedulerBasic(t *testing.T) {
 	scheduler := newTestScheduler(ctx, t, jobscheduler.Config{Concurrency: 2})
 
 	var executed atomic.Bool
-	scheduler.Submit("queue1", "job1", func(_ context.Context) error {
+	scheduler.Submit(jobscheduler.Job{Queue: "queue1", ID: "job1", Cost: 1, Run: func(_ context.Context) error {
 		executed.Store(true)
 		return nil
-	})
+	}})
 
 	eventually(t, time.Second, executed.Load, "job should execute")
 }
@@ -77,7 +77,7 @@ func TestJobSchedulerConcurrency(t *testing.T) {
 	for i := range jobCount {
 		queueID := fmt.Sprintf("queue%d", i)
 		jobID := fmt.Sprintf("job%d", i)
-		scheduler.Submit(queueID, jobID, func(_ context.Context) error {
+		scheduler.Submit(jobscheduler.Job{Queue: queueID, ID: jobID, Cost: 1, Run: func(_ context.Context) error {
 			current := running.Add(1)
 			defer running.Add(-1)
 
@@ -94,7 +94,7 @@ func TestJobSchedulerConcurrency(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 			jobsCompleted.Add(1)
 			return nil
-		})
+		}})
 	}
 
 	eventually(t, 5*time.Second, func() bool {
@@ -134,21 +134,21 @@ func TestJobSchedulerQueueIsolation(t *testing.T) {
 	}
 
 	jobID := "job1"
-	scheduler.Submit("queue1", jobID, func(_ context.Context) error {
+	scheduler.Submit(jobscheduler.Job{Queue: "queue1", ID: jobID, Cost: 1, Run: func(_ context.Context) error {
 		queue1Running.Add(1)
 		defer queue1Running.Add(-1)
 		updateMax(&queue1Running, &maxQueue1Concurrent)
 		time.Sleep(50 * time.Millisecond)
 		return nil
-	})
+	}})
 
-	scheduler.Submit("queue2", jobID, func(_ context.Context) error {
+	scheduler.Submit(jobscheduler.Job{Queue: "queue2", ID: jobID, Cost: 1, Run: func(_ context.Context) error {
 		queue2Running.Add(1)
 		defer queue2Running.Add(-1)
 		updateMax(&queue2Running, &maxQueue2Concurrent)
 		time.Sleep(50 * time.Millisecond)
 		return nil
-	})
+	}})
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -173,12 +173,12 @@ func TestJobSchedulerJobOrdering(t *testing.T) {
 	for i := range 5 {
 		queueID := fmt.Sprintf("queue%d", i)
 		jobID := fmt.Sprintf("job%d", i)
-		scheduler.Submit(queueID, jobID, func(_ context.Context) error {
+		scheduler.Submit(jobscheduler.Job{Queue: queueID, ID: jobID, Cost: 1, Run: func(_ context.Context) error {
 			mu.Lock()
 			order = append(order, i)
 			mu.Unlock()
 			return nil
-		})
+		}})
 	}
 
 	eventually(t, time.Second, func() bool {
@@ -208,15 +208,15 @@ func TestJobSchedulerErrorHandling(t *testing.T) {
 		job2Executed       atomic.Bool
 	)
 
-	scheduler.Submit("queue1", "failing-job", func(_ context.Context) error {
+	scheduler.Submit(jobscheduler.Job{Queue: "queue1", ID: "failing-job", Cost: 1, Run: func(_ context.Context) error {
 		failingJobExecuted.Store(true)
 		return errors.New("intentional error")
-	})
+	}})
 
-	scheduler.Submit("queue2", "job2", func(_ context.Context) error {
+	scheduler.Submit(jobscheduler.Job{Queue: "queue2", ID: "job2", Cost: 1, Run: func(_ context.Context) error {
 		job2Executed.Store(true)
 		return nil
-	})
+	}})
 
 	eventually(t, time.Second, func() bool {
 		return failingJobExecuted.Load() && job2Executed.Load()
@@ -231,11 +231,11 @@ func TestJobSchedulerContextCancellation(t *testing.T) {
 
 	var jobStarted atomic.Bool
 
-	scheduler.Submit("queue1", "job1", func(ctx context.Context) error {
+	scheduler.Submit(jobscheduler.Job{Queue: "queue1", ID: "job1", Cost: 1, Run: func(ctx context.Context) error {
 		jobStarted.Store(true)
 		<-ctx.Done()
 		return ctx.Err()
-	})
+	}})
 
 	eventually(t, time.Second, jobStarted.Load)
 
@@ -253,10 +253,10 @@ func TestJobSchedulerPeriodicJob(t *testing.T) {
 
 	var executionCount atomic.Int32
 
-	scheduler.SubmitPeriodicJob("queue1", "periodic", 50*time.Millisecond, func(_ context.Context) error {
+	scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: "queue1", ID: "periodic", Cost: 1, Run: func(_ context.Context) error {
 		executionCount.Add(1)
 		return nil
-	})
+	}}, 50*time.Millisecond)
 
 	eventually(t, 2*time.Second, func() bool {
 		return executionCount.Load() >= 3
@@ -272,10 +272,10 @@ func TestJobSchedulerPeriodicJobWithError(t *testing.T) {
 
 	var executionCount atomic.Int32
 
-	scheduler.SubmitPeriodicJob("queue1", "periodic-error", 50*time.Millisecond, func(_ context.Context) error {
+	scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: "queue1", ID: "periodic-error", Cost: 1, Run: func(_ context.Context) error {
 		executionCount.Add(1)
 		return errors.New("intentional error")
-	})
+	}}, 50*time.Millisecond)
 
 	eventually(t, 2*time.Second, func() bool {
 		return executionCount.Load() >= 3
@@ -301,14 +301,14 @@ func TestJobSchedulerMultipleQueues(t *testing.T) {
 	for _, queue := range queues {
 		queueExecutions[queue] = false
 		jobID := "job1"
-		scheduler.Submit(queue, jobID, func(_ context.Context) error {
+		scheduler.Submit(jobscheduler.Job{Queue: queue, ID: jobID, Cost: 1, Run: func(_ context.Context) error {
 			mu.Lock()
 			queueExecutions[queue] = true
 			mu.Unlock()
 			time.Sleep(20 * time.Millisecond)
 			completed.Add(1)
 			return nil
-		})
+		}})
 	}
 
 	eventually(t, 5*time.Second, func() bool {
@@ -335,11 +335,11 @@ func TestJobSchedulerHighConcurrency(t *testing.T) {
 	for i := range jobCount {
 		queueID := fmt.Sprintf("queue%d", i)
 		jobID := fmt.Sprintf("job%d", i)
-		scheduler.Submit(queueID, jobID, func(_ context.Context) error {
+		scheduler.Submit(jobscheduler.Job{Queue: queueID, ID: jobID, Cost: 1, Run: func(_ context.Context) error {
 			time.Sleep(time.Millisecond)
 			completed.Add(1)
 			return nil
-		})
+		}})
 	}
 
 	eventually(t, 5*time.Second, func() bool {
@@ -400,7 +400,7 @@ func FuzzJobScheduler(f *testing.F) {
 			}
 			mu.Unlock()
 
-			scheduler.Submit(queueID, jobID, func(_ context.Context) error {
+			scheduler.Submit(jobscheduler.Job{Queue: queueID, ID: jobID, Cost: 1, Run: func(_ context.Context) error {
 				current := running.Add(1)
 				defer running.Add(-1)
 
@@ -425,7 +425,7 @@ func FuzzJobScheduler(f *testing.F) {
 
 				completed.Add(1)
 				return nil
-			})
+			}})
 		}
 
 		// Wait for all jobs to complete
@@ -460,7 +460,7 @@ func FuzzJobScheduler(f *testing.F) {
 	})
 }
 
-func TestJobSchedulerCloneConcurrencyLimit(t *testing.T) {
+func TestJobSchedulerCostLimit(t *testing.T) {
 	_, ctx := logging.Configure(context.Background(), logging.Config{Level: slog.LevelError})
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -468,61 +468,62 @@ func TestJobSchedulerCloneConcurrencyLimit(t *testing.T) {
 	scheduler := newTestScheduler(ctx, t, jobscheduler.Config{
 		Concurrency:         8,
 		MaxCloneConcurrency: 2,
+		MaxCost:             10,
 	})
 
 	var (
-		cloneRunning       atomic.Int32
-		maxCloneConcurrent atomic.Int32
-		fetchCompleted     atomic.Int32
-		cloneCompleted     atomic.Int32
-		allClonesBlocking  sync.WaitGroup
+		heavyRunning       atomic.Int32
+		maxHeavyConcurrent atomic.Int32
+		lightCompleted     atomic.Int32
+		heavyCompleted     atomic.Int32
+		allHeavyBlocking   sync.WaitGroup
 	)
 
-	// Submit 4 clone jobs that block until released.
-	allClonesBlocking.Add(1)
+	// Submit 4 cost-4 jobs that block until released. MaxCost=10 allows at most 2 concurrent (3*4=12>10).
+	allHeavyBlocking.Add(1)
 	for i := range 4 {
 		queue := fmt.Sprintf("repo%d", i)
-		scheduler.Submit(queue, "git-clone", func(_ context.Context) error {
-			current := cloneRunning.Add(1)
-			defer cloneRunning.Add(-1)
+		scheduler.Submit(jobscheduler.Job{Queue: queue, ID: "git-clone", Cost: 4, Clone: true, Run: func(_ context.Context) error {
+			current := heavyRunning.Add(1)
+			defer heavyRunning.Add(-1)
 			for {
-				maxVal := maxCloneConcurrent.Load()
+				maxVal := maxHeavyConcurrent.Load()
 				if current <= maxVal {
 					break
 				}
-				if maxCloneConcurrent.CompareAndSwap(maxVal, current) {
+				if maxHeavyConcurrent.CompareAndSwap(maxVal, current) {
 					break
 				}
 			}
-			allClonesBlocking.Wait()
-			cloneCompleted.Add(1)
+			allHeavyBlocking.Wait()
+			heavyCompleted.Add(1)
 			return nil
-		})
+		}})
 	}
 
-	// Submit fetch jobs on different queues — these should NOT be blocked by clone limit.
+	// Submit cost-1 jobs on different queues — these should still be admitted alongside cost-4 jobs.
 	for i := range 4 {
 		queue := fmt.Sprintf("fetch-repo%d", i)
-		scheduler.Submit(queue, "git-fetch", func(_ context.Context) error {
-			fetchCompleted.Add(1)
+		scheduler.Submit(jobscheduler.Job{Queue: queue, ID: "git-fetch", Cost: 1, Run: func(_ context.Context) error {
+			lightCompleted.Add(1)
 			return nil
-		})
+		}})
 	}
 
-	// Fetch jobs should complete even while clone jobs are blocking workers.
+	// Light jobs should complete even while heavy jobs are blocking workers.
 	eventually(t, 2*time.Second, func() bool {
-		return fetchCompleted.Load() == 4
-	}, "fetch jobs should complete without being blocked by clone limit")
+		return lightCompleted.Load() == 4
+	}, "light jobs should complete without being blocked by cost limit")
 
-	// Clone concurrency should be capped at 2.
-	assert.True(t, maxCloneConcurrent.Load() <= 2,
-		"max concurrent clones (%d) should not exceed MaxCloneConcurrency (2)",
-		maxCloneConcurrent.Load())
+	// Cost-4 job concurrency should be capped at 2 (3*4=12 > MaxCost=10).
+	assert.True(t, maxHeavyConcurrent.Load() <= 2,
+		"max concurrent cost-4 jobs (%d) should not exceed 2",
+		maxHeavyConcurrent.Load())
 
-	// Release clone jobs.
-	allClonesBlocking.Done()
+	// Release heavy jobs.
+	allHeavyBlocking.Done()
 
 	eventually(t, 2*time.Second, func() bool {
-		return cloneCompleted.Load() == 4
-	}, "all clone jobs should eventually complete")
+		return heavyCompleted.Load() == 4
+	}, "all heavy jobs should eventually complete")
 }

--- a/internal/jobscheduler/metrics.go
+++ b/internal/jobscheduler/metrics.go
@@ -9,6 +9,7 @@ import (
 type schedulerMetrics struct {
 	queueDepth    metric.Int64Gauge
 	activeWorkers metric.Int64Gauge
+	activeCost    metric.Int64Gauge
 	activeClones  metric.Int64Gauge
 	jobsTotal     metric.Int64Counter
 	jobDuration   metric.Float64Histogram
@@ -29,6 +30,12 @@ func newSchedulerMetrics() (*schedulerMetrics, error) {
 		metric.WithDescription("Number of workers currently executing jobs"),
 		metric.WithUnit("{workers}")); err != nil {
 		return nil, errors.Wrap(err, "create active_workers gauge")
+	}
+
+	if m.activeCost, err = meter.Int64Gauge("cachew.scheduler.active_cost",
+		metric.WithDescription("Total cost of currently executing jobs"),
+		metric.WithUnit("{cost}")); err != nil {
+		return nil, errors.Wrap(err, "create active_cost gauge")
 	}
 
 	if m.activeClones, err = meter.Int64Gauge("cachew.scheduler.active_clones",

--- a/internal/jobscheduler/store_test.go
+++ b/internal/jobscheduler/store_test.go
@@ -98,10 +98,10 @@ func TestPeriodicJobDelaysWhenRecentlyRun(t *testing.T) {
 	defer scheduler.Close()
 
 	var executed atomic.Bool
-	scheduler.SubmitPeriodicJob("queue1", "periodic", 5*time.Second, func(_ context.Context) error {
+	scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: "queue1", ID: "periodic", Cost: 1, Run: func(_ context.Context) error {
 		executed.Store(true)
 		return nil
-	})
+	}}, 5*time.Second)
 
 	// The job should NOT have run within 200ms because interval is 5s and it "just ran".
 	time.Sleep(200 * time.Millisecond)
@@ -119,10 +119,10 @@ func TestPeriodicJobRunsImmediatelyWhenNeverRun(t *testing.T) {
 	defer scheduler.Close()
 
 	var executed atomic.Bool
-	scheduler.SubmitPeriodicJob("queue1", "periodic", 5*time.Second, func(_ context.Context) error {
+	scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: "queue1", ID: "periodic", Cost: 1, Run: func(_ context.Context) error {
 		executed.Store(true)
 		return nil
-	})
+	}}, 5*time.Second)
 
 	eventually(t, time.Second, executed.Load, "job should run immediately when no prior run recorded")
 }
@@ -145,10 +145,10 @@ func TestPeriodicJobRunsImmediatelyWhenIntervalElapsed(t *testing.T) {
 	defer scheduler.Close()
 
 	var executed atomic.Bool
-	scheduler.SubmitPeriodicJob("queue1", "periodic", 5*time.Second, func(_ context.Context) error {
+	scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: "queue1", ID: "periodic", Cost: 1, Run: func(_ context.Context) error {
 		executed.Store(true)
 		return nil
-	})
+	}}, 5*time.Second)
 
 	eventually(t, time.Second, executed.Load, "job should run immediately when interval has elapsed")
 }
@@ -164,10 +164,10 @@ func TestPeriodicJobRecordsLastRun(t *testing.T) {
 
 	var executed atomic.Bool
 	before := time.Now()
-	scheduler.SubmitPeriodicJob("queue1", "periodic", 5*time.Second, func(_ context.Context) error {
+	scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: "queue1", ID: "periodic", Cost: 1, Run: func(_ context.Context) error {
 		executed.Store(true)
 		return nil
-	})
+	}}, 5*time.Second)
 
 	eventually(t, time.Second, executed.Load, "job should execute")
 

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -28,6 +28,13 @@ import (
 	"github.com/block/cachew/internal/strategy"
 )
 
+const (
+	CostClone    = 4
+	CostSnapshot = 3
+	CostRepack   = 2
+	CostFetch    = 1
+)
+
 func Register(r *strategy.Registry, scheduler jobscheduler.Provider, cloneManagerProvider gitclone.ManagerProvider, tokenManagerProvider githubapp.TokenManagerProvider) {
 	strategy.Register(r, "git", "Caches Git repositories, including tarball snapshots.", func(ctx context.Context, config Config, cache cache.Cache, mux strategy.Mux) (*Strategy, error) {
 		return New(ctx, config, scheduler, cache, mux, cloneManagerProvider, tokenManagerProvider)
@@ -275,9 +282,9 @@ func (s *Strategy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	case gitclone.StateCloning, gitclone.StateEmpty:
 		if state == gitclone.StateEmpty {
 			logger.DebugContext(ctx, "Starting background clone, forwarding to upstream")
-			s.scheduler.Submit(repo.UpstreamURL(), "clone", func(ctx context.Context) error {
+			s.scheduler.Submit(jobscheduler.Job{Queue: repo.UpstreamURL(), ID: "clone", Cost: CostClone, Clone: true, Run: func(ctx context.Context) error {
 				return s.startClone(ctx, repo)
-			})
+			}})
 		}
 		if err := s.serveWithSpool(w, r, host, pathValue, upstreamURL); err != nil {
 			logger.WarnContext(ctx, "Spool failed, forwarding to upstream", "error", err)
@@ -607,9 +614,9 @@ func (s *Strategy) maybeBackgroundFetch(repo *gitclone.Repository) {
 func (s *Strategy) submitFetch(repo *gitclone.Repository) {
 	// Use a separate queue from snapshot/repack so fetches are not serialized
 	// behind long-running jobs on the same upstream URL queue.
-	s.scheduler.Submit(repo.UpstreamURL()+"/fetch", "fetch", func(ctx context.Context) error {
+	s.scheduler.Submit(jobscheduler.Job{Queue: repo.UpstreamURL() + "/fetch", ID: "fetch", Cost: CostFetch, Run: func(ctx context.Context) error {
 		return s.doFetch(ctx, repo)
-	})
+	}})
 }
 
 func (s *Strategy) doFetch(ctx context.Context, repo *gitclone.Repository) error {

--- a/internal/strategy/git/repack.go
+++ b/internal/strategy/git/repack.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/internal/jobscheduler"
 )
 
 func (s *Strategy) scheduleRepackJobs(repo *gitclone.Repository) {
-	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "repack-periodic", s.config.RepackInterval, func(ctx context.Context) error {
+	s.scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: repo.UpstreamURL(), ID: "repack-periodic", Cost: CostRepack, Run: func(ctx context.Context) error {
 		return repo.Repack(ctx)
-	})
+	}}, s.config.RepackInterval)
 }

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/snapshot"
 )
@@ -170,16 +171,16 @@ func (s *Strategy) generateAndUploadMirrorSnapshot(ctx context.Context, repo *gi
 }
 
 func (s *Strategy) scheduleSnapshotJobs(repo *gitclone.Repository) {
-	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "snapshot-periodic", s.config.SnapshotInterval, func(ctx context.Context) error {
+	s.scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: repo.UpstreamURL(), ID: "snapshot-periodic", Cost: CostSnapshot, Run: func(ctx context.Context) error {
 		return s.generateAndUploadSnapshot(ctx, repo)
-	})
+	}}, s.config.SnapshotInterval)
 	mirrorInterval := s.config.MirrorSnapshotInterval
 	if mirrorInterval == 0 {
 		mirrorInterval = s.config.SnapshotInterval
 	}
-	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "mirror-snapshot-periodic", mirrorInterval, func(ctx context.Context) error {
+	s.scheduler.SubmitPeriodicJob(jobscheduler.Job{Queue: repo.UpstreamURL(), ID: "mirror-snapshot-periodic", Cost: CostSnapshot, Run: func(ctx context.Context) error {
 		return s.generateAndUploadMirrorSnapshot(ctx, repo)
-	})
+	}}, mirrorInterval)
 }
 
 func (s *Strategy) snapshotMutexFor(upstreamURL string) *sync.Mutex {
@@ -611,7 +612,7 @@ func (s *Strategy) scheduleDeferredMirrorRestore(ctx context.Context, repo *gitc
 	logger := logging.FromContext(ctx)
 	logger.InfoContext(ctx, "Scheduling deferred mirror restore", "upstream", upstream)
 
-	s.scheduler.Submit(upstream, "deferred-mirror-restore", func(ctx context.Context) error {
+	s.scheduler.Submit(jobscheduler.Job{Queue: upstream, ID: "deferred-mirror-restore", Cost: CostClone, Clone: true, Run: func(ctx context.Context) error {
 		logger := logging.FromContext(ctx)
 		if repo.State() == gitclone.StateReady {
 			logger.InfoContext(ctx, "Mirror already ready, skipping deferred restore", "upstream", upstream)
@@ -652,7 +653,7 @@ func (s *Strategy) scheduleDeferredMirrorRestore(ctx context.Context, repo *gitc
 			s.scheduleRepackJobs(repo)
 		}
 		return nil
-	})
+	}})
 }
 
 // snapshotSpoolEntry holds a spool and a ready channel used to coordinate


### PR DESCRIPTION
## Summary

Replace the binary `isCloneJob`/`MaxCloneConcurrency` mechanism with a generic cost model. Strategies declare the cost of each job at submit time, and the scheduler tracks total active cost against a configurable budget (`max-cost`).

## Design

The `Submit` and `SubmitPeriodicJob` interface methods now accept a `cost int` parameter. The scheduler admits a job only when `activeCost + job.cost <= maxCost` (with a safety valve: any job is admitted when nothing else is running, preventing permanent starvation from misconfiguration).

This removes `isCloneJob` — the scheduler no longer has knowledge of git-specific job types.

## Cost constants (git strategy)

| Job type | Cost | Rationale |
|----------|------|-----------|
| clone | 4 | Heavy CPU/IO/network, minutes |
| snapshot | 3 | Heavy CPU (zstd), moderate IO |
| repack | 2 | Heavy CPU, no network |
| fetch | 1 | Lightweight, seconds |

## Configuration

```hcl
scheduler {
  max-cost = 16  # default: concurrency * 4
}
```

With the defaults (concurrency=4, max-cost=16), you can run up to 4 clones, or 1 clone + 3 snapshots + 1 fetch, etc. The worker count remains the hard parallelism cap.

## Breaking changes

- `max-clone-concurrency` config replaced by `max-cost`
- `Scheduler.Submit` and `SubmitPeriodicJob` signatures changed (added `cost int`)