### PR TITLE
feat: add CacheWriter interface with Abort method and WriteFunc helper

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -35,6 +35,20 @@ var transportHeaders = []string{ //nolint:gochecknoglobals
 	"Time-To-Live",
 }
 
+// CacheWriter extends io.WriteCloser with the ability to abort an in-progress
+// cache write. Exactly one of Close or Abort must be called.
+//
+// Close commits the data to the cache. Abort discards the in-progress write,
+// ensuring the object is never made visible in the cache. Both methods are
+// idempotent after the first call.
+type CacheWriter interface {
+	io.WriteCloser
+	// Abort discards the in-progress write and releases resources.
+	// The provided error is recorded as the cause of cancellation.
+	// The object MUST NOT be made available in the cache after Abort.
+	Abort(err error) error
+}
+
 // HeaderFunc returns headers to attach to each outgoing request.
 type HeaderFunc func() http.Header
 
@@ -175,14 +189,16 @@ func (c *Client) Stat(ctx context.Context, key Key) (http.Header, error) {
 	return filterHeaders(resp.Header, transportHeaders...), nil
 }
 
-// Create stores a new object in the cache server. The returned io.WriteCloser
-// must be closed to complete the upload; if the context is cancelled before
-// Close returns, the object is not made available in the cache.
-func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error) {
+// Create stores a new object in the cache server. The returned CacheWriter
+// must be closed to commit the upload. Call Abort instead of Close to discard
+// the in-progress write and ensure the object is never made visible.
+func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (CacheWriter, error) {
+	ctx, cancel := context.WithCancelCause(ctx)
 	pr, pw := io.Pipe()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.objectURL(key), pr)
 	if err != nil {
+		cancel(err)
 		return nil, errors.Join(errors.Wrap(err, "failed to create request"), pr.Close(), pw.Close())
 	}
 
@@ -193,9 +209,10 @@ func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl t
 	}
 
 	wc := &writeCloser{
-		pw:   pw,
-		done: make(chan error, 1),
-		ctx:  ctx,
+		pw:     pw,
+		done:   make(chan error, 1),
+		ctx:    ctx,
+		cancel: cancel,
 	}
 
 	go func() {
@@ -321,9 +338,11 @@ func filterHeaders(headers http.Header, skip ...string) http.Header {
 
 // writeCloser wraps a pipe writer and waits for the HTTP request to complete.
 type writeCloser struct {
-	pw   *io.PipeWriter
-	done chan error
-	ctx  context.Context
+	pw     *io.PipeWriter
+	done   chan error
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	closed bool
 }
 
 func (wc *writeCloser) Write(p []byte) (int, error) {
@@ -331,7 +350,16 @@ func (wc *writeCloser) Write(p []byte) (int, error) {
 	return n, errors.WithStack(err)
 }
 
+func (wc *writeCloser) Abort(err error) error {
+	wc.cancel(err)
+	return wc.Close()
+}
+
 func (wc *writeCloser) Close() error {
+	if wc.closed {
+		return nil
+	}
+	wc.closed = true
 	if err := wc.ctx.Err(); err != nil {
 		_ = wc.pw.CloseWithError(err)
 		<-wc.done

--- a/client/files.go
+++ b/client/files.go
@@ -95,16 +95,12 @@ func (c *Client) Save(ctx context.Context, key Key, baseDir string, paths []stri
 		}
 	}
 
-	createCtx, cancelCreate := context.WithCancelCause(ctx)
-	defer cancelCreate(nil)
-
-	wc, err := c.Create(createCtx, key, headers, cfg.ttl)
+	wc, err := c.Create(ctx, key, headers, cfg.ttl)
 	if err != nil {
 		return errors.Wrap(err, "failed to create object")
 	}
 	if err := Archive(ctx, wc, baseDir, paths, cfg.exclude, cfg.zstdThreads); err != nil {
-		cancelCreate(err)
-		return errors.Join(err, wc.Close())
+		return errors.Join(err, wc.Abort(err))
 	}
 	return errors.Wrap(wc.Close(), "failed to close writer")
 }

--- a/cmd/cachew/main.go
+++ b/cmd/cachew/main.go
@@ -136,17 +136,13 @@ func (c *PutCmd) Run(ctx context.Context, api *client.Client) error {
 		headers.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(filename))) //nolint:perfsprint
 	}
 
-	createCtx, cancelCreate := context.WithCancelCause(ctx)
-	defer cancelCreate(nil)
-
-	wc, err := api.Namespace(c.Namespace).Create(createCtx, c.Key.Key(), headers, c.TTL)
+	wc, err := api.Namespace(c.Namespace).Create(ctx, c.Key.Key(), headers, c.TTL)
 	if err != nil {
 		return errors.Wrap(err, "failed to create object")
 	}
 
 	if _, err := io.Copy(wc, c.Input); err != nil {
-		cancelCreate(err)
-		return errors.Join(errors.Wrap(err, "failed to copy data"), wc.Close())
+		return errors.Join(errors.Wrap(err, "failed to copy data"), wc.Abort(err))
 	}
 
 	return errors.Wrap(wc.Close(), "failed to close writer")

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -25,6 +25,9 @@ func ParseNamespace(name string) (Namespace, error) {
 	return errors.WithStack2(client.ParseNamespace(name))
 }
 
+// Writer extends io.WriteCloser with abort semantics for cache writes.
+type Writer = client.CacheWriter
+
 // ErrNotFound is returned when a cache backend is not found.
 var ErrNotFound = errors.New("cache backend not found")
 
@@ -144,7 +147,7 @@ type Cache interface {
 	// The file MUST NOT be available for read until completely written and closed.
 	//
 	// If the context is cancelled the object MUST NOT be made available in the cache.
-	Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error)
+	Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error)
 	// Delete a file from the cache.
 	//
 	// MUST be atomic.
