### PR TITLE
feat(opa): expose caller principal from X-Forwarded-Client-Cert

### DIFF
--- a/internal/opa/opa.go
+++ b/internal/opa/opa.go
@@ -164,5 +164,34 @@ func buildInput(r *http.Request) map[string]any {
 		"path":        path,
 		"headers":     headers,
 		"remote_addr": r.RemoteAddr,
+		"principal":   parsePrincipal(r.Header.Get("X-Forwarded-Client-Cert")),
 	}
+}
+
+// parsePrincipal extracts the caller's SPIFFE identity from the X-Forwarded-Client-Cert
+// header set by an upstream Envoy/Istio sidecar. Returns an empty string if the header
+// is missing or the URI field is absent.
+//
+// The XFCC header format is described in
+// https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert.
+// Multiple certificates are separated by commas; within each entry, fields are
+// separated by semicolons. We only inspect the first (caller's) entry and return
+// the URI subject alternative name.
+func parsePrincipal(xfcc string) string {
+	if xfcc == "" {
+		return ""
+	}
+	first, _, _ := strings.Cut(xfcc, ",")
+	for field := range strings.SplitSeq(first, ";") {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(key), "URI") {
+			continue
+		}
+		// URI values may be quoted per RFC; strip surrounding quotes if present.
+		return strings.Trim(strings.TrimSpace(value), `"`)
+	}
+	return ""
 }

--- a/internal/opa/opa_test.go
+++ b/internal/opa/opa_test.go
@@ -289,3 +289,56 @@ func TestMiddlewareEmptyPolicyDeniesAll(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, w.Code)
 	}
 }
+
+func TestMiddlewarePrincipalBasedPolicy(t *testing.T) {
+	policy := `package cachew.authz
+default allow := false
+allow if input.principal == "spiffe://cluster.local/ns/blox/sa/cache-warmer"
+`
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+	handler, err := opa.Middleware(t.Context(), opa.Config{Policy: policy}, next)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		Name           string
+		XFCC           string
+		ExpectedStatus int
+	}{
+		{
+			Name:           "MatchingPrincipalAllowed",
+			XFCC:           `By=spiffe://cluster.local/ns/cachew/sa/cachew;Hash=abc;Subject="";URI=spiffe://cluster.local/ns/blox/sa/cache-warmer`,
+			ExpectedStatus: http.StatusOK,
+		},
+		{
+			Name:           "DifferentPrincipalDenied",
+			XFCC:           `By=spiffe://cluster.local/ns/cachew/sa/cachew;Hash=abc;URI=spiffe://cluster.local/ns/other/sa/other`,
+			ExpectedStatus: http.StatusForbidden,
+		},
+		{
+			Name:           "NoXFCCDenied",
+			XFCC:           "",
+			ExpectedStatus: http.StatusForbidden,
+		},
+		{
+			Name:           "QuotedURIAllowed",
+			XFCC:           `By=spiffe://cluster.local/ns/cachew/sa/cachew;Hash=abc;URI="spiffe://cluster.local/ns/blox/sa/cache-warmer"`,
+			ExpectedStatus: http.StatusOK,
+		},
+		{
+			Name:           "ChainOnlyChecksFirstEntry",
+			XFCC:           `By=x;URI=spiffe://cluster.local/ns/blox/sa/cache-warmer,By=y;URI=spiffe://cluster.local/ns/other/sa/other`,
+			ExpectedStatus: http.StatusOK,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			r := newRequest(http.MethodPost, "/api/v1/object/brew/key")
+			if test.XFCC != "" {
+				r.Header.Set("X-Forwarded-Client-Cert", test.XFCC)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+			assert.Equal(t, test.ExpectedStatus, w.Code)
+		})
+	}
+}


### PR DESCRIPTION
Parse the URI subject alternative name out of the first XFCC entry and add it to the OPA evaluation input as `principal`. This lets policies authorize requests by SPIFFE identity (e.g., the caller's Kubernetes ServiceAccount under Istio mTLS) instead of relying on spoofable headers or remote address only.

Empty string when the header is absent or the URI field is missing, so existing policies that don't reference `input.principal` continue to work unchanged.