### PR TITLE
fix: use native S3 Expires header for TTL management

### DIFF
--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -110,7 +110,7 @@ func testExpiration(t *testing.T, c cache.Cache) {
 
 	key := cache.NewKey("test-key")
 
-	writer, err := c.Create(ctx, key, nil, time.Millisecond*250)
+	writer, err := c.Create(ctx, key, nil, 2*time.Second)
 	assert.NoError(t, err)
 
 	_, err = writer.Write([]byte("test data"))
@@ -123,7 +123,7 @@ func testExpiration(t *testing.T, c cache.Cache) {
 	assert.NoError(t, err)
 	assert.NoError(t, reader.Close())
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(4 * time.Second)
 
 	_, _, err = c.Open(ctx, key)
 	assert.IsError(t, err, os.ErrNotExist)

--- a/internal/cache/disk_test.go
+++ b/internal/cache/disk_test.go
@@ -19,7 +19,7 @@ func TestDiskCache(t *testing.T) {
 		_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 		c, err := cache.NewDisk(ctx, cache.DiskConfig{
 			Root:   dir,
-			MaxTTL: 100 * time.Millisecond,
+			MaxTTL: 3 * time.Second,
 		})
 		assert.NoError(t, err)
 		return c

--- a/internal/cache/memory_test.go
+++ b/internal/cache/memory_test.go
@@ -16,7 +16,7 @@ import (
 func TestMemoryCache(t *testing.T) {
 	cachetest.Suite(t, func(t *testing.T) cache.Cache {
 		_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelError})
-		c, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: 100 * time.Millisecond})
+		c, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: 3 * time.Second})
 		assert.NoError(t, err)
 		return c
 	})

--- a/internal/cache/remote_test.go
+++ b/internal/cache/remote_test.go
@@ -21,7 +21,7 @@ func TestRemoteCache(t *testing.T) {
 		ctx := t.Context()
 		_, ctx = logging.Configure(ctx, logging.Config{Level: slog.LevelError})
 		memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{
-			MaxTTL: 100 * time.Millisecond,
+			MaxTTL: 3 * time.Second,
 		})
 		assert.NoError(t, err)
 		t.Cleanup(func() { memCache.Close() })

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -119,109 +119,68 @@ func (s *S3) keyToPath(namespace Namespace, key Key) string {
 	return prefix + hexKey[:2] + "/" + hexKey
 }
 
