### PR TITLE
fix(gitclone): bump CloneTimeout to 1h for very large repos

### DIFF
--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -473,9 +473,10 @@ func configureMirror(ctx context.Context, repoPath string, packThreads int) erro
 }
 
 // CloneTimeout bounds `git clone --mirror` so a stuck clone cannot block
-// the repo indefinitely. This is deliberately generous: large repos may
-// take 10-20 minutes for GitHub to compute the server-side pack.
-const CloneTimeout = 30 * time.Minute
+// the repo indefinitely. This is deliberately generous: very large repos
+// can take 30+ minutes for the upstream to compute the server-side pack
+// and stream it.
+const CloneTimeout = 1 * time.Hour
 
 func (r *Repository) executeClone(ctx context.Context) error {
 	parentDir := filepath.Dir(r.path)


### PR DESCRIPTION
## Summary

Raises the hard ceiling on `git clone --mirror` from 30 minutes to 1 hour.

## Why

The 30-minute bound has proven too tight for very large monorepos: a cold clone can be killed mid-pack-stream by the context deadline, leaving the mirror unavailable. Every subsequent client request then re-attempts the same doomed clone, so the repo never converges to a usable state and the snapshot tier never gets populated.

Upstream pack computation + transfer for very large repositories can take 30+ minutes on the first cold clone before the mirror exists. After that, ongoing fetches are cheap and the timeout is effectively never approached.

## Risk

The timeout is a safety bound against a stuck process — raising it only widens the window in which a genuinely stuck clone could hold a worker. In practice the clone subprocess is well-behaved and exits on its own when the upstream stream completes; the deadline only fires for pathologically large repos.