### PR TITLE
fix: clean up stale multi-pack-index.lock after repack failure

### DIFF
--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -721,6 +721,14 @@ func (r *Repository) Repack(ctx context.Context) error {
 	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		// When git repack is killed (e.g. by our timeout), it cannot clean up
+		// the multi-pack-index.lock it holds. A stale lock blocks all future
+		// repacks, causing pack fragmentation that eventually degrades snapshot
+		// serving performance. Remove it so the next attempt can proceed.
+		lockPath := filepath.Join(r.path, "objects", "pack", "multi-pack-index.lock")
+		if rmErr := os.Remove(lockPath); rmErr == nil {
+			logger.WarnContext(ctx, "Removed stale multi-pack-index.lock after repack failure", "upstream", r.upstreamURL)
+		}
 		return errors.Wrapf(err, "git repack: %s", string(output))
 	}
 

--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -401,6 +401,36 @@ func TestRepository_Repack(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRepository_Repack_CleansUpStaleLockOnFailure(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelError})
+	tmpDir := t.TempDir()
+	upstreamPath := createBareRepo(t, tmpDir)
+
+	clonePath := filepath.Join(tmpDir, "mirror")
+	cmd := exec.Command("git", "clone", "--mirror", upstreamPath, clonePath)
+	assert.NoError(t, cmd.Run())
+
+	repo := &Repository{
+		state:       StateReady,
+		path:        clonePath,
+		upstreamURL: upstreamPath,
+		fetchSem:    make(chan struct{}, 1),
+	}
+	repo.fetchSem <- struct{}{}
+
+	// Place a stale lock file simulating a killed repack.
+	lockPath := filepath.Join(clonePath, "objects", "pack", "multi-pack-index.lock")
+	assert.NoError(t, os.WriteFile(lockPath, []byte("stale"), 0o644))
+
+	// Repack should fail because of the lock, but should clean it up.
+	err := repo.Repack(ctx)
+	assert.Error(t, err)
+
+	// The stale lock should have been removed.
+	_, statErr := os.Stat(lockPath)
+	assert.True(t, os.IsNotExist(statErr), "expected multi-pack-index.lock to be removed after failed repack")
+}
+
 func TestRepository_HasCommit(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
When git repack is killed by the 10-minute timeout, it leaves behind a `multi-pack-index.lock` file. This stale lock blocks all subsequent repacks, causing progressive pack fragmentation that eventually degrades snapshot serving performance and causes workstation bootstrap timeouts.

After a repack failure, attempt to remove the lock file so the next periodic repack can proceed normally.