### PR TITLE
fix: Narrow hermit GitHub redirect to release downloads only

### DIFF
--- a/internal/strategy/hermit.go
+++ b/internal/strategy/hermit.go
@@ -59,7 +59,7 @@ func NewHermit(ctx context.Context, config HermitConfig, _ jobscheduler.Schedule
 	if config.GitHubBaseURL != "" {
 		isInternalRedirect := config.GitHubBaseURL == defaultGitHubBaseURL
 		s.redirectHandler = s.createRedirectHandler(isInternalRedirect, c)
-		mux.Handle("GET /hermit/github.com/{path...}", s.redirectHandler)
+		mux.Handle("GET /hermit/github.com/{org}/{repo}/releases/download/{path...}", s.redirectHandler)
 		logger.InfoContext(ctx, "Hermit strategy initialized", "github_base_url", config.GitHubBaseURL,
 			"internal_redirect", isInternalRedirect)
 	} else {
@@ -99,12 +99,16 @@ func (s *Hermit) createRedirectHandler(isInternalRedirect bool, c cache.Cache) h
 		})
 }
 
+func (s *Hermit) githubReleasePath(r *http.Request) string {
+	return r.PathValue("org") + "/" + r.PathValue("repo") + "/releases/download/" + r.PathValue("path")
+}
+
 func (s *Hermit) buildGitHubURL(r *http.Request) string {
-	return buildURL("https", "github.com", r.PathValue("path"), r.URL.RawQuery)
+	return buildURL("https", "github.com", s.githubReleasePath(r), r.URL.RawQuery)
 }
 
 func (s *Hermit) buildRedirectRequest(r *http.Request) (*http.Request, error) {
-	path := ensureLeadingSlash(r.PathValue("path"))
+	path := ensureLeadingSlash(s.githubReleasePath(r))
 	redirectURL := s.config.GitHubBaseURL + path
 	if r.URL.RawQuery != "" {
 		redirectURL += "?" + r.URL.RawQuery

--- a/internal/strategy/hermit_test.go
+++ b/internal/strategy/hermit_test.go
@@ -184,6 +184,33 @@ func TestHermitDifferentSources(t *testing.T) {
 	}
 }
 
+func TestHermitGitHubArchive(t *testing.T) {
+	httpTransportMutexHermit.Lock()
+	defer httpTransportMutexHermit.Unlock()
+
+	callCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("archive-content"))
+	}))
+	defer backend.Close()
+
+	originalTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = originalTransport }()                                   //nolint:reassign
+	http.DefaultTransport = &mockTransport{backend: backend, originalTransport: originalTransport} //nolint:reassign
+
+	mux, ctx, _ := setupHermitTest(t)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/hermit/github.com/npryce/adr-tools/archive/refs/tags/3.0.0.tar.gz", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "archive-content", w.Body.String())
+	assert.Equal(t, 1, callCount)
+}
+
 func TestHermitCacheKeyGeneration(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
The hermit strategy was redirecting all github.com URLs to the
github-releases strategy, but only /releases/download/ URLs have
a matching handler. Archive URLs (e.g. /archive/refs/tags/) got
a 404 from the unmatched internal route. Narrowing the redirect
lets archive URLs fall through to the direct proxy handler.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
