### PR TITLE
feat: set lfs.concurrenttransfers to 100 for mirror clones

### DIFF
--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -431,6 +431,10 @@ func mirrorConfigSettings(packThreads int) [][2]string {
 		{"pack.threads", strconv.Itoa(packThreads)},
 		{"pack.deltaCacheSize", "512m"},
 		{"pack.windowMemory", "1g"},
+		// LFS fetches are I/O-bound; the git-lfs default of 8 is too low.
+		// See git-lfs/git-lfs#6241 for an upstream change (unreleased) that
+		// raises the default to 3×NCPU.
+		{"lfs.concurrenttransfers", "100"},
 	}
 }
 


### PR DESCRIPTION
The git-lfs default of 8 concurrent transfers is too low for LFS snapshot generation, which is I/O-bound. This sets it to 100 via the mirror git config to better saturate network bandwidth during `git lfs fetch`.

See git-lfs/git-lfs#6241 for an upstream change (unreleased) that raises the default to 3xNCPU.