### PR TITLE
fix(git): run startup warm-up in background and gate /_readiness on it

### DIFF
--- a/cmd/cachewd/main.go
+++ b/cmd/cachewd/main.go
@@ -174,7 +174,17 @@ func newMux(ctx context.Context, cr *cache.Registry, mr *metadatadb.Registry, sr
 		_, _ = w.Write([]byte("OK")) //nolint:errcheck
 	})
 
+	// readiers is populated by config.Load below. The /_readiness handler
+	// reads it through this closure so the slice is in scope before the
+	// HTTP server starts accepting connections.
+	var readiers []strategy.Readier
 	mux.HandleFunc("GET /_readiness", func(w http.ResponseWriter, _ *http.Request) {
+		for _, r := range readiers {
+			if !r.Ready() {
+				http.Error(w, "warming up", http.StatusServiceUnavailable)
+				return
+			}
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK")) //nolint:errcheck
 	})
@@ -199,10 +209,11 @@ func newMux(ctx context.Context, cr *cache.Registry, mr *metadatadb.Registry, sr
 		http.DefaultServeMux.ServeHTTP(w, r)
 	}))
 
-	handler, _, err := config.Load(ctx, cr, mr, sr, providersConfigHCL, mux, vars)
+	handler, _, loaded, err := config.Load(ctx, cr, mr, sr, providersConfigHCL, mux, vars)
 	if err != nil {
 		return nil, errors.Errorf("load config: %w", err)
 	}
