### PR TITLE
fix(gitclone): bound repack memory to prevent OOM kills

### DIFF
--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -64,6 +64,7 @@ type Config struct {
 	FetchTimeout     time.Duration `hcl:"fetch-timeout,optional" help:"Upper bound for 'git fetch' so a slow upstream cannot block the fetch path indefinitely." default:"5m"`
 	LsRemoteTimeout  time.Duration `hcl:"ls-remote-timeout,optional" help:"Upper bound for 'git ls-remote' so a slow upstream cannot block the request path indefinitely." default:"1m"`
 	RepackTimeout    time.Duration `hcl:"repack-timeout,optional" help:"Upper bound for 'git repack' so a slow repack on a large repository cannot block the scheduler queue indefinitely." default:"10m"`
+	RepackThreads    int           `hcl:"repack-threads,optional" help:"Threads for git repack operations. Limits memory since windowMemory and deltaCacheSize are per-thread. 0 = pack-threads." default:"4"`
 }
 
 // CredentialProvider provides credentials for git operations.
@@ -716,8 +717,21 @@ func (r *Repository) Repack(ctx context.Context) error {
 	repackCtx, cancel := context.WithTimeout(ctx, r.config.RepackTimeout)
 	defer cancel()
 
+	threads := r.config.RepackThreads
+	if threads <= 0 {
+		threads = r.config.PackThreads
+	}
+
+	// Override pack settings for repack to bound memory usage. The repo-level
+	// config uses high values (512m deltaCacheSize, 1g windowMemory) tuned for
+	// serving performance with many threads. Repack is a background task that
+	// can afford to be slower in exchange for bounded memory.
 	// #nosec G204 - r.path is controlled by us
-	cmd := exec.CommandContext(repackCtx, "git", "-C", r.path, "repack", "-d", "--geometric=2", "--write-midx", "--write-bitmap-index")
+	cmd := exec.CommandContext(repackCtx, "git", "-C", r.path,
+		"-c", "pack.threads="+strconv.Itoa(threads),
+		"-c", "pack.windowMemory=256m",
+		"-c", "pack.deltaCacheSize=128m",
+		"repack", "-d", "--geometric=2", "--write-midx", "--write-bitmap-index")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)

--- a/internal/jobscheduler/jobs.go
+++ b/internal/jobscheduler/jobs.go
@@ -245,7 +245,10 @@ func (q *RootScheduler) waitForJob() (queueJob, bool) {
 func (q *RootScheduler) runJob(ctx context.Context, logger *slog.Logger, job queueJob) {
 	defer q.markQueueInactive(job.queue)
 
-	jobAttrs := attribute.String("job.type", jobType(job.id))
+	jobAttrs := []attribute.KeyValue{
+		attribute.String("job.type", jobType(job.id)),
+		attribute.String("job.queue", job.queue),
+	}
 	start := time.Now()
 	logger.InfoContext(ctx, "Starting job", "job", job)
 
@@ -269,9 +272,9 @@ func (q *RootScheduler) runJob(ctx context.Context, logger *slog.Logger, job que
 	} else {
 		logger.InfoContext(ctx, "Job completed", "job", job, "elapsed", elapsed)
 	}
-	statusAttr := attribute.String("status", status)
-	q.metrics.jobsTotal.Add(ctx, 1, metric.WithAttributes(jobAttrs, statusAttr))
-	q.metrics.jobDuration.Record(ctx, elapsed.Seconds(), metric.WithAttributes(jobAttrs, statusAttr))
+	jobAttrs = append(jobAttrs, attribute.String("status", status))
+	q.metrics.jobsTotal.Add(ctx, 1, metric.WithAttributes(jobAttrs...))
+	q.metrics.jobDuration.Record(ctx, elapsed.Seconds(), metric.WithAttributes(jobAttrs...))
 }
 
 // jobType extracts a normalised job type from the job ID for metric labels.

--- a/internal/strategy/git/repack.go
+++ b/internal/strategy/git/repack.go
@@ -2,12 +2,22 @@ package git
 
 import (
 	"context"
+	"time"
+
+	"github.com/alecthomas/errors"
 
 	"github.com/block/cachew/internal/gitclone"
 )
 
 func (s *Strategy) scheduleRepackJobs(repo *gitclone.Repository) {
 	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "repack-periodic", s.config.RepackInterval, func(ctx context.Context) error {
-		return repo.Repack(ctx)
+		start := time.Now()
+		err := repo.Repack(ctx)
+		status := "success"
+		if err != nil {
+			status = "error"
+		}
+		s.metrics.recordOperation(ctx, "repack", status, time.Since(start))
+		return errors.Wrap(err, "repack")
 	})
 }


### PR DESCRIPTION
`git repack --geometric=2` inherits the repo-level `pack.threads` (set to GOMAXPROCS at clone time, typically 96 on m5d.16xlarge), along with `pack.windowMemory=1g` and `pack.deltaCacheSize=512m`. Peak theoretical: 96 x 1.5 GB = 144 GB, well over the 96 GiB pod limit. In production, `linux-kselftest` was OOM-killed every hour; `cash-server` succeeded but used far more memory than needed.

Fix: override pack settings during repack via `-c` flags. 4 threads (configurable), 256m windowMemory, 128m deltaCacheSize. Bounds repack memory to ~1.5 GB regardless of repo size. No performance regression since geometric repack is I/O-bound and pack data is hot in page cache.

Tested on playpen:
- `cash-server` (4.2 GB packs): 3m22s (same as production baseline)
- `linux-kselftest` (1.6 GB packs): 1m59s (previously killed every time)

Also adds `job.queue` label to scheduler metrics and emits repack operation metrics.