### PR TITLE
fix(git): cap default zstd-threads to 4 in server config

### DIFF
--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -47,7 +47,7 @@ type Config struct {
 	SnapshotInterval       time.Duration `hcl:"snapshot-interval,optional" help:"How often to generate tar.zstd workstation snapshots. 0 disables snapshots." default:"0"`
 	MirrorSnapshotInterval time.Duration `hcl:"mirror-snapshot-interval,optional" help:"How often to generate mirror snapshots for pod bootstrap. 0 uses snapshot-interval. Defaults to 2h." default:"2h"`
 	RepackInterval         time.Duration `hcl:"repack-interval,optional" help:"How often to run full repack. 0 disables." default:"0"`
-	ZstdThreads            int           `hcl:"zstd-threads,optional" help:"Threads for zstd compression/decompression (0 = all CPU cores)." default:"0"`
+	ZstdThreads            int           `hcl:"zstd-threads,optional" help:"Threads for zstd compression/decompression. 0 = all CPU cores; useful for short-lived CLI invocations but risky on a long-running server where multiple snapshot/restore operations can run concurrently." default:"4"`
 	BundleCacheTTL         time.Duration `hcl:"bundle-cache-ttl,optional" help:"TTL of cached server-side git bundles." default:"2h"`
 }
 


### PR DESCRIPTION
## Problem

The git strategy's `zstd-threads` config defaults to `0`, which expands to `runtime.NumCPU()` at compression time. On a 32–64 vCPU host, every snapshot subprocess therefore runs `zstd -T<NumCPU>`, and each zstd worker holds several MB of buffers — easily a few hundred MB per snapshot.

`scheduleSnapshotJobs` schedules three periodic snapshot jobs per warm mirror, and on startup `warmExistingRepos` fires one immediately for every mirror it discovers. Total transient memory during warm-up scales as `mirrors × cores`, easily reaching tens of GB on a many-mirror server.

## Change

Cap the **server-side** default to `4` threads. Operators who want the legacy behaviour can set `zstd-threads = 0` (or any other value) explicitly in their HCL config.

The CLI flags in `cmd/cachew/{main,git}.go` keep `0` as their default, because `cachew save`/`restore`/`git clone` are short-lived single operations where using all cores is the right behaviour.