### PR TITLE
test(jobscheduler): fix data race in TestJobSchedulerMultipleQueues

### DIFF
--- a/internal/jobscheduler/jobs_test.go
+++ b/internal/jobscheduler/jobs_test.go
@@ -298,8 +298,16 @@ func TestJobSchedulerMultipleQueues(t *testing.T) {
 		queueExecutions = make(map[string]bool)
 	)
 
+	// Pre-populate the map before any Submit so the worker goroutines that
+	// later write to it under mu don't race with the main goroutine on map
+	// writes. scheduler.Submit synchronises internally (sync.Cond+sync.Mutex),
+	// which establishes happens-before from these writes to the eventual
+	// worker reads/writes.
 	for _, queue := range queues {
 		queueExecutions[queue] = false
+	}
+
+	for _, queue := range queues {
 		jobID := "job1"
 		scheduler.Submit(queue, jobID, func(_ context.Context) error {
 			mu.Lock()


### PR DESCRIPTION
## Summary

`TestJobSchedulerMultipleQueues` had a data race between the test goroutine and the worker goroutines it submitted, caught intermittently by `-race` in CI (e.g. https://github.com/block/cachew/actions/runs/25342813809/job/74304174116).

## Root cause

The test wrote `queueExecutions[queue] = false` in the same loop that called `scheduler.Submit`, without holding `mu`:

```go
for _, queue := range queues {
    queueExecutions[queue] = false             // main goroutine, no lock
    scheduler.Submit(queue, jobID, func(...) {
        mu.Lock()
        queueExecutions[queue] = true          // worker goroutine, with lock
        mu.Unlock()
        ...
    })
}
```

Workers can execute as soon as the scheduler decides to dispatch them. With `Concurrency: 3` and 5 queues, a worker that starts mid-loop can write to the map at the same time the main goroutine writes the `false` for the next iteration — a concurrent map write that the race detector correctly flags. It manifests as a flake because it depends on dispatch timing.

## Fix

Split into two loops: pre-populate the map up front in a single goroutine, then submit. `scheduler.Submit` synchronises internally (`sync.Cond` + `sync.Mutex`), establishing a happens-before edge from the prepopulate writes to the eventual worker reads/writes, so workers safely observe the existing keys and just update them under `mu`.

## Verification

- `go test -race -count=20 -run TestJobSchedulerMultipleQueues ./internal/jobscheduler/` — 20/20 clean on this branch.
- `just lint` and `just test` both pass.
- The race detector caught the original issue in CI (linked above) — that run is what motivated this fix.
