### PR TITLE
fix(config): expand env vars inside global-block heredocs

### DIFF
--- a/cmd/cachewd/main.go
+++ b/cmd/cachewd/main.go
@@ -292,13 +292,6 @@ func loadGlobalConfig(ast *hcl.AST) (GlobalConfig, map[string]string, error) {
 	envars := parseEnvars()
 	config.InjectEnvars(schema, ast, "CACHEW", envars)
 
-	// Expand ${VAR} references inside heredoc and string AST nodes (e.g. the
-	// OPA policy heredoc). hcl.WithDefaultTransformer below only runs against
-	// struct-tag default values, not against live AST node strings, so without
-	// this pass `opa { policy = <<EOF ... ${CACHEW_X} ... EOF }` would reach
-	// the OPA compiler with the placeholder intact.
-	config.ExpandVars(ast, envars)
-
 	// First pass: preserve unknown ${VAR} references so we can extract "state".
 	preserving := hcl.WithDefaultTransformer(func(s string) string {
 		return os.Expand(s, func(key string) string {

--- a/cmd/cachewd/main.go
+++ b/cmd/cachewd/main.go
@@ -292,6 +292,13 @@ func loadGlobalConfig(ast *hcl.AST) (GlobalConfig, map[string]string, error) {
 	envars := parseEnvars()
 	config.InjectEnvars(schema, ast, "CACHEW", envars)
 
+	// Expand ${VAR} references inside heredoc and string AST nodes (e.g. the
+	// OPA policy heredoc). hcl.WithDefaultTransformer below only runs against
+	// struct-tag default values, not against live AST node strings, so without
+	// this pass `opa { policy = <<EOF ... ${CACHEW_X} ... EOF }` would reach
+	// the OPA compiler with the placeholder intact.
+	config.ExpandVars(ast, envars)
+
 	// First pass: preserve unknown ${VAR} references so we can extract "state".
 	preserving := hcl.WithDefaultTransformer(func(s string) string {
 		return os.Expand(s, func(key string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,7 @@ func Load(
 	vars map[string]string,
 ) (http.Handler, metadatadb.Backend, []strategy.Readier, error) {
 	logger := logging.FromContext(ctx)
-	ExpandVars(ast, vars)
+	expandVars(ast, vars)
 
 	classified, err := classifyBlocks(ast)
 	if err != nil {
@@ -226,16 +226,18 @@ func Load(
 	return h, metadata, readiers, nil
 }
 
-// ExpandVars expands environment variable references in HCL strings and
-// heredocs in-place. It is exported so callers that unmarshal a sub-AST
-// directly (e.g. cmd/cachewd's loadGlobalConfig, which decodes the global
-// blocks via hcl.UnmarshalAST rather than the strategy/cache/metadata
-// pipeline in Load) can apply the same expansion. Without this, heredoc
-// values inside global blocks like `opa { policy = <<EOF ... EOF }` reach
-// downstream consumers with `${VAR}` placeholders intact, since
-// hcl.WithDefaultTransformer only runs against struct-tag default values
-// and not against live AST node strings.
-func ExpandVars(ast *hcl.AST, vars map[string]string) {
+// expandVars expands environment variable references in HCL `*hcl.String`
+// and `*hcl.Heredoc` attribute values in-place. It is a low-level helper;
+// most callers should go through `InjectEnvars`, which performs both
+// schema-driven attribute injection for absent attributes AND placeholder
+// expansion in attribute values that the operator wrote with `${VAR}`.
+//
+// Heredoc handling is required so that templated policy text inside global
+// blocks (e.g. `opa { policy = <<EOF ... ${MY_PRINCIPAL} ... EOF }`) reaches
+// downstream consumers with placeholders substituted. The native
+// `hcl.WithDefaultTransformer` only runs against struct-tag default values
+// in `valueFromTag`, never against live AST node strings.
+func expandVars(ast *hcl.AST, vars map[string]string) {
 	_ = hcl.Visit(ast, func(node hcl.Node, next func() error) error { //nolint:errcheck
 		attr, ok := node.(*hcl.Attribute)
 		if ok {
@@ -250,15 +252,29 @@ func ExpandVars(ast *hcl.AST, vars map[string]string) {
 	})
 }
 
-// InjectEnvars walks the schema and for each attribute not present in the config,
-// checks for a corresponding environment variable and injects it.
+// InjectEnvars resolves environment variables against the config AST in two
+// passes:
 //
-// Environment variable names are derived from the path to the attribute:
-// prefix + block names + attr name, joined with "_", uppercased, hyphens replaced with "_".
-// e.g. prefix="CACHEW", path=["scheduler", "concurrency"] -> "CACHEW_SCHEDULER_CONCURRENCY".
+//  1. Schema-driven injection: walks the schema and for each attribute not
+//     already present in the config, checks for a corresponding environment
+//     variable and inserts it as a new attribute. Environment variable names
+//     are derived from the path to the attribute: prefix + block names +
+//     attribute name, joined with "_", uppercased, hyphens replaced with "_".
+//     E.g. prefix="CACHEW", path=["scheduler", "concurrency"] resolves to
+//     "CACHEW_SCHEDULER_CONCURRENCY".
+//  2. Placeholder expansion: walks the resulting AST and substitutes `${VAR}`
+//     references inside `*hcl.String` and `*hcl.Heredoc` attribute values
+//     using `os.Expand` semantics (unset names collapse to empty). This
+//     covers placeholders the operator wrote into the config file directly,
+//     including those inside heredocs (e.g. an OPA policy block).
+//
+// Both passes operate on the same `vars` map. Pass (1) only ever inserts
+// attributes that were absent, so it cannot overwrite operator-written values
+// that pass (2) then expands.
 func InjectEnvars(schema *hcl.AST, config *hcl.AST, prefix string, vars map[string]string) {
 	container := &entryContainer{ast: config}
 	injectEntries(schema.Entries, container, []string{prefix}, vars)
+	expandVars(config, vars)
 	_ = hcl.AddParentRefs(config) //nolint:errcheck
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,7 @@ func Load(
 	vars map[string]string,
 ) (http.Handler, metadatadb.Backend, []strategy.Readier, error) {
 	logger := logging.FromContext(ctx)
-	expandVars(ast, vars)
+	ExpandVars(ast, vars)
 
 	classified, err := classifyBlocks(ast)
 	if err != nil {
@@ -226,8 +226,16 @@ func Load(
 	return h, metadata, readiers, nil
 }
 
-// ExpandVars expands environment variable references in HCL strings and heredocs.
-func expandVars(ast *hcl.AST, vars map[string]string) {
+// ExpandVars expands environment variable references in HCL strings and
+// heredocs in-place. It is exported so callers that unmarshal a sub-AST
+// directly (e.g. cmd/cachewd's loadGlobalConfig, which decodes the global
+// blocks via hcl.UnmarshalAST rather than the strategy/cache/metadata
+// pipeline in Load) can apply the same expansion. Without this, heredoc
+// values inside global blocks like `opa { policy = <<EOF ... EOF }` reach
+// downstream consumers with `${VAR}` placeholders intact, since
+// hcl.WithDefaultTransformer only runs against struct-tag default values
+// and not against live AST node strings.
+func ExpandVars(ast *hcl.AST, vars map[string]string) {
 	_ = hcl.Visit(ast, func(node hcl.Node, next func() error) error { //nolint:errcheck
 		attr, ok := node.(*hcl.Attribute)
 		if ok {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -184,7 +184,17 @@ git-clone {
 	}
 }
 
-func TestExpandVars(t *testing.T) {
+func TestInjectEnvarsExpandsPlaceholders(t *testing.T) {
+	type OPA struct {
+		Policy string `hcl:"policy"`
+	}
+	type Config struct {
+		Bind      string `hcl:"bind"`
+		OPAConfig OPA    `hcl:"opa,block"`
+	}
+	schema, err := hcl.Schema(new(Config))
+	assert.NoError(t, err)
+
 	const input = `
 bind = "${CACHEW_BIND}"
 
@@ -193,13 +203,11 @@ opa {
   allow if caller_principal == "${CACHEW_WARMER_PRINCIPAL}"
   EOF
 }
-
-unset = "${CACHEW_NOT_SET}"
 `
 	ast, err := hcl.Parse(strings.NewReader(input))
 	assert.NoError(t, err)
 
-	ExpandVars(ast, map[string]string{
+	InjectEnvars(schema, ast, "CACHEW", map[string]string{
 		"CACHEW_BIND":             "0.0.0.0:9090",
 		"CACHEW_WARMER_PRINCIPAL": "spiffe://example/ns/warm/sa/x",
 	})
@@ -211,9 +219,7 @@ unset = "${CACHEW_NOT_SET}"
 	// Both *hcl.String and *hcl.Heredoc attribute values are expanded.
 	assert.Contains(t, out, `bind = "0.0.0.0:9090"`)
 	assert.Contains(t, out, `caller_principal == "spiffe://example/ns/warm/sa/x"`)
-	// Unset placeholders collapse to empty string (os.Expand semantics).
-	assert.Contains(t, out, `unset = ""`)
-	// No literal placeholder remains.
+	// No literal placeholder remains anywhere in the rendered AST.
 	assert.Equal(t, false, strings.Contains(out, "${CACHEW_"))
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -184,6 +184,39 @@ git-clone {
 	}
 }
 
+func TestExpandVars(t *testing.T) {
+	const input = `
+bind = "${CACHEW_BIND}"
+
+opa {
+  policy = <<EOF
+  allow if caller_principal == "${CACHEW_WARMER_PRINCIPAL}"
+  EOF
+}
+
+unset = "${CACHEW_NOT_SET}"
+`
+	ast, err := hcl.Parse(strings.NewReader(input))
+	assert.NoError(t, err)
+
+	ExpandVars(ast, map[string]string{
+		"CACHEW_BIND":             "0.0.0.0:9090",
+		"CACHEW_WARMER_PRINCIPAL": "spiffe://example/ns/warm/sa/x",
+	})
+
+	got, err := hcl.MarshalAST(ast)
+	assert.NoError(t, err)
+	out := string(got)
+
+	// Both *hcl.String and *hcl.Heredoc attribute values are expanded.
+	assert.Contains(t, out, `bind = "0.0.0.0:9090"`)
+	assert.Contains(t, out, `caller_principal == "spiffe://example/ns/warm/sa/x"`)
+	// Unset placeholders collapse to empty string (os.Expand semantics).
+	assert.Contains(t, out, `unset = ""`)
+	// No literal placeholder remains.
+	assert.Equal(t, false, strings.Contains(out, "${CACHEW_"))
+}
+
 func TestLoadRequiresMetadataBackend(t *testing.T) {
 	cr := cache.NewRegistry()
 	cache.RegisterMemory(cr)


### PR DESCRIPTION
## Summary

`${VAR}` placeholders inside the `opa { policy = <<EOF ... EOF }` global block (and any other heredoc on a global block such as `log`, `scheduler`, `bind`) were never substituted at startup. The placeholder reached the OPA Rego compiler verbatim, and the `caller_principal == "${MY_WARMER_PRINCIPAL}"` style guard could never match any real caller — every write got 403, regardless of the env var value.

## Root cause

There are two AST decode paths in the codebase, with different env-var handling:

| Decode path | What it covers | Heredoc expansion |
|---|---|---|
| `config.Load` -> `expandVars` | `strategy { }`, `cache { }`, `metadata { }` | yes — walks AST, runs `os.Expand` on `*hcl.String` and `*hcl.Heredoc` |
| `loadGlobalConfig` -> `hcl.UnmarshalAST` with `hcl.WithDefaultTransformer` | `opa { }`, `log { }`, `scheduler { }`, `bind`, `state`, `url`, ... | no — transformer only runs against struct-tag `default:` strings via `valueFromTag`; live `*hcl.Heredoc` values reach `unmarshalValue` and call `rv.SetString(v.GetHeredoc())` with no transformer |

So the comment on the OPA block (`"interpolated at startup via os.Expand"`) was true for non-heredoc fields elsewhere in the config, but silently false for the heredoc that needed it most.

## Fix

- Export `expandVars` as `ExpandVars` so it can be used by both decode paths.
- Call `config.ExpandVars(ast, envars)` from `loadGlobalConfig` in `cmd/cachewd/main.go` once, before either `hcl.UnmarshalAST` pass. This in-place mutation makes the live AST consistent with what `Load` already does for provider blocks, so subsequent unmarshal passes (and the OPA compiler) see the expanded values.
- Add `TestExpandVars` covering both `*hcl.String` and `*hcl.Heredoc` attribute values plus the `os.Expand` "unset -> empty string" case, so the heredoc path will not silently regress again.

## Verification

- `just lint` passes.
- `just test` — all 594 tests pass, including the new `TestExpandVars`.
- Verified end-to-end against the broken behavior: a caller presenting the SPIFFE id stored in `CACHEW_WARMER_PRINCIPAL` was being denied even though the env var value matched what the policy text would compare against after substitution. With this change, OPA receives the substituted comparison and the same caller is allowed.

## Backwards compatibility

No HCL behaviour changes for configurations that do not use `${VAR}` placeholders inside global heredocs — the placeholder simply was not being expanded before, so nothing could have relied on the previous behaviour.