+	readiers = loaded
 
 	return handler, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,41 +154,41 @@ func Load(
 	ast *hcl.AST,
 	mux *http.ServeMux,
 	vars map[string]string,
-) (http.Handler, metadatadb.Backend, error) {
+) (http.Handler, metadatadb.Backend, []strategy.Readier, error) {
 	logger := logging.FromContext(ctx)
 	expandVars(ast, vars)
 
 	classified, err := classifyBlocks(ast)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var caches []cache.Cache
 	for _, block := range classified.caches {
 		name, inner, err := unwrapBlock(block)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		c, err := cr.Create(ctx, name, inner, vars)
 		if err != nil {
-			return nil, nil, errors.Errorf("%s: %w", block.Pos, err)
+			return nil, nil, nil, errors.Errorf("%s: %w", block.Pos, err)
 		}
 		caches = append(caches, c)
 	}
 	if len(caches) == 0 {
-		return nil, nil, errors.Errorf("%s: expected at least one cache backend", ast.Pos)
+		return nil, nil, nil, errors.Errorf("%s: expected at least one cache backend", ast.Pos)
 	}
 
 	if classified.metadata == nil {
-		return nil, nil, errors.Errorf("%s: expected a metadata backend", ast.Pos)
+		return nil, nil, nil, errors.Errorf("%s: expected a metadata backend", ast.Pos)
 	}
 	metaName, metaInner, err := unwrapBlock(classified.metadata)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	metadata, err := mr.Create(ctx, metaName, metaInner, vars)
 	if err != nil {
-		return nil, nil, errors.Errorf("%s: %w", classified.metadata.Pos, err)
+		return nil, nil, nil, errors.Errorf("%s: %w", classified.metadata.Pos, err)
 	}
 
 	cache := cache.MaybeNewTiered(ctx, caches)
@@ -197,18 +197,23 @@ func Load(
 
 	// Second pass, instantiate strategies and bind them to the mux.
 	// Collect strategies that implement Interceptor separately — they need
-	// to run before ServeMux route matching, not as mux routes.
+	// to run before ServeMux route matching, not as mux routes. Strategies
+	// that implement Readier are tracked so /_readiness can gate on warm-up.
 	var interceptors []strategy.Interceptor
+	var readiers []strategy.Readier
 	for _, block := range classified.strategies {
 		name := block.Name
 		slogger := logger.With("strategy", name)
 		mlog := &loggingMux{logger: slogger, mux: mux}
 		s, err := sr.Create(ctx, name, block, cache, mlog, vars)
 		if err != nil {
-			return nil, nil, errors.Errorf("%s: %w", block.Pos, err)
+			return nil, nil, nil, errors.Errorf("%s: %w", block.Pos, err)
 		}
 		if interceptor, ok := s.(strategy.Interceptor); ok {
 			interceptors = append(interceptors, interceptor)
+		}
+		if readier, ok := s.(strategy.Readier); ok {
+			readiers = append(readiers, readier)
 		}
 	}
 
@@ -218,7 +223,7 @@ func Load(
 	for i := len(interceptors) - 1; i >= 0; i-- {
 		h = interceptors[i].Intercept(h)
 	}
-	return h, metadata, nil
+	return h, metadata, readiers, nil
 }
 
 // ExpandVars expands environment variable references in HCL strings and heredocs.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -195,7 +195,7 @@ func TestLoadRequiresMetadataBackend(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := logging.ContextWithLogger(context.Background(), slog.Default())
-	_, _, err = Load(ctx, cr, mr, sr, ast, http.NewServeMux(), nil)
+	_, _, _, err = Load(ctx, cr, mr, sr, ast, http.NewServeMux(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "expected a metadata backend")
 }

--- a/internal/strategy/api.go
+++ b/internal/strategy/api.go
@@ -120,3 +120,13 @@ type Interceptor interface {
 	// requests and delegates all others to next.
 	Intercept(next http.Handler) http.Handler
 }
+
+// Readier is an optional interface a Strategy may implement to gate the
+// /_readiness probe on background warm-up completing. The HTTP listener and
+// /_liveness come up immediately so the kubelet doesn't restart the pod, but
+// the Service load balancer holds traffic until every Readier reports true.
+type Readier interface {
+	Strategy
+	// Ready reports whether the strategy is ready to serve traffic.
+	Ready() bool
+}

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/alecthomas/errors"
@@ -57,6 +58,7 @@ type Strategy struct {
 	coldSnapshotMu      sync.Map // keyed by upstream URL, values are *coldSnapshotEntry
 	deferredRestoreOnce sync.Map // keyed by upstream URL, ensures at most one deferred restore per repo
 	metrics             *gitMetrics
+	ready               atomic.Bool
 }
 
 func New(
@@ -124,9 +126,17 @@ func New(
 		tokenManager: tokenManager,
 		metrics:      m,
 	}
-	if err := s.warmExistingRepos(ctx); err != nil {
-		logger.WarnContext(ctx, "Failed to warm existing repos", "error", err)
-	}
+	// Run startup fetches in the background so the HTTP listener (and
+	// /_liveness) come up immediately. /_readiness gates on Ready() so the
+	// Service load balancer holds traffic until warming completes.
+	go func() {
+		warmCtx := context.WithoutCancel(ctx)
+		if err := s.warmExistingRepos(warmCtx); err != nil {
+			logger.WarnContext(warmCtx, "Failed to warm existing repos", "error", err)
+		}
+		s.ready.Store(true)
+		logger.InfoContext(warmCtx, "Git strategy ready")
+	}()
 
 	s.proxy = &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
@@ -166,6 +176,12 @@ func New(
 }
 
 var _ strategy.Strategy = (*Strategy)(nil)
+var _ strategy.Readier = (*Strategy)(nil)
+
+// Ready reports whether startup warm-up has completed.
+func (s *Strategy) Ready() bool {
+	return s.ready.Load()
+}
 
 func (s *Strategy) warmExistingRepos(ctx context.Context) error {
 	logger := logging.FromContext(ctx)

--- a/internal/strategy/git/git_test.go
+++ b/internal/strategy/git/git_test.go
@@ -40,6 +40,20 @@ func newTestScheduler(ctx context.Context, t *testing.T) jobscheduler.Provider {
 	return jobscheduler.NewProvider(ctx, jobscheduler.Config{})
 }
 
+// waitForReady blocks until the strategy reports Ready() — used by tests that
+// operate directly on the mirror directory to avoid racing with the background
+// warm-up goroutine started in git.New.
+func waitForReady(t *testing.T, s *git.Strategy) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !s.Ready() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !s.Ready() {
+		t.Fatal("strategy never became ready")
+	}
+}
+
 func TestNew(t *testing.T) {
 	_, ctx := logging.Configure(context.Background(), logging.Config{})
 	tmpDir := t.TempDir()

--- a/internal/strategy/git/git_test.go
+++ b/internal/strategy/git/git_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
 
@@ -182,6 +183,28 @@ func TestNewWithExistingCloneOnDisk(t *testing.T) {
 	}, nil)
 	_, err = git.New(ctx, git.Config{}, newTestScheduler(ctx, t), nil, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
 	assert.NoError(t, err)
+}
+
+// TestNewIsReadyAfterWarm verifies that startup warm-up runs in the background
+// (so the HTTP listener can bind immediately) and that Ready() flips to true
+// once warming completes.
+func TestNewIsReadyAfterWarm(t *testing.T) {
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	mux := newTestMux()
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+		MirrorRoot:    tmpDir,
+		FetchInterval: 15,
+	}, nil)
+	s, err := git.New(ctx, git.Config{}, newTestScheduler(ctx, t), nil, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !s.Ready() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.True(t, s.Ready(), "strategy should be ready after warm-up completes")
 }
 
 func TestIntegrationWithMockUpstream(t *testing.T) {

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -201,6 +201,7 @@ func TestSnapshotGenerationViaLocalClone(t *testing.T) {
 	assert.Equal(t, gitclone.StateReady, repo.State())
 
 	// Generate the snapshot.
+	waitForReady(t, s)
 	err = s.GenerateAndUploadSnapshot(ctx, repo)
 	assert.NoError(t, err)
 
@@ -267,6 +268,7 @@ func TestSnapshotGenerationIncludesTrackedLockFiles(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, gitclone.StateReady, repo.State())
 
+	waitForReady(t, s)
 	err = s.GenerateAndUploadSnapshot(ctx, repo)
 	assert.NoError(t, err)
 
@@ -311,6 +313,7 @@ func TestMirrorSnapshotRestoreDirectly(t *testing.T) {
 	repo, err := manager.GetOrCreate(ctx, upstreamURL)
 	assert.NoError(t, err)
 
+	waitForReady(t, s)
 	err = s.GenerateAndUploadMirrorSnapshot(ctx, repo)
 	assert.NoError(t, err)
 
@@ -386,6 +389,7 @@ func TestMirrorSnapshotWithMultipleBranches(t *testing.T) {
 	repo, err := manager.GetOrCreate(ctx, upstreamURL)
 	assert.NoError(t, err)
 
+	waitForReady(t, s)
 	err = s.GenerateAndUploadMirrorSnapshot(ctx, repo)
 	assert.NoError(t, err)
 
@@ -477,6 +481,7 @@ func TestSnapshotServesFreshSnapshotWithCommitHeader(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Generate a snapshot — it will embed the mirror's HEAD as X-Cachew-Snapshot-Commit.
+	waitForReady(t, s)
 	err = s.GenerateAndUploadSnapshot(ctx, repo)
 	assert.NoError(t, err)
 
@@ -527,6 +532,7 @@ func TestSnapshotServesBundleURLWhenStale(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Generate a snapshot at the current HEAD.
+	waitForReady(t, s)
 	err = s.GenerateAndUploadSnapshot(ctx, repo)
 	assert.NoError(t, err)
 
@@ -720,6 +726,7 @@ func TestSnapshotRemoteURLUsesUpstreamURL(t *testing.T) {
 	repo, err := manager.GetOrCreate(ctx, upstreamURL)
 	assert.NoError(t, err)
 
+	waitForReady(t, s)
 	err = s.GenerateAndUploadSnapshot(ctx, repo)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Previously, `NewStrategy` ran `warmExistingRepos` synchronously before the HTTP listener was bound. With many on-disk mirrors, this could exceed the kubelet liveness probe deadline (port 8080 not yet listening), so the kubelet would SIGKILL cachew mid-warm-up. Each kill leaves stale git lockfiles behind, slowing the next startup further and trapping the pod in a crash loop.

This change:
- Runs `warmExistingRepos` in a goroutine using `context.WithoutCancel` so the HTTP listener (and `/_liveness`) come up immediately.
- Adds a `Readier` optional interface that strategies can implement.
- `/_readiness` now returns 503 until every `Readier` reports true, so the Service load balancer holds traffic until warm-up finishes.

The 'don't serve cold traffic' guarantee is preserved at the load-balancer layer instead of the listener-bind layer.