### PR TITLE
fix: use GOMAXPROCS instead of NumCPU for child process thread counts

### DIFF
--- a/client/archive.go
+++ b/client/archive.go
@@ -19,7 +19,7 @@ import (
 // cores.
 func Archive(ctx context.Context, w io.Writer, baseDir string, includePaths []string, excludePatterns []string, threads int) error {
 	if threads <= 0 {
-		threads = runtime.NumCPU()
+		threads = runtime.GOMAXPROCS(0)
 	}
 
 	if len(includePaths) == 0 {
@@ -54,7 +54,7 @@ func Archive(ctx context.Context, w io.Writer, baseDir string, includePaths []st
 // parallelism; 0 uses all CPU cores.
 func Extract(ctx context.Context, r io.Reader, directory string, threads int) error {
 	if threads <= 0 {
-		threads = runtime.NumCPU()
+		threads = runtime.GOMAXPROCS(0)
 	}
 
 	if err := os.MkdirAll(directory, 0o750); err != nil {

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -121,7 +121,7 @@ func NewManager(ctx context.Context, config Config, credentialProvider Credentia
 	}
 
 	if config.PackThreads <= 0 {
-		config.PackThreads = runtime.NumCPU()
+		config.PackThreads = runtime.GOMAXPROCS(0)
 	}
 
 	if err := os.MkdirAll(config.MirrorRoot, 0o750); err != nil {


### PR DESCRIPTION
`runtime.NumCPU()` returns the node's CPU count (e.g. 64 on m5d.16xlarge), ignoring the cgroup CPU limit. This causes zstd (`-T64`) and git pack operations to spawn more threads than the CFS quota allows, resulting in constant CPU throttling despite low average utilization.

Uses `runtime.GOMAXPROCS(0)` which reflects the cgroup-aware effective CPU count, matching the container's actual CPU limit.