@@ -155,4 +158,18 @@ type Cache interface {
 	ListNamespaces(ctx context.Context) ([]string, error)
 	// Close the Cache.
 	Close() error
+}
+
+// WriteFunc is a convenience wrapper around Cache.Create that handles aborting
+// the write on error. The provided function receives a writer; if it returns an
+// error the cache entry is discarded. On success the entry is committed.
+func WriteFunc(ctx context.Context, c Cache, key Key, headers http.Header, ttl time.Duration, fn func(w io.Writer) error) error {
+	w, err := c.Create(ctx, key, headers, ttl)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err := fn(w); err != nil {
+		return errors.Join(err, w.Abort(err))
+	}
+	return errors.WithStack(w.Close())
 }

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -153,7 +153,7 @@ func (d *Disk) Stats(_ context.Context) (Stats, error) {
 	}, nil
 }
 
-func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error) {
+func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
 	if ttl > d.config.MaxTTL || ttl == 0 {
 		ttl = d.config.MaxTTL
 	}
@@ -181,6 +181,8 @@ func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl tim
 
 	expiresAt := now.Add(ttl)
 
+	ctx, cancel := context.WithCancelCause(ctx)
+
 	return &diskWriter{
 		disk:      d,
 		file:      f,
@@ -191,6 +193,7 @@ func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl tim
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
 		ctx:       ctx,
+		cancel:    cancel,
 	}, nil
 }
 