-func (s *S3) Stat(ctx context.Context, key Key) (http.Header, error) {
+// statAndHeaders retrieves object metadata, checks expiry, and returns parsed headers.
+func (s *S3) statAndHeaders(ctx context.Context, key Key) (minio.ObjectInfo, http.Header, error) {
 	objectName := s.keyToPath(s.namespace, key)
 
-	// Get object info to check metadata
 	objInfo, err := s.client.StatObject(ctx, s.config.Bucket, objectName, minio.StatObjectOptions{})
 	if err != nil {
 		errResponse := minio.ToErrorResponse(err)
 		if errResponse.Code == s3ErrNoSuchKey {
-			return nil, os.ErrNotExist
+			return minio.ObjectInfo{}, nil, os.ErrNotExist
 		}
-		return nil, errors.Errorf("failed to stat object: %w", err)
+		return minio.ObjectInfo{}, nil, errors.Errorf("failed to stat object: %w", err)
 	}
 
-	// Check if object has expired
-	// Note: UserMetadata keys are returned WITHOUT the "X-Amz-Meta-" prefix by minio-go
-	expiresAtStr := objInfo.UserMetadata["Expires-At"]
-	if expiresAtStr != "" {
-		var expiresAt time.Time
-		if err := expiresAt.UnmarshalText([]byte(expiresAtStr)); err == nil {
-			if time.Now().After(expiresAt) {
-				// Object expired, delete it and return not found
-				return nil, errors.Join(os.ErrNotExist, s.Delete(ctx, key))
-			}
-		}
+	if !objInfo.Expires.IsZero() && time.Now().After(objInfo.Expires) {
+		return minio.ObjectInfo{}, nil, errors.Join(os.ErrNotExist, s.Delete(ctx, key))
 	}
 
-	// Retrieve headers from metadata
-	// Note: UserMetadata keys are returned WITHOUT the "X-Amz-Meta-" prefix by minio-go
 	headers := make(http.Header)
 	if headersJSON := objInfo.UserMetadata["Headers"]; headersJSON != "" {
 		if err := json.Unmarshal([]byte(headersJSON), &headers); err != nil {
-			return nil, errors.Errorf("failed to unmarshal headers: %w", err)
+			return minio.ObjectInfo{}, nil, errors.Errorf("failed to unmarshal headers: %w", err)
 		}
 	}
 
-	// Add Last-Modified header from S3 object metadata if not already present
 	if headers.Get("Last-Modified") == "" && !objInfo.LastModified.IsZero() {
 		headers.Set("Last-Modified", objInfo.LastModified.UTC().Format(http.TimeFormat))
 	}
 
-	return headers, nil
+	return objInfo, headers, nil
+}
+
+func (s *S3) Stat(ctx context.Context, key Key) (http.Header, error) {
+	_, headers, err := s.statAndHeaders(ctx, key)
+	return headers, err
 }
 
 func (s *S3) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error) {
-	objectName := s.keyToPath(s.namespace, key)
-
-	// Get object info to retrieve metadata and check expiration
-	objInfo, err := s.client.StatObject(ctx, s.config.Bucket, objectName, minio.StatObjectOptions{})
+	objInfo, headers, err := s.statAndHeaders(ctx, key)
 	if err != nil {
-		errResponse := minio.ToErrorResponse(err)
-		if errResponse.Code == s3ErrNoSuchKey {
-			return nil, nil, os.ErrNotExist
-		}
-		return nil, nil, errors.Errorf("failed to stat object: %w", err)
-	}
-
-	// Check if object has expired
-	expiresAtStr := objInfo.UserMetadata["Expires-At"]
-	if expiresAtStr != "" {
-		var expiresAt time.Time
-		if err := expiresAt.UnmarshalText([]byte(expiresAtStr)); err == nil {
-			if time.Now().After(expiresAt) {
-				return nil, nil, errors.Join(os.ErrNotExist, s.Delete(ctx, key))
-			}
-		}
-	}
-
-	// Retrieve headers from metadata
-	headers := make(http.Header)
-	if headersJSON := objInfo.UserMetadata["Headers"]; headersJSON != "" {
-		if err := json.Unmarshal([]byte(headersJSON), &headers); err != nil {
-			return nil, nil, errors.Errorf("failed to unmarshal headers: %w", err)
-		}
-	}
-
-	// Add Last-Modified header from S3 object metadata if not already present
-	if headers.Get("Last-Modified") == "" && !objInfo.LastModified.IsZero() {
-		headers.Set("Last-Modified", objInfo.LastModified.UTC().Format(http.TimeFormat))
+		return nil, nil, err
 	}
 
 	headers.Set("Content-Length", strconv.FormatInt(objInfo.Size, 10))
 
+	objectName := s.keyToPath(s.namespace, key)
+
 	// Reset expiration time to implement LRU (same as disk cache).
 	// Only refresh when remaining TTL is below 50% of max to avoid a
 	// server-side copy on every read.
-	now := time.Now()
-	if expiresAtStr != "" {
-		var expiresAt time.Time
-		if err := expiresAt.UnmarshalText([]byte(expiresAtStr)); err == nil {
-			remaining := expiresAt.Sub(now)
-			if remaining < s.config.MaxTTL/2 {
-				newExpiresAt := now.Add(s.config.MaxTTL)
-				go func() {
-					bgCtx := context.WithoutCancel(ctx)
-					if err := s.refreshExpiration(bgCtx, objectName, objInfo, newExpiresAt); err != nil {
-						s.logger.WarnContext(bgCtx, "Failed to refresh S3 expiration", "object", objectName, "error", err)
-					}
-				}()
-			}
+	if !objInfo.Expires.IsZero() {
+		now := time.Now()
+		if objInfo.Expires.Sub(now) < s.config.MaxTTL/2 {
+			newExpiresAt := ceilSecond(now.Add(s.config.MaxTTL))
+			go func() {
+				bgCtx := context.WithoutCancel(ctx)
+				if err := s.refreshExpiration(bgCtx, objectName, objInfo, newExpiresAt); err != nil {
+					s.logger.WarnContext(bgCtx, "Failed to refresh S3 expiration", "object", objectName, "error", err)
+				}
+			}()
 		}
 	}
 
-	// Download object using parallel range-GET for large objects.
 	reader, err := s.parallelGetReader(ctx, s.config.Bucket, objectName, objInfo.Size, objInfo.ETag)
 	if err != nil {
 		return nil, nil, err
@@ -230,20 +189,10 @@ func (s *S3) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, err
 	return reader, headers, nil
 }
 
-// refreshExpiration updates the Expires-At metadata on an S3 object using
+// refreshExpiration updates the Expires header on an S3 object using
 // server-side copy-to-self with metadata replacement. This avoids re-uploading
 // the object data.
 func (s *S3) refreshExpiration(ctx context.Context, objectName string, objInfo minio.ObjectInfo, newExpiresAt time.Time) error {
-	newExpiresAtBytes, err := newExpiresAt.MarshalText()
-	if err != nil {
-		return errors.Wrap(err, "marshal expiration time")
-	}
-
-	// Rebuild user metadata with updated expiration
-	newMetadata := make(map[string]string)
-	maps.Copy(newMetadata, objInfo.UserMetadata)
-	newMetadata["Expires-At"] = string(newExpiresAtBytes)
-
 	src := minio.CopySrcOptions{
 		Bucket: s.config.Bucket,
 		Object: objectName,
@@ -251,13 +200,24 @@ func (s *S3) refreshExpiration(ctx context.Context, objectName string, objInfo m
 	dst := minio.CopyDestOptions{
 		Bucket:          s.config.Bucket,
 		Object:          objectName,
-		UserMetadata:    newMetadata,
+		UserMetadata:    objInfo.UserMetadata,
 		ReplaceMetadata: true,
+		Expires:         newExpiresAt,
 	}
 	if _, err := s.client.CopyObject(ctx, dst, src); err != nil {
 		return errors.Wrap(err, "copy object")
 	}
 	return nil
+}
+
+// ceilSecond rounds a time up to the next whole second. S3's Expires header
+// uses HTTP-date format (second precision), so sub-second components would be
+// silently truncated, potentially causing premature expiry.
+func ceilSecond(t time.Time) time.Time {
+	if t.Nanosecond() == 0 {
+		return t
+	}
+	return t.Truncate(time.Second).Add(time.Second)
 }
 
 const s3ErrNoSuchKey = "NoSuchKey"
@@ -293,7 +253,7 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 	clonedHeaders := make(http.Header)
 	maps.Copy(clonedHeaders, headers)
 
-	expiresAt := time.Now().Add(ttl)
+	expiresAt := ceilSecond(time.Now().Add(ttl))
 
 	ctx, cancel := context.WithCancelCause(ctx)
 
@@ -410,19 +370,7 @@ func (w *s3Writer) upload(pr *io.PipeReader, r io.Reader) {
 
 	objectName := w.s3.keyToPath(w.namespace, w.key)
 
-	// Prepare user metadata
 	userMetadata := make(map[string]string)
-
-	// Store expiration time
-	expiresAtBytes, err := w.expiresAt.MarshalText()
-	if err != nil {
-		uploadErr = errors.Errorf("failed to marshal expiration time: %w", err)
-		w.errCh <- uploadErr
-		return
-	}
-	userMetadata["Expires-At"] = string(expiresAtBytes)
-
-	// Store headers as JSON
 	if len(w.headers) > 0 {
 		headersJSON, err := json.Marshal(w.headers)
 		if err != nil {
@@ -438,6 +386,7 @@ func (w *s3Writer) upload(pr *io.PipeReader, r io.Reader) {
 	opts := minio.PutObjectOptions{
 		UserMetadata: userMetadata,
 		AutoChecksum: minio.ChecksumCRC64NVME,
+		Expires:      w.expiresAt,
 	}
 
 	// Enable concurrent streaming for multi-part uploads if configured
@@ -448,7 +397,7 @@ func (w *s3Writer) upload(pr *io.PipeReader, r io.Reader) {
 	}
 
 	// Upload object with streaming (size -1 means unknown size, will use chunked encoding)
-	_, err = w.s3.client.PutObject(
+	_, err := w.s3.client.PutObject(
 		w.ctx,
 		w.s3.config.Bucket,
 		objectName,

--- a/internal/cache/s3_test.go
+++ b/internal/cache/s3_test.go
@@ -29,7 +29,7 @@ func newS3Cache(t *testing.T, bucket string) cache.Cache {
 
 	c, err := cache.NewS3(ctx, cache.S3Config{
 		Bucket:           bucket,
-		MaxTTL:           500 * time.Millisecond,
+		MaxTTL:           3 * time.Second,
 		UploadPartSizeMB: 16,
 	}, clientProvider)
 	assert.NoError(t, err)

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -58,7 +58,7 @@ func tieredPermutations(t *testing.T) []struct {
 		})
 		c, err := cache.NewS3(ctx, cache.S3Config{
 			Bucket:           bucket,
-			MaxTTL:           100 * time.Millisecond,
+			MaxTTL:           3 * time.Second,
 			UploadPartSizeMB: 16,
 		}, clientProvider)
 		assert.NoError(t, err)

--- a/internal/metadatadb/s3.go
+++ b/internal/metadatadb/s3.go
@@ -194,9 +194,7 @@ func (s *S3Backend) lockNamespace(ctx context.Context, namespace string) error {
 	key := s.lockKey(namespace)
 	for {
 		opts := minio.PutObjectOptions{
-			UserMetadata: map[string]string{
-				"Expires-At": time.Now().Add(s.lockTTL).Format(time.RFC3339),
-			},
+			Expires: time.Now().Add(s.lockTTL),
 		}
 		opts.SetMatchETagExcept("*")
 
@@ -235,11 +233,7 @@ func (s *S3Backend) tryExpireStaleLock(ctx context.Context, key string) error {
 	if err != nil {
 		return errors.Wrap(err, "stat lock")
 	}
-	expiresAt, err := time.Parse(time.RFC3339, info.UserMetadata["Expires-At"])
-	if err != nil {
-		return errors.Wrap(err, "parse lock expiry")
-	}
-	if time.Now().Before(expiresAt) {
+	if info.Expires.IsZero() || time.Now().Before(info.Expires) {
 		return errors.New("lock not expired")
 	}
 	return errors.Wrap(


### PR DESCRIPTION
Replace custom Expires-At user metadata with the native S3 Expires header (PutObjectOptions.Expires / ObjectInfo.Expires) for TTL management in both the cache and metadatadb S3 backends.

- Extract shared stat/expiry/header logic into statAndHeaders helper
- Add ceilSecond to prevent premature expiry from second-precision truncation
- Switch metadatadb lock TTL from Expires-At metadata to native Expires
- Bump test suite expiration timing to 2s/4s for second-precision compatibility