### PR TITLE
fix: fold LFS snapshot scheduling into scheduleSnapshotJobs

### DIFF
--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -199,7 +199,6 @@ func (s *Strategy) warmExistingRepos(ctx context.Context) error {
 
 		if s.config.SnapshotInterval > 0 {
 			s.scheduleSnapshotJobs(repo)
-			s.scheduleLFSSnapshotJobs(repo)
 		}
 		if s.config.RepackInterval > 0 {
 			s.scheduleRepackJobs(repo)
@@ -545,7 +544,6 @@ func (s *Strategy) startClone(ctx context.Context, repo *gitclone.Repository) er
 
 			if s.config.SnapshotInterval > 0 {
 				s.scheduleSnapshotJobs(repo)
-				s.scheduleLFSSnapshotJobs(repo)
 			}
 			if s.config.RepackInterval > 0 {
 				s.scheduleRepackJobs(repo)
@@ -576,7 +574,6 @@ func (s *Strategy) startClone(ctx context.Context, repo *gitclone.Repository) er
 
 	if s.config.SnapshotInterval > 0 {
 		s.scheduleSnapshotJobs(repo)
-		s.scheduleLFSSnapshotJobs(repo)
 	}
 	if s.config.RepackInterval > 0 {
 		s.scheduleRepackJobs(repo)

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -172,6 +172,9 @@ func (s *Strategy) scheduleSnapshotJobs(repo *gitclone.Repository) {
 	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "snapshot-periodic", s.config.SnapshotInterval, func(ctx context.Context) error {
 		return s.generateAndUploadSnapshot(ctx, repo)
 	})
+	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "lfs-snapshot-periodic", s.config.SnapshotInterval, func(ctx context.Context) error {
+		return s.generateAndUploadLFSSnapshot(ctx, repo)
+	})
 	mirrorInterval := s.config.MirrorSnapshotInterval
 	if mirrorInterval == 0 {
 		mirrorInterval = s.config.SnapshotInterval
@@ -762,12 +765,6 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 	s.metrics.recordOperation(ctx, "lfs-snapshot", "success", time.Since(start))
 	logger.InfoContext(ctx, "LFS snapshot generation completed", "upstream", upstream)
 	return nil
-}
-
-func (s *Strategy) scheduleLFSSnapshotJobs(repo *gitclone.Repository) {
-	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "lfs-snapshot-periodic", s.config.SnapshotInterval, func(ctx context.Context) error {
-		return s.generateAndUploadLFSSnapshot(ctx, repo)
-	})
 }
 
 func (s *Strategy) handleLFSSnapshotRequest(w http.ResponseWriter, r *http.Request, host, pathValue string) {


### PR DESCRIPTION
scheduleLFSSnapshotJobs was a separate function that needed to be called alongside scheduleSnapshotJobs at every call site. Two paths added before LFS support (writeSnapshotSpool and scheduleDeferredMirrorRestore) were missing the call, so repos first initialized through cold-start or on-demand spool never had their LFS periodic job registered.

This folds the LFS periodic job into scheduleSnapshotJobs itself so there's only one function to call and every code path gets LFS scheduling automatically.

Discovered because ios-register never had an LFS snapshot generated. It was always initialized through the cold-start path. Other repos like cash-android worked by luck: their mirrors survived pod restarts on the persistent volume, so warmExistingRepos (which had the correct call) kept their LFS jobs scheduled.