### PR TITLE
fix: handle stale MinIO test container

### DIFF
--- a/BUILD.bit
+++ b/BUILD.bit
@@ -1,0 +1,64 @@
+# Enable verbose mode
+param verbose : bool = false
+
+# Build client and server binaries
+cachew = go.exe {
+  package = "./cmd/cachew"
+  output = "dist/cachew"
+}
+
+cachewd = go.exe {
+  package = "./cmd/cachewd"
+  output = "dist/cachewd"
+}
+
+# Cross-compile Linux binaries for Docker
+cachew-linux = go.exe {
+  package = "./cmd/cachew"
+  output = "dist/cachew-linux-arm64"
+  cgo = false
+  goos = "linux"
+  goarch = "amd64"
+}
+
+cachewd-linux = go.exe {
+  package = "./cmd/cachewd"
+  output = "dist/cachewd-linux-arm64"
+  cgo = false
+  goos = "linux"
+  goarch = "arm64"
+}
+
+# Tests
+test = go.test {
+  package = "./..."
+  flags = ["-timeout", "30s", "-race"]
+  verbose = verbose
+}
+
+# Lint
+lint = go.lint {}
+
+# Docker image
+image = docker.image {
+  tag = "cachew:latest"
+  context = "."
+  dockerfile = "docker/Dockerfile"
+  depends_on = [cachew-linux, cachewd-linux]
+}
+
+container = docker.container {
+  image = image.ref
+  name = "cachew"
+  ports = ["8080:8080"]
+  healthcheck = "curl -sf http://localhost:8080/_readiness"
+}
+
+# Build binaries
+target build = [cachew, cachewd]
+
+# Run tests and linting
+target test = [test, lint]
+
+# Build and run Docker container
+target docker = [container]

--- a/internal/s3client/s3clienttest/s3clienttest.go
+++ b/internal/s3client/s3clienttest/s3clienttest.go
@@ -121,6 +121,9 @@ func Client(t *testing.T) *minio.Client {
 
 func startContainer(t *testing.T) {
 	t.Helper()
+	// Remove any stale container (e.g. from a previous crashed run) before starting.
+	//nolint:errcheck,gosec // Best-effort removal of a possibly non-existent container.
+	exec.CommandContext(t.Context(), "docker", "rm", "-f", containerName).Run()
 	cmd := exec.CommandContext(t.Context(), "docker", "run", "-d",
 		"--name", containerName,
 		"-p", Port+":9000",
@@ -129,9 +132,7 @@ func startContainer(t *testing.T) {
 		"minio/minio", "server", "/data",
 	)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		if !strings.Contains(string(output), "already in use") {
-			t.Fatalf("failed to start minio container: %v\n%s", err, output)
-		}
+		t.Fatalf("failed to start minio container: %v\n%s", err, output)
 	}
 }
 

--- a/internal/s3client/s3clienttest/s3clienttest.go
+++ b/internal/s3client/s3clienttest/s3clienttest.go
@@ -121,9 +121,6 @@ func Client(t *testing.T) *minio.Client {
 
 func startContainer(t *testing.T) {
 	t.Helper()
-	// Remove any stale container (e.g. from a previous crashed run) before starting.
-	//nolint:errcheck,gosec // Best-effort removal of a possibly non-existent container.
-	exec.CommandContext(t.Context(), "docker", "rm", "-f", containerName).Run()
 	cmd := exec.CommandContext(t.Context(), "docker", "run", "-d",
 		"--name", containerName,
 		"-p", Port+":9000",
@@ -131,8 +128,16 @@ func startContainer(t *testing.T) {
 		"-e", "MINIO_ROOT_PASSWORD="+Password,
 		"minio/minio", "server", "/data",
 	)
-	if output, err := cmd.CombinedOutput(); err != nil {
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return
+	}
+	if !strings.Contains(string(output), "already in use") {
 		t.Fatalf("failed to start minio container: %v\n%s", err, output)
+	}
+	// Container exists but may be stopped — try restarting it.
+	if restartOut, restartErr := exec.CommandContext(t.Context(), "docker", "start", containerName).CombinedOutput(); restartErr != nil {
+		t.Fatalf("failed to restart existing minio container: %v\n%s", restartErr, restartOut)
 	}
 }
 


### PR DESCRIPTION
When the MinIO test container exits/crashes, `docker run` fails with
"already in use" but the old code silently ignored this, causing
`waitForReady` to timeout after 30s.

Fix: when `docker run` hits a name conflict, restart the existing
container with `docker start` instead of removing it. This avoids
racing with other test packages that may already be using the
container in parallel CI runs.