### PR TITLE
perf: use pzstd for snapshot compression

### DIFF
--- a/client/archive.go
+++ b/client/archive.go
@@ -103,11 +103,11 @@ func Extract(ctx context.Context, r io.Reader, directory string, threads int) er
 	return errors.Join(errs...)
 }
 
-// runTarZstdPipeline runs tar piped through zstd, writing compressed output
+// runTarZstdPipeline runs tar piped through pzstd, writing compressed output
 // to w. The caller is responsible for closing w after this returns.
 func runTarZstdPipeline(ctx context.Context, tarArgs []string, threads int, w io.Writer) error {
 	tarCmd := exec.CommandContext(ctx, "tar", tarArgs...)
-	zstdCmd := exec.CommandContext(ctx, "zstd", "-c", fmt.Sprintf("-T%d", threads)) //nolint:gosec
+	zstdCmd := exec.CommandContext(ctx, "pzstd", "-c", fmt.Sprintf("-p%d", threads)) //nolint:gosec
 
 	// Manual pipe so we can close both ends in the parent after starting
 	// children. Prevents deadlock if zstd exits while tar is still writing:

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -78,7 +78,7 @@ func New(
 		config.BundleCacheTTL = 2 * time.Hour
 	}
 	if config.SnapshotInterval > 0 {
-		for _, bin := range []string{"tar", "zstd"} {
+		for _, bin := range []string{"tar", "pzstd"} {
 			if _, err := exec.LookPath(bin); err != nil {
 				return nil, errors.Errorf("%s is required for snapshots (snapshot-interval > 0) but not found in PATH", bin)
 			}


### PR DESCRIPTION
Switch snapshot compression from `zstd` to `pzstd`, which produces multi-frame output that clients can decompress in parallel. The output is still a valid zstd stream so no client changes are needed.