@@ -428,6 +431,8 @@ type diskWriter struct {
 	headers   http.Header
 	size      int64
 	ctx       context.Context
+	cancel    context.CancelCauseFunc
+	closed    bool
 }
 
 func (w *diskWriter) Write(p []byte) (int, error) {
@@ -436,7 +441,17 @@ func (w *diskWriter) Write(p []byte) (int, error) {
 	return n, errors.WithStack(err)
 }
 
+func (w *diskWriter) Abort(err error) error {
+	w.cancel(err)
+	return w.Close()
+}
+
 func (w *diskWriter) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+
 	if err := w.file.Close(); err != nil {
 		return errors.Errorf("failed to close file: %w", err)
 	}

--- a/internal/cache/http.go
+++ b/internal/cache/http.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"context"
 	"io"
 	"maps"
 	"net/http"
@@ -54,10 +53,8 @@ func FetchDirect(client *http.Client, r *http.Request, c Cache, key Key) (*http.
 	}
 
 	responseHeaders := maps.Clone(resp.Header)
-	createCtx, cancelCreate := context.WithCancelCause(r.Context())
-	cw, err := c.Create(createCtx, key, responseHeaders, 0)
+	cw, err := c.Create(r.Context(), key, responseHeaders, 0)
 	if err != nil {
-		cancelCreate(nil)
 		_ = resp.Body.Close()
 		return nil, httputil.Errorf(http.StatusInternalServerError, "failed to create cache entry: %w", err)
 	}
@@ -65,13 +62,14 @@ func FetchDirect(client *http.Client, r *http.Request, c Cache, key Key) (*http.
 	originalBody := resp.Body
 	pr, pw := io.Pipe()
 	go func() {
-		defer cancelCreate(nil)
 		mw := io.MultiWriter(pw, cw)
 		_, copyErr := io.Copy(mw, originalBody)
+		var closeErr error
 		if copyErr != nil {
-			cancelCreate(copyErr)
+			closeErr = errors.Join(cw.Abort(copyErr), originalBody.Close())
+		} else {
+			closeErr = errors.Join(cw.Close(), originalBody.Close())
 		}
-		closeErr := errors.Join(cw.Close(), originalBody.Close())
 		pw.CloseWithError(errors.Join(copyErr, closeErr))
 	}()
 

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -99,7 +99,7 @@ func (m *Memory) Open(_ context.Context, key Key) (io.ReadCloser, http.Header, e
 	return io.NopCloser(bytes.NewReader(entry.data)), entry.headers, nil
 }
 
-func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error) {
+func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
 	if ttl == 0 {
 		ttl = m.config.MaxTTL
 	}
@@ -112,6 +112,8 @@ func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl t
 		clonedHeaders.Set("Last-Modified", now.UTC().Format(http.TimeFormat))
 	}
 
+	ctx, cancel := context.WithCancelCause(ctx)
+
 	writer := &memoryWriter{
 		cache:     m,
 		namespace: m.namespace,
@@ -120,6 +122,7 @@ func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl t
 		expiresAt: now.Add(ttl),
 		headers:   clonedHeaders,
 		ctx:       ctx,
+		cancel:    cancel,
 	}
 
 	return writer, nil
@@ -216,6 +219,7 @@ type memoryWriter struct {
 	headers   http.Header
 	closed    bool
 	ctx       context.Context
+	cancel    context.CancelCauseFunc
 }
 
 func (w *memoryWriter) Write(p []byte) (int, error) {
@@ -223,6 +227,11 @@ func (w *memoryWriter) Write(p []byte) (int, error) {
 		return 0, errors.New("writer closed")
 	}
 	return errors.WithStack2(w.buf.Write(p))
+}
+
+func (w *memoryWriter) Abort(err error) error {
+	w.cancel(err)
+	return w.Close()
 }
 
 func (w *memoryWriter) Close() error {

--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -30,7 +30,7 @@ func (n *noOpCache) Open(_ context.Context, _ Key) (io.ReadCloser, http.Header, 
 	return nil, nil, os.ErrNotExist
 }
 
-func (n *noOpCache) Create(_ context.Context, _ Key, _ http.Header, _ time.Duration) (io.WriteCloser, error) {
+func (n *noOpCache) Create(_ context.Context, _ Key, _ http.Header, _ time.Duration) (Writer, error) {
 	// Return a discard writer that does nothing
 	return &noOpWriter{}, nil
 }
@@ -58,8 +58,12 @@ func (n *noOpWriter) Close() error {
 	return nil
 }
 
+func (n *noOpWriter) Abort(_ error) error {
+	return nil
+}
+
 var _ Cache = (*noOpCache)(nil)
-var _ io.WriteCloser = (*noOpWriter)(nil)
+var _ Writer = (*noOpWriter)(nil)
 
 // Namespace creates a namespaced view (no-op for noop cache).
 func (n *noOpCache) Namespace(_ Namespace) Cache {

--- a/internal/cache/remote.go
+++ b/internal/cache/remote.go
@@ -47,7 +47,7 @@ func (r *Remote) Stat(ctx context.Context, key Key) (http.Header, error) {
 	return errors.WithStack2(r.c.Stat(ctx, key))
 }
 
-func (r *Remote) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error) {
+func (r *Remote) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
 	return errors.WithStack2(r.c.Create(ctx, key, headers, ttl))
 }
 

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -284,7 +284,7 @@ func (r *s3Reader) Close() error {
 	return errors.WithStack(r.obj.Close())
 }
 
-func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error) {
+func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
 	if ttl > s.config.MaxTTL || ttl == 0 {
 		ttl = s.config.MaxTTL
 	}
@@ -294,6 +294,8 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 	maps.Copy(clonedHeaders, headers)
 
 	expiresAt := time.Now().Add(ttl)
+
+	ctx, cancel := context.WithCancelCause(ctx)
 
 	pr, pw := io.Pipe()
 
@@ -305,6 +307,7 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
 		ctx:       ctx,
+		cancel:    cancel,
 		errCh:     make(chan error, 1),
 	}
 
@@ -345,8 +348,10 @@ type s3Writer struct {
 	expiresAt time.Time
 	headers   http.Header
 	ctx       context.Context
+	cancel    context.CancelCauseFunc
 	errCh     chan error
 	uploadErr error
+	closed    bool
 }
 
 func (w *s3Writer) Write(p []byte) (int, error) {
@@ -366,7 +371,17 @@ func (w *s3Writer) Write(p []byte) (int, error) {
 	return n, nil
 }
 
+func (w *s3Writer) Abort(err error) error {
+	w.cancel(err)
+	return w.Close()
+}
+
 func (w *s3Writer) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+
 	// Close the pipe writer to signal EOF to the reader
 	if err := w.pipe.Close(); err != nil {
 		return errors.Wrap(err, "failed to close pipe")

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -51,11 +51,11 @@ func (t Tiered) Close() error {
 }
 
 // Create a new object. All underlying caches will be written to in sequence.
-func (t Tiered) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error) {
+func (t Tiered) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
 	// The first error will cancel all outstanding writes.
 	ctx, cancel := context.WithCancelCause(ctx)
 
-	tw := tieredWriter{make([]io.WriteCloser, len(t.caches)), cancel}
+	tw := &tieredWriter{writers: make([]Writer, len(t.caches)), cancel: cancel}
 	// Note: we can't use errgroup here because we do not want to cancel the context on Wait().
 	wg := sync.WaitGroup{}
 	for i, cache := range t.caches {
@@ -269,14 +269,25 @@ func (t Tiered) Stats(ctx context.Context) (Stats, error) {
 }
 
 type tieredWriter struct {
-	writers []io.WriteCloser
+	writers []Writer
 	cancel  context.CancelCauseFunc
+	closed  bool
 }
 
-var _ io.WriteCloser = (*tieredWriter)(nil)
+var _ Writer = (*tieredWriter)(nil)
+
+func (t *tieredWriter) Abort(err error) error {
+	t.cancel(err)
+	return t.Close()
+}
 
 // Close all writers and return all errors.
-func (t tieredWriter) Close() error {
+func (t *tieredWriter) Close() error {
+	if t.closed {
+		return nil
+	}
+	t.closed = true
+
 	wg := sync.WaitGroup{}
 	errs := make([]error, len(t.writers))
 	for i, cache := range t.writers {
@@ -286,7 +297,7 @@ func (t tieredWriter) Close() error {
 	return errors.Join(errs...)
 }
 
-func (t tieredWriter) Write(p []byte) (n int, err error) {
+func (t *tieredWriter) Write(p []byte) (n int, err error) {
 	for _, cache := range t.writers {
 		n, err = cache.Write(p)
 		if err != nil {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -46,19 +46,13 @@ func CreatePaths(ctx context.Context, remote cache.Cache, key cache.Key, baseDir
 		}
 	}
 
-	// Wrap the context so we can cancel the upload on archive failure,
-	// preventing partial data from being persisted.
-	createCtx, cancelCreate := context.WithCancelCause(ctx)
-	defer cancelCreate(nil)
-
-	wc, err := remote.Create(createCtx, key, headers, ttl)
+	wc, err := remote.Create(ctx, key, headers, ttl)
 	if err != nil {
 		return errors.Wrap(err, "failed to create object")
 	}
 
 	if err := client.Archive(ctx, wc, baseDir, includePaths, excludePatterns, threads); err != nil {
-		cancelCreate(err)
-		return errors.Join(err, wc.Close())
+		return errors.Join(err, wc.Abort(err))
 	}
 	return errors.Wrap(wc.Close(), "failed to close writer")
 }

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -131,20 +131,15 @@ func (d *APIV1) putObject(w http.ResponseWriter, r *http.Request) {
 	// Extract and filter headers from request
 	headers := httputil.FilterHeaders(r.Header, httputil.TransportHeaders...)
 
-	createCtx, cancelCreate := context.WithCancelCause(r.Context())
-	defer cancelCreate(nil)
-
 	namespacedCache := d.cache.Namespace(namespace)
-	cw, err := namespacedCache.Create(createCtx, key, headers, ttl)
+	cw, err := namespacedCache.Create(r.Context(), key, headers, ttl)
 	if err != nil {
 		d.httpError(w, http.StatusInternalServerError, err, "Failed to create cache writer", "key", key)
 		return
 	}
 
 	if _, err := io.Copy(cw, r.Body); err != nil {
-		cancelCreate(err)
-		_ = cw.Close()
-		d.httpError(w, http.StatusInternalServerError, err, "Failed to copy request body to cache writer")
+		d.httpError(w, http.StatusInternalServerError, errors.Join(err, cw.Abort(err)), "Failed to copy request body to cache writer")
 		return
 	}
 

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -401,18 +401,13 @@ func (s *Strategy) cacheBundleAsync(ctx context.Context, key cache.Key, data []b
 }
 
 func (s *Strategy) cacheBundleSync(ctx context.Context, key cache.Key, data []byte) error {
-	createCtx, cancelCreate := context.WithCancelCause(ctx)
-	defer cancelCreate(nil)
-
 	headers := http.Header{"Content-Type": {"application/x-git-bundle"}}
-	wc, err := s.cache.Create(createCtx, key, headers, bundleCacheTTL)
+	wc, err := s.cache.Create(ctx, key, headers, bundleCacheTTL)
 	if err != nil {
 		return errors.Wrap(err, "create cache entry")
 	}
 	if _, err := wc.Write(data); err != nil {
-		cancelCreate(err)
-		_ = wc.Close()
-		return errors.Wrap(err, "write bundle to cache")
+		return errors.Join(errors.Wrap(err, "write bundle to cache"), wc.Abort(err))
 	}
 	return errors.Wrap(wc.Close(), "close bundle cache writer")
 }

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -727,7 +727,7 @@ type failWriteCache struct {
 	cache.Cache
 }
 
-func (f *failWriteCache) Create(ctx context.Context, key cache.Key, headers http.Header, ttl time.Duration) (io.WriteCloser, error) {
+func (f *failWriteCache) Create(ctx context.Context, key cache.Key, headers http.Header, ttl time.Duration) (cache.Writer, error) {
 	wc, err := f.Cache.Create(ctx, key, headers, ttl)
 	if err != nil {
 		return nil, err
@@ -740,7 +740,7 @@ func (f *failWriteCache) Namespace(ns cache.Namespace) cache.Cache {
 }
 
 type failWriter struct {
-	inner io.WriteCloser
+	inner cache.Writer
 }
 
 func (w *failWriter) Write(_ []byte) (int, error) {
@@ -749,6 +749,10 @@ func (w *failWriter) Write(_ []byte) (int, error) {
 
 func (w *failWriter) Close() error {
 	return w.inner.Close()
+}
+
+func (w *failWriter) Abort(err error) error {
+	return w.inner.Abort(err)
 }
 
 func TestSnapshotRemoteURLUsesUpstreamURL(t *testing.T) {

--- a/internal/strategy/gomod/cacher.go
+++ b/internal/strategy/gomod/cacher.go
@@ -33,24 +33,17 @@ func (g *goproxyCacher) Put(ctx context.Context, name string, content io.ReadSee
 
 	key := cache.NewKey(name)
 
-	createCtx, cancelCreate := context.WithCancelCause(ctx)
-	defer cancelCreate(nil)
-
-	wc, err := g.cache.Create(createCtx, key, nil, 0)
+	wc, err := g.cache.Create(ctx, key, nil, 0)
 	if err != nil {
 		return errors.Errorf("create cache entry: %w", err)
 	}
 
 	if _, err := content.Seek(0, io.SeekStart); err != nil {
-		cancelCreate(err)
-		_ = wc.Close()
-		return errors.Errorf("seek to start: %w", err)
+		return errors.Join(errors.Errorf("seek to start: %w", err), wc.Abort(err))
 	}
 
 	if _, err := io.Copy(wc, content); err != nil {
-		cancelCreate(err)
-		_ = wc.Close()
-		return errors.Errorf("write to cache: %w", err)
+		return errors.Join(errors.Errorf("write to cache: %w", err), wc.Abort(err))
 	}
 
 	if err := wc.Close(); err != nil {

--- a/internal/strategy/handler/handler.go
+++ b/internal/strategy/handler/handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"io"
 	"maps"
 	"net/http"
@@ -180,23 +179,22 @@ func (h *Handler) streamNonOKResponse(w http.ResponseWriter, resp *http.Response
 func (h *Handler) streamAndCache(w http.ResponseWriter, r *http.Request, key cache.Key, resp *http.Response) error {
 	ttl := h.ttlFunc(r)
 	responseHeaders := maps.Clone(resp.Header)
-	createCtx, cancelCreate := context.WithCancelCause(r.Context())
-	cw, err := h.cache.Create(createCtx, key, responseHeaders, ttl)
+	cw, err := h.cache.Create(r.Context(), key, responseHeaders, ttl)
 	if err != nil {
-		cancelCreate(nil)
 		h.errorHandler(httputil.Errorf(http.StatusInternalServerError, "failed to create cache entry: %w", err), w, r)
 		return nil
 	}
 
 	pr, pw := io.Pipe()
 	go func() {
-		defer cancelCreate(nil)
 		mw := io.MultiWriter(pw, cw)
 		_, copyErr := io.Copy(mw, resp.Body)
+		var closeErr error
 		if copyErr != nil {
-			cancelCreate(copyErr)
+			closeErr = cw.Abort(copyErr)
+		} else {
+			closeErr = cw.Close()
 		}
-		closeErr := cw.Close()
 		pw.CloseWithError(errors.Join(copyErr, closeErr))
 	}()
 


### PR DESCRIPTION
Replace the error-prone WithCancelCause/cancelCreate boilerplate at
Cache.Create call sites with a CacheWriter interface that manages
context cancellation internally.

- Define client.CacheWriter (io.WriteCloser + Abort(error) error)
- Alias as cache.Writer; update Cache.Create return type
- Add cache.WriteFunc convenience wrapper
- Each writer wraps context internally; Abort cancels and closes
- Simplify ~10 call sites to use Abort instead of manual cancellation
- Preserve existing external context cancellation semantics
