### PR TITLE
fix: cancel test scheduler on cleanup to prevent flaky temp dir errors

### DIFF
--- a/internal/strategy/git/git_test.go
+++ b/internal/strategy/git/git_test.go
@@ -37,7 +37,16 @@ func (m *testMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *
 
 func newTestScheduler(ctx context.Context, t *testing.T) jobscheduler.Provider {
 	t.Helper()
-	return jobscheduler.NewProvider(ctx, jobscheduler.Config{})
+	// Derive a context that carries the caller's logger but cancels when the
+	// test ends (via t.Context()). This ensures scheduler workers shut down
+	// before TempDir cleanup without needing an explicit context.WithCancel.
+	schedCtx := logging.ContextWithLogger(t.Context(), logging.FromContext(ctx))
+	sched, err := jobscheduler.New(schedCtx, jobscheduler.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { sched.Wait() })
+	return func() (*jobscheduler.RootScheduler, error) { return sched, nil }
 }
 
 // waitForReady blocks until the strategy reports Ready() — used by tests that

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/githubapp"
-	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/snapshot"
 	"github.com/block/cachew/internal/strategy/git"
@@ -42,8 +41,11 @@ func TestSnapshotHTTPEndpoint(t *testing.T) {
 	}, nil)
 	// SnapshotInterval=0 disables periodic snapshot jobs so they don't
 	// overwrite the fake cached snapshot we insert below.
-	_, err = git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	s, err := git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
 	assert.NoError(t, err)
+	// The warm-up goroutine uses context.WithoutCancel so it survives
+	// t.Context() cancellation. Wait for it before TempDir cleanup.
+	t.Cleanup(func() { waitForReady(t, s) })
 
 	// Create a fake snapshot in the cache with a Last-Modified after the
 	// mirror's last fetch so the endpoint considers it fresh.
@@ -585,23 +587,15 @@ func TestColdSnapshotServesWithoutCommitHeader(t *testing.T) {
 	}
 
 	_, ctx := logging.Configure(context.Background(), logging.Config{})
-	ctx, cancelAll := context.WithCancel(ctx)
 	tmpDir := t.TempDir()
 	mirrorRoot := filepath.Join(tmpDir, "mirrors")
-
-	sched, err := jobscheduler.New(ctx, jobscheduler.Config{})
-	assert.NoError(t, err)
-	// Cancel the context and wait for all scheduler workers to drain before
-	// TempDir cleanup runs, preventing a race with background jobs.
-	t.Cleanup(func() { cancelAll(); sched.Wait() })
 
 	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
 	assert.NoError(t, err)
 	mux := newTestMux()
 
-	schedProvider := func() (*jobscheduler.RootScheduler, error) { return sched, nil }
 	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{MirrorRoot: mirrorRoot}, nil)
-	_, err = git.New(ctx, git.Config{}, schedProvider, memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	_, err = git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
 	assert.NoError(t, err)
 
 	// Pre-populate the cache with a fake snapshot that has NO X-Cachew-Snapshot-Commit
@@ -648,21 +642,15 @@ func TestDeferredRestoreOnlyScheduledOnce(t *testing.T) {
 	}
 
 	_, ctx := logging.Configure(context.Background(), logging.Config{})
-	ctx, cancelAll := context.WithCancel(ctx)
 	tmpDir := t.TempDir()
 	mirrorRoot := filepath.Join(tmpDir, "mirrors")
-
-	sched, err := jobscheduler.New(ctx, jobscheduler.Config{})
-	assert.NoError(t, err)
-	t.Cleanup(func() { cancelAll(); sched.Wait() })
 
 	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
 	assert.NoError(t, err)
 	mux := newTestMux()
 
-	schedProvider := func() (*jobscheduler.RootScheduler, error) { return sched, nil }
 	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{MirrorRoot: mirrorRoot}, nil)
-	_, err = git.New(ctx, git.Config{}, schedProvider, memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	_, err = git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
 	assert.NoError(t, err)
 
 	// Pre-populate cache with a fake snapshot.


### PR DESCRIPTION
`newTestScheduler` created a scheduler with background workers that were never cancelled, allowing them to outlive the test and access deleted temp directories from other tests. This caused flaky failures in `TestSnapshotHTTPEndpoint` with `readdirent ... no such file or directory` and `TempDir RemoveAll cleanup: directory not empty`.

Cancels the scheduler context and waits for workers in `t.Cleanup()`.