### PR TITLE
refactor: promote tuning constants to config structs

### DIFF
--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -38,10 +38,12 @@ func RegisterS3(r *Registry, clientProvider s3client.ClientProvider) {
 // (endpoint, region, SSL, credentials) are provided by the global
 // s3client.Config block and shared via the s3client.ClientProvider.
 type S3Config struct {
-	Bucket            string        `hcl:"bucket" help:"S3 bucket name."`
-	MaxTTL            time.Duration `hcl:"max-ttl,optional" help:"Maximum time-to-live for entries in the S3 cache (defaults to 1 hour)." default:"1h"`
-	UploadConcurrency uint          `hcl:"upload-concurrency,optional" help:"Number of concurrent workers for multi-part uploads (0 = use all CPU cores, defaults to 1)." default:"1"`
-	UploadPartSizeMB  uint          `hcl:"upload-part-size-mb,optional" help:"Size of each part for multi-part uploads in megabytes (defaults to 16MB, minimum 5MB)." default:"16"`
+	Bucket              string        `hcl:"bucket" help:"S3 bucket name."`
+	MaxTTL              time.Duration `hcl:"max-ttl,optional" help:"Maximum time-to-live for entries in the S3 cache (defaults to 1 hour)." default:"1h"`
+	UploadConcurrency   uint          `hcl:"upload-concurrency,optional" help:"Number of concurrent workers for multi-part uploads (0 = use all CPU cores, defaults to 1)." default:"1"`
+	UploadPartSizeMB    uint          `hcl:"upload-part-size-mb,optional" help:"Size of each part for multi-part uploads in megabytes (defaults to 16MB, minimum 5MB)." default:"16"`
+	DownloadConcurrency uint          `hcl:"download-concurrency,optional" help:"Number of concurrent range-GET workers for downloads (defaults to 8)." default:"8"`
+	DownloadPartSizeMB  uint          `hcl:"download-part-size-mb,optional" help:"Size of each parallel range-GET request in megabytes (defaults to 32MB)." default:"32"`
 }
 
 type S3 struct {
@@ -73,6 +75,14 @@ func NewS3(ctx context.Context, config S3Config, clientProvider s3client.ClientP
 		return nil, errors.New("upload-part-size-mb must be at least 5MB (S3 minimum part size)")
 	}
 
+	if config.DownloadConcurrency == 0 {
+		config.DownloadConcurrency = 8
+	}
+
+	if config.DownloadPartSizeMB == 0 {
+		config.DownloadPartSizeMB = 32
+	}
+
 	client, err := clientProvider()
 	if err != nil {
 		return nil, errors.Errorf("failed to obtain shared S3 client: %w", err)
@@ -81,7 +91,8 @@ func NewS3(ctx context.Context, config S3Config, clientProvider s3client.ClientP
 	logging.FromContext(ctx).InfoContext(ctx, "Constructing S3 cache",
 		"endpoint", client.EndpointURL(), "bucket", config.Bucket,
 		"max-ttl", config.MaxTTL,
-		"upload-concurrency", config.UploadConcurrency, "upload-part-size-mb", config.UploadPartSizeMB)
+		"upload-concurrency", config.UploadConcurrency, "upload-part-size-mb", config.UploadPartSizeMB,
+		"download-concurrency", config.DownloadConcurrency, "download-part-size-mb", config.DownloadPartSizeMB)
 
 	// Verify bucket exists
 	exists, err := client.BucketExists(ctx, config.Bucket)

--- a/internal/cache/s3_parallel_get.go
+++ b/internal/cache/s3_parallel_get.go
@@ -9,22 +9,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	// s3DownloadChunkSize is the size of each parallel range-GET request.
-	// 32 MiB matches the gradle-cache-tool's benchmarked default.
-	s3DownloadChunkSize = 32 << 20
-	// s3DownloadWorkers is the number of concurrent range-GET requests.
-	// 8 workers should be enough to saturate the host's network connection.
-	s3DownloadWorkers = 8
-)
-
 // parallelGetReader returns an io.ReadCloser that downloads the S3 object
 // using parallel range-GET requests and reassembles chunks in order.
 // For objects smaller than one chunk, it falls back to a single GetObject.
 // The etag pins all chunk requests to one object revision, preventing
 // corruption if the key is overwritten during a large read.
 func (s *S3) parallelGetReader(ctx context.Context, bucket, objectName string, size int64, etag string) (io.ReadCloser, error) {
-	if size <= s3DownloadChunkSize {
+	chunkSize := int64(s.config.DownloadPartSizeMB) << 20 // #nosec G115 -- DownloadPartSizeMB is a small operator-supplied tuning value.
+	if size <= chunkSize {
 		// Small object: single stream.
 		obj, err := s.client.GetObject(ctx, bucket, objectName, minio.GetObjectOptions{})
 		if err != nil {
@@ -64,8 +56,9 @@ func (c *cancelReadCloser) Close() error {
 // All chunk requests are pinned to the given etag to ensure consistency.
 // An errgroup cancels all workers on the first error from any goroutine.
 func (s *S3) parallelGet(ctx context.Context, bucket, objectName string, size int64, etag string, w io.Writer) error {
-	numChunks := int((size + s3DownloadChunkSize - 1) / s3DownloadChunkSize)
-	numWorkers := min(s3DownloadWorkers, numChunks)
+	chunkSize := int64(s.config.DownloadPartSizeMB) << 20 // #nosec G115 -- DownloadPartSizeMB is a small operator-supplied tuning value.
+	numChunks := int((size + chunkSize - 1) / chunkSize)
+	numWorkers := min(int(s.config.DownloadConcurrency), numChunks) // #nosec G115 -- DownloadConcurrency is a small operator-supplied tuning value.
 
 	// One buffered channel per chunk so workers never block after sending.
 	results := make([]chan []byte, numChunks)
@@ -91,8 +84,8 @@ func (s *S3) parallelGet(ctx context.Context, bucket, objectName string, size in
 					return egCtx.Err()
 				}
 
-				start := int64(seq) * s3DownloadChunkSize
-				end := min(start+s3DownloadChunkSize-1, size-1)
+				start := int64(seq) * chunkSize
+				end := min(start+chunkSize-1, size-1)
 
 				opts := minio.GetObjectOptions{}
 				if err := opts.SetRange(start, end); err != nil {

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -60,6 +60,10 @@ type Config struct {
 	RefCheckInterval time.Duration `hcl:"ref-check-interval,optional" help:"How long to cache ref checks." default:"10s"`
 	Maintenance      bool          `hcl:"maintenance,optional" help:"Enable git maintenance scheduling for mirror repos." default:"false"`
 	PackThreads      int           `hcl:"pack-threads,optional" help:"Threads for git pack operations (0 = all CPU cores)." default:"0"`
+	CloneTimeout     time.Duration `hcl:"clone-timeout,optional" help:"Upper bound for 'git clone --mirror'. Generous by default since large repos can take 30+ minutes." default:"1h"`
+	FetchTimeout     time.Duration `hcl:"fetch-timeout,optional" help:"Upper bound for 'git fetch' so a slow upstream cannot block the fetch path indefinitely." default:"5m"`
+	LsRemoteTimeout  time.Duration `hcl:"ls-remote-timeout,optional" help:"Upper bound for 'git ls-remote' so a slow upstream cannot block the request path indefinitely." default:"1m"`
+	RepackTimeout    time.Duration `hcl:"repack-timeout,optional" help:"Upper bound for 'git repack' so a slow repack on a large repository cannot block the scheduler queue indefinitely." default:"10m"`
 }
 
 // CredentialProvider provides credentials for git operations.
@@ -122,6 +126,22 @@ func NewManager(ctx context.Context, config Config, credentialProvider Credentia
 
 	if config.PackThreads <= 0 {
 		config.PackThreads = runtime.GOMAXPROCS(0)
+	}
+
+	if config.CloneTimeout == 0 {
+		config.CloneTimeout = 1 * time.Hour
+	}
+
+	if config.FetchTimeout == 0 {
+		config.FetchTimeout = 5 * time.Minute
+	}
+
+	if config.LsRemoteTimeout == 0 {
+		config.LsRemoteTimeout = 60 * time.Second
+	}
+
+	if config.RepackTimeout == 0 {
+		config.RepackTimeout = 10 * time.Minute
 	}
 
 	if err := os.MkdirAll(config.MirrorRoot, 0o750); err != nil {
@@ -472,12 +492,6 @@ func configureMirror(ctx context.Context, repoPath string, packThreads int) erro
 	return nil
 }
 
-// CloneTimeout bounds `git clone --mirror` so a stuck clone cannot block
-// the repo indefinitely. This is deliberately generous: very large repos
-// can take 30+ minutes for the upstream to compute the server-side pack
-// and stream it.
-const CloneTimeout = 1 * time.Hour
-
 func (r *Repository) executeClone(ctx context.Context) error {
 	parentDir := filepath.Dir(r.path)
 	if err := os.MkdirAll(parentDir, 0o750); err != nil {
@@ -494,7 +508,7 @@ func (r *Repository) executeClone(ctx context.Context) error {
 	// known subdirectory so we can rename it atomically afterwards.
 	cloneDest := filepath.Join(tmpDir, "repo")
 
-	cloneCtx, cancel := context.WithTimeout(ctx, CloneTimeout)
+	cloneCtx, cancel := context.WithTimeout(ctx, r.config.CloneTimeout)
 	defer cancel()
 
 	config := DefaultGitTuningConfig()
@@ -533,12 +547,12 @@ func (r *Repository) executeClone(ctx context.Context) error {
 }
 
 func (r *Repository) Fetch(ctx context.Context) error {
-	return r.FetchWithTimeout(ctx, fetchTimeout)
+	return r.FetchWithTimeout(ctx, r.config.FetchTimeout)
 }
 
 // FetchWithTimeout fetches from upstream with a configurable timeout. Use this
 // for catch-up fetches after snapshot restore where the delta may be large and
-// the default fetchTimeout is too short.
+// the default Config.FetchTimeout is too short.
 func (r *Repository) FetchWithTimeout(ctx context.Context, timeout time.Duration) error {
 	return r.fetchInternal(ctx, timeout, true)
 }
@@ -609,14 +623,6 @@ func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, e
 	return nil
 }
 
-// fetchTimeout bounds `git fetch` so a slow or unresponsive upstream
-// cannot block the fetch path indefinitely.
-const fetchTimeout = 5 * time.Minute
-
-// lsRemoteTimeout bounds `git ls-remote` so a slow or unresponsive upstream
-// cannot block the request path indefinitely.
-const lsRemoteTimeout = 60 * time.Second
-
 // EnsureRefsUpToDate checks whether the local mirror's refs match upstream.
 // If refs are stale it returns NeedsFetch=true so the caller can schedule a
 // background fetch via the job scheduler, rather than fetching synchronously
@@ -636,7 +642,7 @@ func (r *Repository) EnsureRefsUpToDate(ctx context.Context) (needsFetch bool, e
 		return false, errors.Wrap(err, "get local refs")
 	}
 
-	lsCtx, cancel := context.WithTimeout(ctx, lsRemoteTimeout)
+	lsCtx, cancel := context.WithTimeout(ctx, r.config.LsRemoteTimeout)
 	defer cancel()
 
 	upstreamRefs, err := r.GetUpstreamRefs(lsCtx)
@@ -697,10 +703,6 @@ func (r *Repository) GetUpstreamRefs(ctx context.Context) (map[string]string, er
 	return ParseGitRefs(output), nil
 }
 
-// repackTimeout bounds `git repack` so a slow repack on a large repository
-// cannot block the scheduler queue indefinitely.
-const repackTimeout = 10 * time.Minute
-
 // Repack consolidates pack files using geometric repacking. Unlike a full
 // repack (-a), geometric repacking only merges packs when there is significant
 // fragmentation (many small packs), making it orders of magnitude faster on
@@ -711,7 +713,7 @@ func (r *Repository) Repack(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 	logger.InfoContext(ctx, "Geometric repack started", "upstream", r.upstreamURL)
 
-	repackCtx, cancel := context.WithTimeout(ctx, repackTimeout)
+	repackCtx, cancel := context.WithTimeout(ctx, r.config.RepackTimeout)
 	defer cancel()
 
 	// #nosec G204 - r.path is controlled by us

--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -16,6 +16,17 @@ import (
 	"github.com/block/cachew/internal/logging"
 )
 
+// testRepoConfig returns a Config with timeouts populated, suitable for
+// constructing Repository values directly in tests that bypass NewManager.
+func testRepoConfig() Config {
+	return Config{
+		CloneTimeout:    1 * time.Hour,
+		FetchTimeout:    5 * time.Minute,
+		LsRemoteTimeout: 60 * time.Second,
+		RepackTimeout:   10 * time.Minute,
+	}
+}
+
 // createBareRepo creates a bare git repository at the given path, suitable for
 // use as an upstream or as a mirror clone target.
 func createBareRepo(t *testing.T, dir string) string {
@@ -267,6 +278,7 @@ func TestRepository_Clone_StateVisibleDuringClone(t *testing.T) {
 	clonePath := filepath.Join(tmpDir, "clone")
 	repo := &Repository{
 		state:       StateEmpty,
+		config:      testRepoConfig(),
 		path:        clonePath,
 		upstreamURL: upstreamPath,
 		fetchSem:    make(chan struct{}, 1),
@@ -306,9 +318,11 @@ func TestRepository_CloneSetsMirrorConfig(t *testing.T) {
 	upstreamPath := createBareRepo(t, tmpDir)
 
 	clonePath := filepath.Join(tmpDir, "clone")
+	cfg := testRepoConfig()
+	cfg.PackThreads = 4
 	repo := &Repository{
 		state:       StateEmpty,
-		config:      Config{PackThreads: 4},
+		config:      cfg,
 		path:        clonePath,
 		upstreamURL: upstreamPath,
 		fetchSem:    make(chan struct{}, 1),
@@ -333,6 +347,7 @@ func TestRepository_CloneFailedLeavesNoDebris(t *testing.T) {
 	clonePath := filepath.Join(tmpDir, "mirrors", "github.com", "owner", "repo")
 	repo := &Repository{
 		state:       StateEmpty,
+		config:      testRepoConfig(),
 		path:        clonePath,
 		upstreamURL: "https://github.com/nonexistent-owner-abc123/nonexistent-repo-abc123",
 		fetchSem:    make(chan struct{}, 1),
@@ -359,6 +374,7 @@ func TestRepository_CloneDoesNotClobberSiblings(t *testing.T) {
 	clonePath := filepath.Join(mirrorRoot, "github.com")
 	repo := &Repository{
 		state:       StateEmpty,
+		config:      testRepoConfig(),
 		path:        clonePath,
 		upstreamURL: "https://github.com/",
 		fetchSem:    make(chan struct{}, 1),
@@ -383,6 +399,7 @@ func TestRepository_Repack(t *testing.T) {
 
 	repo := &Repository{
 		state:       StateReady,
+		config:      testRepoConfig(),
 		path:        clonePath,
 		upstreamURL: upstreamPath,
 		fetchSem:    make(chan struct{}, 1),
@@ -412,6 +429,7 @@ func TestRepository_Repack_CleansUpStaleLockOnFailure(t *testing.T) {
 
 	repo := &Repository{
 		state:       StateReady,
+		config:      testRepoConfig(),
 		path:        clonePath,
 		upstreamURL: upstreamPath,
 		fetchSem:    make(chan struct{}, 1),

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -40,6 +40,7 @@ type Config struct {
 	MirrorSnapshotInterval time.Duration `hcl:"mirror-snapshot-interval,optional" help:"How often to generate mirror snapshots for pod bootstrap. 0 uses snapshot-interval. Defaults to 2h." default:"2h"`
 	RepackInterval         time.Duration `hcl:"repack-interval,optional" help:"How often to run full repack. 0 disables." default:"0"`
 	ZstdThreads            int           `hcl:"zstd-threads,optional" help:"Threads for zstd compression/decompression (0 = all CPU cores)." default:"0"`
+	BundleCacheTTL         time.Duration `hcl:"bundle-cache-ttl,optional" help:"TTL of cached server-side git bundles." default:"2h"`
 }
 
 type Strategy struct {
@@ -72,6 +73,9 @@ func New(
 ) (*Strategy, error) {
 	if _, err := exec.LookPath("git"); err != nil {
 		return nil, errors.New("git is required but not found in PATH")
+	}
+	if config.BundleCacheTTL == 0 {
+		config.BundleCacheTTL = 2 * time.Hour
 	}
 	if config.SnapshotInterval > 0 {
 		for _, bin := range []string{"tar", "zstd"} {
@@ -198,7 +202,7 @@ func (s *Strategy) warmExistingRepos(ctx context.Context) error {
 		}
 
 		start := time.Now()
-		if err := repo.FetchLenient(ctx, gitclone.CloneTimeout); err != nil {
+		if err := repo.FetchLenient(ctx, s.cloneManager.Config().CloneTimeout); err != nil {
 			logger.ErrorContext(ctx, "Startup fetch failed for existing repo", "upstream", repo.UpstreamURL(), "error", err,
 				"duration", time.Since(start))
 			continue
@@ -540,7 +544,7 @@ func (s *Strategy) startClone(ctx context.Context, repo *gitclone.Repository) er
 		// State remains StateCloning until fetch succeeds so that
 		// concurrent requests (via ensureCloneReady) block rather than
 		// serving from a potentially empty or stale mirror.
-		if err := repo.FetchLenient(ctx, gitclone.CloneTimeout); err != nil {
+		if err := repo.FetchLenient(ctx, s.cloneManager.Config().CloneTimeout); err != nil {
 			logger.WarnContext(ctx, "Post-restore fetch failed, discarding snapshot and falling back to clone",
 				"upstream", upstream, "error", err)
 			// The restored snapshot may be corrupt or empty. Remove it and

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -389,8 +389,6 @@ func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseW
 	return errors.Wrap(err, "stream snapshot")
 }
 
-const bundleCacheTTL = 2 * time.Hour
-
 func (s *Strategy) cacheBundleAsync(ctx context.Context, key cache.Key, data []byte) {
 	go func() {
 		bgCtx := context.WithoutCancel(ctx)
@@ -402,7 +400,7 @@ func (s *Strategy) cacheBundleAsync(ctx context.Context, key cache.Key, data []b
 
 func (s *Strategy) cacheBundleSync(ctx context.Context, key cache.Key, data []byte) error {
 	headers := http.Header{"Content-Type": {"application/x-git-bundle"}}
-	wc, err := s.cache.Create(ctx, key, headers, bundleCacheTTL)
+	wc, err := s.cache.Create(ctx, key, headers, s.config.BundleCacheTTL)
 	if err != nil {
 		return errors.Wrap(err, "create cache entry")
 	}
@@ -653,7 +651,7 @@ func (s *Strategy) scheduleDeferredMirrorRestore(ctx context.Context, repo *gitc
 			return nil
 		}
 
-		if err := repo.FetchLenient(ctx, gitclone.CloneTimeout); err != nil {
+		if err := repo.FetchLenient(ctx, s.cloneManager.Config().CloneTimeout); err != nil {
 			logger.WarnContext(ctx, "Deferred mirror post-restore fetch failed", "upstream", upstream, "error", err)
 			repo.ResetToEmpty()
 			if rmErr := os.RemoveAll(repo.Path()); rmErr != nil {


### PR DESCRIPTION
Move CloneTimeout/fetchTimeout/lsRemoteTimeout/repackTimeout into
gitclone.Config, bundleCacheTTL into git.Config, and the s3 download
chunk size/worker count into cache.S3Config (as DownloadPartSizeMB and
DownloadConcurrency). Defaults are preserved as zero-value fallbacks in
the relevant constructors.
