### PR TITLE
feat(git): add /ensure-refs endpoint for client-driven ref freshness

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -96,7 +97,7 @@ type Client struct {
 // request.
 func New(baseURL string, headerFunc HeaderFunc) *Client {
 	return &Client{
-		baseURL: baseURL + "/api/v1",
+		baseURL: strings.TrimRight(baseURL, "/"),
 		http:    NewHTTPClient(headerFunc),
 	}
 }
@@ -106,7 +107,7 @@ func New(baseURL string, headerFunc HeaderFunc) *Client {
 // the supplied client (e.g. via a custom RoundTripper).
 func NewWithHTTPClient(baseURL string, httpClient *http.Client) *Client {
 	return &Client{
-		baseURL: baseURL + "/api/v1",
+		baseURL: strings.TrimRight(baseURL, "/"),
 		http:    httpClient,
 	}
 }
@@ -115,7 +116,7 @@ func NewWithHTTPClient(baseURL string, httpClient *http.Client) *Client {
 // non-API endpoints with the same auth configuration.
 func (c *Client) HTTP() *http.Client { return c.http }
 
-// BaseURL returns the /api/v1 base URL this client targets.
+// BaseURL returns the cachew server root URL this client targets.
 func (c *Client) BaseURL() string { return c.baseURL }
 
 // String describes the client.
@@ -138,7 +139,7 @@ func (c *Client) resolvedNamespace() Namespace {
 }
 
 func (c *Client) objectURL(key Key) string {
-	return fmt.Sprintf("%s/object/%s/%s", c.baseURL, c.resolvedNamespace(), key.String())
+	return fmt.Sprintf("%s/api/v1/object/%s/%s", c.baseURL, c.resolvedNamespace(), key.String())
 }
 
 // Open retrieves an object from the cache server.
@@ -268,7 +269,7 @@ func (c *Client) Close() error {
 
 // Stats retrieves cache statistics from the server.
 func (c *Client) Stats(ctx context.Context) (Stats, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/stats", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v1/stats", nil)
 	if err != nil {
 		return Stats{}, errors.Wrap(err, "failed to create request")
 	}
@@ -297,7 +298,7 @@ func (c *Client) Stats(ctx context.Context) (Stats, error) {
 
 // ListNamespaces requests the namespace list from the server.
 func (c *Client) ListNamespaces(ctx context.Context) ([]string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/namespaces", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v1/namespaces", nil)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/client/git.go
+++ b/client/git.go
@@ -1,0 +1,205 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/errors"
+)
+
+// SnapshotCommitHeader is the response header on /snapshot.tar.zst that
+// contains the mirror's HEAD SHA at the time the snapshot was generated. An
+// empty value means the snapshot was served cold (no associated mirror) and
+// the caller should freshen the working tree itself.
+const SnapshotCommitHeader = "X-Cachew-Snapshot-Commit"
+
+// BundleURLHeader is the response header on /snapshot.tar.zst that, when
+// present, points at a delta bundle that brings the snapshot up to the
+// mirror's current HEAD.
+const BundleURLHeader = "X-Cachew-Bundle-Url"
+
+// EnsureGitRefsResponse is the response returned by EnsureGitRefs.
+//
+// Refs contains the resolved local SHA for each requested ref (empty if the
+// ref is still missing on the server after the fetch). Fetched reports
+// whether the server performed an upstream fetch to satisfy the request.
+type EnsureGitRefsResponse struct {
+	Refs    map[string]string `json:"refs"`
+	Fetched bool              `json:"fetched"`
+}
+
+// EnsureGitRefs asks the cachew server to ensure its local mirror of repoURL
+// contains the listed refs at the given SHAs before the caller fetches. An
+// empty SHA means "require the ref to exist, at any SHA". The server will
+// synchronously fetch from upstream if any requested ref is missing or stale.
+//
+// Use this before issuing a git fetch/clone against cachew when fresh refs
+// are required and the default ref-check rate-limit window would otherwise
+// allow stale refs to be served.
+func (c *Client) EnsureGitRefs(ctx context.Context, repoURL string, refs map[string]string) (EnsureGitRefsResponse, error) {
+	endpoint, err := gitEndpointURL(c.baseURL, repoURL, "ensure-refs")
+	if err != nil {
+		return EnsureGitRefsResponse{}, err
+	}
+
+	body, err := json.Marshal(struct {
+		Refs map[string]string `json:"refs"`
+	}{Refs: refs})
+	if err != nil {
+		return EnsureGitRefsResponse{}, errors.Wrap(err, "encode request")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return EnsureGitRefsResponse{}, errors.Wrap(err, "create request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return EnsureGitRefsResponse{}, errors.Wrap(err, "execute request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body) //nolint:errcheck
+		return EnsureGitRefsResponse{}, errors.Errorf("ensure refs: status %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var out EnsureGitRefsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return EnsureGitRefsResponse{}, errors.Wrap(err, "decode response")
+	}
+	return out, nil
+}
+
+// GitSnapshot is a streaming response from OpenGitSnapshot.
+//
+// Body is the zstd-compressed tarball; the caller must Close it. Commit holds
+// the mirror's HEAD SHA at snapshot time (empty for cold serves). BundleURL,
+// if non-empty, identifies a delta bundle that brings the snapshot up to the
+// mirror's current HEAD; it can be passed to OpenGitBundle.
+type GitSnapshot struct {
+	Body      io.ReadCloser
+	Headers   http.Header
+	Commit    string
+	BundleURL string
+}
+
+// Close releases the underlying response body.
+func (s *GitSnapshot) Close() error { return errors.WithStack(s.Body.Close()) }
+
+// OpenGitSnapshot fetches a working-tree snapshot for repoURL from cachew.
+// The caller is responsible for extracting the returned zstd-compressed
+// tarball (e.g. via the snapshot package). Returns os.ErrNotExist when the
+// server has no snapshot available.
+func (c *Client) OpenGitSnapshot(ctx context.Context, repoURL string) (*GitSnapshot, error) {
+	return c.openGitArtifact(ctx, repoURL, "snapshot.tar.zst")
+}
+
+// OpenGitLFSSnapshot fetches the LFS-object snapshot for repoURL. Returns
+// os.ErrNotExist when the server has no LFS snapshot cached.
+func (c *Client) OpenGitLFSSnapshot(ctx context.Context, repoURL string) (*GitSnapshot, error) {
+	return c.openGitArtifact(ctx, repoURL, "lfs-snapshot.tar.zst")
+}
+
+// OpenGitBundle fetches the bundle pointed at by a BundleURL returned in a
+// previous GitSnapshot response. The caller is responsible for writing the
+// body to a file and applying it via `git pull`/`git fetch`.
+func (c *Client) OpenGitBundle(ctx context.Context, bundleURL string) (io.ReadCloser, error) {
+	resolved, err := resolveBundleURL(c.baseURL, bundleURL)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolved, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "create bundle request")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "execute bundle request")
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		return nil, errors.Join(os.ErrNotExist, resp.Body.Close())
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		return nil, errors.Join(errors.WithStack(&HTTPStatusError{StatusCode: resp.StatusCode}), resp.Body.Close())
+	}
+	return resp.Body, nil
+}
+
+func (c *Client) openGitArtifact(ctx context.Context, repoURL, suffix string) (*GitSnapshot, error) {
+	endpoint, err := gitEndpointURL(c.baseURL, repoURL, suffix)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "create request")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "execute request")
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		return nil, errors.Join(os.ErrNotExist, resp.Body.Close())
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		return nil, errors.Join(errors.WithStack(&HTTPStatusError{StatusCode: resp.StatusCode}), resp.Body.Close())
+	}
+	return &GitSnapshot{
+		Body:      resp.Body,
+		Headers:   filterHeaders(resp.Header, transportHeaders...),
+		Commit:    resp.Header.Get(SnapshotCommitHeader),
+		BundleURL: resp.Header.Get(BundleURLHeader),
+	}, nil
+}
+
+// gitEndpointURL builds a /git/{host}/{repoPath}/{suffix} URL from a cachew
+// base URL and an upstream repository URL (e.g. https://github.com/org/repo).
+func gitEndpointURL(baseURL, repoURL, suffix string) (string, error) {
+	parsed, err := url.Parse(repoURL)
+	if err != nil {
+		return "", errors.Wrap(err, "parse repo URL")
+	}
+	if parsed.Host == "" {
+		return "", errors.Errorf("repo URL %q is missing a host", repoURL)
+	}
+	repoPath := strings.TrimSuffix(strings.TrimPrefix(parsed.Path, "/"), ".git")
+	if repoPath == "" {
+		return "", errors.Errorf("repo URL %q is missing a path", repoURL)
+	}
+	return fmt.Sprintf("%s/git/%s/%s/%s", baseURL, parsed.Host, repoPath, suffix), nil
+}
+
+// resolveBundleURL joins an X-Cachew-Bundle-Url header value (which may be
+// absolute or root-relative) onto the client's base URL.
+func resolveBundleURL(baseURL, bundleURL string) (string, error) {
+	parsed, err := url.Parse(bundleURL)
+	if err != nil {
+		return "", errors.Wrap(err, "parse bundle URL")
+	}
+	if parsed.IsAbs() {
+		return bundleURL, nil
+	}
+	if !strings.HasPrefix(bundleURL, "/") {
+		bundleURL = "/" + bundleURL
+	}
+	return baseURL + bundleURL, nil
+}

--- a/client/git_test.go
+++ b/client/git_test.go
@@ -1,0 +1,141 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
+
+	"github.com/block/cachew/client"
+)
+
+func TestEnsureGitRefs(t *testing.T) {
+	var receivedBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/git/github.com/org/repo/ensure-refs", r.URL.Path)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&receivedBody))
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"refs":    map[string]string{"refs/heads/main": "abc123"},
+			"fetched": true,
+		}))
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	resp, err := api.EnsureGitRefs(context.Background(),
+		"https://github.com/org/repo",
+		map[string]string{"refs/heads/main": ""})
+	assert.NoError(t, err)
+	assert.True(t, resp.Fetched)
+	assert.Equal(t, "abc123", resp.Refs["refs/heads/main"])
+
+	refs, ok := receivedBody["refs"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "", refs["refs/heads/main"])
+}
+
+func TestEnsureGitRefsServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	_, err := api.EnsureGitRefs(context.Background(),
+		"https://github.com/org/repo",
+		map[string]string{"refs/heads/main": ""})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 400")
+}
+
+func TestEnsureGitRefsInvalidRepoURL(t *testing.T) {
+	api := client.New("http://example.com", nil)
+
+	_, err := api.EnsureGitRefs(context.Background(), "not-a-url", nil)
+	assert.Error(t, err)
+
+	_, err = api.EnsureGitRefs(context.Background(), "https://github.com/", nil)
+	assert.Error(t, err)
+}
+
+func TestOpenGitSnapshot(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst"):
+			assert.Equal(t, "/git/github.com/org/repo/snapshot.tar.zst", r.URL.Path)
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Header().Set(client.SnapshotCommitHeader, "deadbeef")
+			w.Header().Set(client.BundleURLHeader, "/git/github.com/org/repo/snapshot.bundle?base=deadbeef")
+			_, _ = w.Write([]byte("snapshot-bytes")) //nolint:errcheck
+
+		case strings.HasSuffix(r.URL.Path, "/lfs-snapshot.tar.zst"):
+			http.NotFound(w, r)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+
+	snap, err := api.OpenGitSnapshot(context.Background(), "https://github.com/org/repo")
+	assert.NoError(t, err)
+	defer snap.Close()
+
+	assert.Equal(t, "deadbeef", snap.Commit)
+	assert.Equal(t, "/git/github.com/org/repo/snapshot.bundle?base=deadbeef", snap.BundleURL)
+	body, err := io.ReadAll(snap.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "snapshot-bytes", string(body))
+
+	_, err = api.OpenGitLFSSnapshot(context.Background(), "https://github.com/org/repo")
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestOpenGitBundle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/git/github.com/org/repo/snapshot.bundle", r.URL.Path)
+		assert.Equal(t, "abc", r.URL.Query().Get("base"))
+		w.Header().Set("Content-Type", "application/x-git-bundle")
+		_, _ = w.Write([]byte("bundle-bytes")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+
+	// Root-relative URL (as returned in X-Cachew-Bundle-Url).
+	body, err := api.OpenGitBundle(context.Background(),
+		"/git/github.com/org/repo/snapshot.bundle?base=abc")
+	assert.NoError(t, err)
+	data, err := io.ReadAll(body)
+	assert.NoError(t, err)
+	assert.NoError(t, body.Close())
+	assert.Equal(t, "bundle-bytes", string(data))
+
+	// Absolute URL.
+	body, err = api.OpenGitBundle(context.Background(),
+		srv.URL+"/git/github.com/org/repo/snapshot.bundle?base=abc")
+	assert.NoError(t, err)
+	assert.NoError(t, body.Close())
+}
+
+func TestOpenGitBundleNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	_, err := api.OpenGitBundle(context.Background(), "/git/x/y/snapshot.bundle")
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}

--- a/cmd/cachew/git.go
+++ b/cmd/cachew/git.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/alecthomas/errors"
 
-	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/client"
 	"github.com/block/cachew/internal/snapshot"
 )
 
@@ -22,76 +21,73 @@ type GitCmd struct {
 }
 
 // GitRestoreCmd fetches a git snapshot, extracts it, and optionally applies
-// a delta bundle to bring the working copy up to the mirror's current HEAD.
+// a delta bundle. If --ref is set it then asks the server to ensure those
+// refs are fresh and runs `git pull --ff-only` so the working tree catches
+// up to upstream.
 type GitRestoreCmd struct {
-	RepoURL     string `arg:"" help:"Repository URL (e.g. https://github.com/org/repo)."`
-	Directory   string `arg:"" help:"Target directory for the clone." type:"path"`
-	NoBundle    bool   `help:"Skip applying delta bundle."`
-	ZstdThreads int    `help:"Threads for zstd decompression (0 = all CPU cores)." default:"0"`
+	RepoURL     string            `arg:"" help:"Repository URL (e.g. https://github.com/org/repo)."`
+	Directory   string            `arg:"" help:"Target directory for the clone." type:"path"`
+	Ref         map[string]string `help:"Required refs to freshen on the server before pulling, in the form 'name=sha' (e.g. 'refs/heads/main=abc123'). An empty SHA means any SHA is acceptable. Setting this also runs a final 'git pull' from origin so the working tree is brought up to date."`
+	NoBundle    bool              `help:"Skip applying delta bundle."`
+	ZstdThreads int               `help:"Threads for zstd decompression (0 = all CPU cores)." default:"0"`
 }
 
-func (c *GitRestoreCmd) Run(ctx context.Context, cli *CLI, client *http.Client) error {
-	repoPath, err := gitclone.RepoPathFromURL(c.RepoURL)
-	if err != nil {
-		return errors.Wrap(err, "invalid repository URL")
-	}
+func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
+	fmt.Fprintf(os.Stderr, "Fetching snapshot for %s\n", c.RepoURL) //nolint:forbidigo
 
-	snapshotURL := fmt.Sprintf("%s/git/%s/snapshot.tar.zst", cli.URL, repoPath)
-	fmt.Fprintf(os.Stderr, "Fetching snapshot from %s\n", snapshotURL) //nolint:forbidigo
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, snapshotURL, nil)
+	snap, err := api.OpenGitSnapshot(ctx, c.RepoURL)
 	if err != nil {
-		return errors.Wrap(err, "create snapshot request")
-	}
-
-	resp, err := client.Do(req) //nolint:gosec // URL constructed from CLI flags
-	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.Errorf("no snapshot available for %s", c.RepoURL)
+		}
 		return errors.Wrap(err, "fetch snapshot")
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck
-		return errors.Errorf("snapshot request failed with status %d", resp.StatusCode)
-	}
+	defer snap.Close()
 
 	fmt.Fprintf(os.Stderr, "Extracting to %s...\n", c.Directory) //nolint:forbidigo
-	if err := snapshot.Extract(ctx, resp.Body, c.Directory, c.ZstdThreads); err != nil {
+	if err := snapshot.Extract(ctx, snap.Body, c.Directory, c.ZstdThreads); err != nil {
 		return errors.Wrap(err, "extract snapshot")
 	}
 	fmt.Fprintf(os.Stderr, "Snapshot restored to %s\n", c.Directory) //nolint:forbidigo
 
-	bundleURL := resp.Header.Get("X-Cachew-Bundle-Url")
-	if bundleURL == "" || c.NoBundle {
-		return nil
+	if snap.BundleURL != "" && !c.NoBundle {
+		fmt.Fprintf(os.Stderr, "Applying delta bundle...\n") //nolint:forbidigo
+		if err := applyBundle(ctx, api, snap.BundleURL, c.Directory); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to apply delta bundle: %v\n", err) //nolint:forbidigo
+		} else {
+			fmt.Fprintf(os.Stderr, "Delta bundle applied\n") //nolint:forbidigo
+		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Applying delta bundle...\n") //nolint:forbidigo
-	if err := applyBundle(ctx, cli.URL, client, bundleURL, c.Directory); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to apply delta bundle: %v\n", err) //nolint:forbidigo
-		return nil
+	// Snapshot + bundle leave the working tree at whatever the mirror had
+	// when the bundle was last generated, which may be arbitrarily old. If
+	// the caller asked for specific refs to be fresh, freshen the mirror
+	// and then pull from origin to catch the working tree up.
+	if len(c.Ref) > 0 {
+		fmt.Fprintf(os.Stderr, "Ensuring %d ref(s) are fresh for %s\n", len(c.Ref), c.RepoURL) //nolint:forbidigo
+		resp, err := api.EnsureGitRefs(ctx, c.RepoURL, c.Ref)
+		if err != nil {
+			return errors.Wrap(err, "ensure refs")
+		}
+		if resp.Fetched {
+			fmt.Fprintf(os.Stderr, "Server fetched fresh refs from upstream\n") //nolint:forbidigo
+		}
+
+		fmt.Fprintf(os.Stderr, "Pulling from origin...\n") //nolint:forbidigo
+		if err := gitPullOrigin(ctx, c.Directory); err != nil {
+			return errors.Wrap(err, "git pull from origin")
+		}
 	}
-	fmt.Fprintf(os.Stderr, "Delta bundle applied\n") //nolint:forbidigo
 
 	return nil
 }
 
-func applyBundle(ctx context.Context, baseURL string, client *http.Client, bundlePath, directory string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+bundlePath, nil)
-	if err != nil {
-		return errors.Wrap(err, "create bundle request")
-	}
-
-	resp, err := client.Do(req) //nolint:gosec // URL constructed from CLI flags
+func applyBundle(ctx context.Context, api *client.Client, bundleURL, directory string) error {
+	body, err := api.OpenGitBundle(ctx, bundleURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch bundle")
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck
-		return errors.Errorf("bundle request failed with status %d", resp.StatusCode)
-	}
+	defer body.Close()
 
 	tmpFile, err := os.CreateTemp("", "cachew-bundle-*.bundle")
 	if err != nil {
@@ -99,7 +95,7 @@ func applyBundle(ctx context.Context, baseURL string, client *http.Client, bundl
 	}
 	defer os.Remove(tmpFile.Name()) //nolint:errcheck
 
-	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+	if _, err := io.Copy(tmpFile, body); err != nil {
 		_ = tmpFile.Close()
 		return errors.Wrap(err, "download bundle")
 	}
@@ -121,5 +117,17 @@ func applyBundle(ctx context.Context, baseURL string, client *http.Client, bundl
 		return errors.Wrapf(err, "git pull from bundle: %s", string(output))
 	}
 
+	return nil
+}
+
+// gitPullOrigin runs `git pull --ff-only` from the working clone's origin,
+// catching the working tree up to any commits made on the requested refs
+// after the bundle was generated. The clone's origin is the upstream URL,
+// so this respects the user's git insteadOf config to route through cachew.
+func gitPullOrigin(ctx context.Context, directory string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", directory, "pull", "--ff-only") //nolint:gosec
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "git pull: %s", string(output))
+	}
 	return nil
 }

--- a/cmd/cachew/git_test.go
+++ b/cmd/cachew/git_test.go
@@ -3,15 +3,20 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/client"
 )
 
 func initGitRepo(t *testing.T, dir string, files map[string]string) {
@@ -99,8 +104,8 @@ func TestGitRestoreSnapshot(t *testing.T) {
 		RepoURL:   "https://github.com/test/repo",
 		Directory: dstDir,
 	}
-	cli := &CLI{URL: srv.URL}
-	err := cmd.Run(context.Background(), cli, srv.Client())
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	err := cmd.Run(context.Background(), api)
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(dstDir, "hello.txt"))
@@ -159,8 +164,8 @@ func TestGitRestoreWithBundle(t *testing.T) {
 		RepoURL:   "https://github.com/test/repo",
 		Directory: dstDir,
 	}
-	cli := &CLI{URL: srv.URL}
-	err = restoreCmd.Run(context.Background(), cli, srv.Client())
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	err = restoreCmd.Run(context.Background(), api)
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(dstDir, "file.txt"))
@@ -202,8 +207,8 @@ func TestGitRestoreNoBundle(t *testing.T) {
 		Directory: dstDir,
 		NoBundle:  true,
 	}
-	cli := &CLI{URL: srv.URL}
-	err := restoreCmd.Run(context.Background(), cli, srv.Client())
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	err := restoreCmd.Run(context.Background(), api)
 	assert.NoError(t, err)
 	assert.False(t, bundleRequested)
 
@@ -223,10 +228,136 @@ func TestGitRestoreSnapshotNotFound(t *testing.T) {
 		RepoURL:   "https://github.com/test/repo",
 		Directory: dstDir,
 	}
-	cli := &CLI{URL: srv.URL}
-	err := restoreCmd.Run(context.Background(), cli, srv.Client())
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	err := restoreCmd.Run(context.Background(), api)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "status 404")
+	assert.Contains(t, err.Error(), "no snapshot available")
+}
+
+func TestGitRestoreWithRef(t *testing.T) {
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir, map[string]string{"file.txt": "v1"})
+	snapshotData := createTarZst(t, srcDir)
+
+	var ensureCalled atomic.Bool
+	var snapshotServedAt atomic.Int64
+	var ensurePayload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst"):
+			snapshotServedAt.Store(time.Now().UnixNano())
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Write(snapshotData) //nolint:errcheck
+
+		case strings.HasSuffix(r.URL.Path, "/ensure-refs"):
+			ensureCalled.Store(true)
+			if snapshotServedAt.Load() == 0 {
+				t.Error("ensure-refs must run after snapshot")
+			}
+			if r.Method != http.MethodPost {
+				t.Errorf("ensure-refs: want POST, got %s", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&ensurePayload); err != nil {
+				t.Errorf("decode ensure-refs body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"refs":    map[string]string{"refs/heads/main": "abc123"},
+				"fetched": true,
+			})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	restoreCmd := &GitRestoreCmd{
+		RepoURL:   "https://github.com/test/repo",
+		Directory: dstDir,
+		Ref:       map[string]string{"refs/heads/main": "abc123"},
+		NoBundle:  true,
+	}
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	// The restored snapshot has no origin remote, so the post-pull will fail.
+	// That's expected; we just want to verify ensure-refs ran after snapshot.
+	err := restoreCmd.Run(context.Background(), api)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "git pull")
+	assert.True(t, ensureCalled.Load())
+
+	refs, ok := ensurePayload["refs"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "abc123", refs["refs/heads/main"])
+}
+
+func TestGitRestorePullsFromOrigin(t *testing.T) {
+	// Build an "upstream" repo whose snapshot we serve, plus a bare clone of
+	// it that the working tree's origin will point at after restore. The
+	// upstream then gets an extra commit so we can verify that the post-
+	// restore `git pull` picks it up.
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	assert.NoError(t, os.MkdirAll(workDir, 0o755))
+	initGitRepo(t, workDir, map[string]string{"file.txt": "v1"})
+
+	bareDir := filepath.Join(tmpDir, "origin.git")
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		out, err := cmd.CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+	runGit("clone", "--bare", workDir, bareDir)
+
+	// Add an origin pointing at the bare clone so the post-restore pull has
+	// somewhere to fetch from.
+	runGit("-C", workDir, "remote", "add", "origin", bareDir)
+	// Track origin/main so `git pull` knows what to merge.
+	runGit("-C", workDir, "fetch", "origin")
+	runGit("-C", workDir, "branch", "--set-upstream-to=origin/main", "main")
+
+	snapshotData := createTarZst(t, workDir)
+
+	// Add a commit upstream that the snapshot doesn't have.
+	workDir2 := filepath.Join(tmpDir, "work2")
+	runGit("clone", bareDir, workDir2)
+	assert.NoError(t, os.WriteFile(filepath.Join(workDir2, "new.txt"), []byte("added"), 0o644))
+	runGit("-C", workDir2, "add", "-A")
+	runGit("-C", workDir2, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "add")
+	runGit("-C", workDir2, "push", "origin", "main")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst"):
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Write(snapshotData) //nolint:errcheck
+		case strings.HasSuffix(r.URL.Path, "/ensure-refs"):
+			w.Header().Set("Content-Type", "application/json")
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"refs": map[string]string{}, "fetched": false,
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	restoreCmd := &GitRestoreCmd{
+		RepoURL:   "https://github.com/test/repo",
+		Directory: dstDir,
+		Ref:       map[string]string{"refs/heads/main": ""},
+	}
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	assert.NoError(t, restoreCmd.Run(context.Background(), api))
+
+	// The post-restore pull from origin (= the bare repo) should have brought
+	// in the new.txt commit.
+	content, err := os.ReadFile(filepath.Join(dstDir, "new.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, "added", string(content))
 }
 
 func TestGitRestoreBundleFailureNonFatal(t *testing.T) {
@@ -256,8 +387,8 @@ func TestGitRestoreBundleFailureNonFatal(t *testing.T) {
 		RepoURL:   "https://github.com/test/repo",
 		Directory: dstDir,
 	}
-	cli := &CLI{URL: srv.URL}
-	err := restoreCmd.Run(context.Background(), cli, srv.Client())
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	err := restoreCmd.Run(context.Background(), api)
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(dstDir, "file.txt"))

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -672,6 +672,65 @@ func (r *Repository) EnsureRefsUpToDate(ctx context.Context) (needsFetch bool, e
 	return false, nil
 }
 
+// EnsureRefs guarantees the local mirror contains each ref in expect at the
+// given SHA. If a SHA is empty, it only requires the ref to exist. When a
+// requested ref does not match the local mirror, EnsureRefs synchronously
+// fetches from upstream once and then re-checks. The returned map contains
+// the resulting local SHAs for the requested refs (empty string if still
+// missing after fetch).
+//
+// This bypasses RefCheckInterval because callers are explicitly asserting
+// they require these refs to be fresh right now.
+func (r *Repository) EnsureRefs(ctx context.Context, expect map[string]string) (resolved map[string]string, fetched bool, err error) {
+	localRefs, err := r.GetLocalRefs(ctx)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "get local refs")
+	}
+
+	if refsSatisfied(localRefs, expect) {
+		return resolvedRefs(localRefs, expect), false, nil
+	}
+
+	if err := r.FetchWithTimeout(ctx, r.config.FetchTimeout); err != nil {
+		return nil, false, errors.Wrap(err, "fetch upstream")
+	}
+
+	// Invalidate the cached ref-check so the normal transparent path also
+	// re-evaluates after our forced fetch.
+	r.mu.Lock()
+	r.refCheckValid = false
+	r.mu.Unlock()
+
+	localRefs, err = r.GetLocalRefs(ctx)
+	if err != nil {
+		return nil, true, errors.Wrap(err, "get local refs after fetch")
+	}
+	return resolvedRefs(localRefs, expect), true, nil
+}
+
+// refsSatisfied reports whether every ref in expect is present in localRefs at
+// the expected SHA (or at any SHA when the expected SHA is empty).
+func refsSatisfied(localRefs, expect map[string]string) bool {
+	for ref, wantSHA := range expect {
+		localSHA, ok := localRefs[ref]
+		if !ok {
+			return false
+		}
+		if wantSHA != "" && localSHA != wantSHA {
+			return false
+		}
+	}
+	return true
+}
+
+func resolvedRefs(localRefs, expect map[string]string) map[string]string {
+	out := make(map[string]string, len(expect))
+	for ref := range expect {
+		out[ref] = localRefs[ref]
+	}
+	return out
+}
+
 func (r *Repository) GetLocalRefs(ctx context.Context) (map[string]string, error) {
 	var output []byte
 	var err error

--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -489,6 +489,75 @@ func TestRepository_HasCommit(t *testing.T) {
 	assert.False(t, repo.HasCommit(ctx, "v9.9.9"))
 }
 
+func TestRepository_EnsureRefs(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	upstreamPath := createBareRepo(t, tmpDir)
+
+	clonePath := filepath.Join(tmpDir, "clone")
+	repo := &Repository{
+		state:       StateEmpty,
+		config:      testRepoConfig(),
+		path:        clonePath,
+		upstreamURL: upstreamPath,
+		fetchSem:    make(chan struct{}, 1),
+	}
+	repo.fetchSem <- struct{}{}
+	assert.NoError(t, repo.Clone(ctx))
+
+	local, err := repo.GetLocalRefs(ctx)
+	assert.NoError(t, err)
+	mainSHA, ok := local["refs/heads/main"]
+	if !ok {
+		mainSHA = local["refs/heads/master"]
+	}
+	assert.NotEqual(t, "", mainSHA)
+
+	head := "refs/heads/main"
+	if !ok {
+		head = "refs/heads/master"
+	}
+
+	// Mirror already satisfies the request → no fetch.
+	resolved, fetched, err := repo.EnsureRefs(ctx, map[string]string{head: mainSHA})
+	assert.NoError(t, err)
+	assert.False(t, fetched)
+	assert.Equal(t, mainSHA, resolved[head])
+
+	// Add a new commit to upstream so the mirror is now behind.
+	workPath := filepath.Join(tmpDir, "work")
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "f.txt"), []byte("y"), 0o644))
+	for _, args := range [][]string{
+		{"git", "-C", workPath, "commit", "-am", "update"},
+		{"git", "-C", workPath, "push", upstreamPath, "HEAD:" + strings.TrimPrefix(head, "refs/heads/")},
+	} {
+		assert.NoError(t, exec.Command(args[0], args[1:]...).Run())
+	}
+
+	newSHAOut, err := exec.Command("git", "-C", workPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	newSHA := strings.TrimSpace(string(newSHAOut))
+	assert.NotEqual(t, mainSHA, newSHA)
+
+	// Asking for the new SHA triggers a fetch and the mirror catches up.
+	resolved, fetched, err = repo.EnsureRefs(ctx, map[string]string{head: newSHA})
+	assert.NoError(t, err)
+	assert.True(t, fetched)
+	assert.Equal(t, newSHA, resolved[head])
+
+	// Empty SHA means "any": already satisfied without fetching.
+	resolved, fetched, err = repo.EnsureRefs(ctx, map[string]string{head: ""})
+	assert.NoError(t, err)
+	assert.False(t, fetched)
+	assert.Equal(t, newSHA, resolved[head])
+
+	// Missing ref: fetch runs but ref remains missing → empty resolved SHA.
+	resolved, fetched, err = repo.EnsureRefs(ctx, map[string]string{"refs/heads/does-not-exist": ""})
+	assert.NoError(t, err)
+	assert.True(t, fetched)
+	assert.Equal(t, "", resolved["refs/heads/does-not-exist"])
+}
+
 // TestMirrorConfigAllowsUnreachableSHA verifies that the mirror config lets
 // git upload-pack serve objects that are present in the ODB but unreachable
 // from any ref (e.g. after a force-push orphans a commit).

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -272,6 +272,11 @@ func (s *Strategy) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	logger.DebugContext(ctx, "Git request", "method", r.Method, "host", host, "path", pathValue)
 
+	if strings.HasSuffix(pathValue, EnsureRefsPath) {
+		s.handleEnsureRefs(w, r, host, pathValue)
+		return
+	}
+
 	if strings.HasSuffix(pathValue, "/snapshot.tar.zst") {
 		s.metrics.recordRequest(ctx, "snapshot")
 		s.handleSnapshotRequest(w, r, host, pathValue)

--- a/internal/strategy/git/refs.go
+++ b/internal/strategy/git/refs.go
@@ -1,0 +1,91 @@
+package git
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/alecthomas/errors"
+
+	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/internal/logging"
+)
+
+// EnsureRefsPath is the URL suffix for the ref-freshness endpoint. Clients
+// POST to /git/{host}/{repo}/ensure-refs to force cachew to ensure the local
+// mirror contains the listed refs before they fetch.
+const EnsureRefsPath = "/ensure-refs"
+
+// EnsureRefsRequest is the JSON request body for POST .../ensure-refs.
+//
+// Refs maps each required ref (e.g. "refs/heads/main") to the expected SHA.
+// An empty SHA means "require the ref to exist, at any SHA".
+type EnsureRefsRequest struct {
+	Refs map[string]string `json:"refs"`
+}
+
+// EnsureRefsResponse is the JSON response body for POST .../ensure-refs.
+//
+// Refs contains the resolved local SHA for each requested ref (empty if the
+// ref is still missing after the fetch). Fetched reports whether an upstream
+// fetch was performed to satisfy the request.
+type EnsureRefsResponse struct {
+	Refs    map[string]string `json:"refs"`
+	Fetched bool              `json:"fetched"`
+}
+
+func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host, pathValue string) {
+	ctx := r.Context()
+	logger := logging.FromContext(ctx)
+
+	s.metrics.recordRequest(ctx, "ensure-refs")
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req EnsureRefsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(req.Refs) == 0 {
+		http.Error(w, "refs is required and must be non-empty", http.StatusBadRequest)
+		return
+	}
+
+	repoPath := strings.TrimSuffix(pathValue, EnsureRefsPath)
+	repoPath = strings.TrimSuffix(repoPath, ".git")
+	upstreamURL := "https://" + host + "/" + repoPath
+
+	repo, err := s.cloneManager.GetOrCreate(ctx, upstreamURL)
+	if err != nil {
+		logger.ErrorContext(ctx, "Failed to get or create clone", "error", err, "upstream", upstreamURL)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if repo.State() != gitclone.StateReady {
+		if err := s.ensureCloneReady(ctx, repo); err != nil {
+			logger.ErrorContext(ctx, "Clone not ready", "error", err, "upstream", upstreamURL)
+			http.Error(w, "clone not ready: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+	}
+
+	resolved, fetched, err := repo.EnsureRefs(ctx, req.Refs)
+	if err != nil {
+		logger.ErrorContext(ctx, "EnsureRefs failed", "error", errors.WithStack(err), "upstream", upstreamURL)
+		http.Error(w, "ensure refs: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	logger.DebugContext(ctx, "EnsureRefs completed", "upstream", upstreamURL,
+		"requested", len(req.Refs), "fetched", fetched)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(EnsureRefsResponse{Refs: resolved, Fetched: fetched}); err != nil {
+		logger.ErrorContext(ctx, "Failed to encode response", "error", err)
+	}
+}

--- a/internal/strategy/git/refs_test.go
+++ b/internal/strategy/git/refs_test.go
@@ -1,0 +1,114 @@
+package git_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/internal/githubapp"
+	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/strategy/git"
+)
+
+func TestEnsureRefsHandler(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+
+	// Build a bare upstream repo and a mirror clone of it. The mirror path
+	// must match what cachew derives from /git/local/repo.
+	upstreamPath := filepath.Join(tmpDir, "upstream.git")
+	workPath := filepath.Join(tmpDir, "work")
+	for _, args := range [][]string{
+		{"init", "--bare", upstreamPath},
+		{"clone", upstreamPath, workPath},
+		{"-C", workPath, "config", "user.email", "test@test.com"},
+		{"-C", workPath, "config", "user.name", "Test"},
+	} {
+		assert.NoError(t, exec.Command("git", args...).Run())
+	}
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "f.txt"), []byte("v1"), 0o644))
+	for _, args := range [][]string{
+		{"-C", workPath, "add", "."},
+		{"-C", workPath, "commit", "-m", "v1"},
+		{"-C", workPath, "push", "origin", "HEAD:main"},
+	} {
+		assert.NoError(t, exec.Command("git", args...).Run())
+	}
+
+	mirrorPath := filepath.Join(mirrorRoot, "local", "repo")
+	assert.NoError(t, exec.Command("git", "clone", "--mirror", upstreamPath, mirrorPath).Run())
+
+	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	mux := newTestMux()
+
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{MirrorRoot: mirrorRoot}, nil)
+	s, err := git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, cm,
+		func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+	waitForReady(t, s)
+
+	handler := mux.handlers["POST /git/{host}/{path...}"]
+	assert.NotZero(t, handler)
+
+	doRequest := func(refs map[string]string) (*httptest.ResponseRecorder, git.EnsureRefsResponse) {
+		body, err := json.Marshal(map[string]any{"refs": refs})
+		assert.NoError(t, err)
+		req := httptest.NewRequestWithContext(ctx, http.MethodPost,
+			"/git/local/repo/ensure-refs", bytes.NewReader(body))
+		req.SetPathValue("host", "local")
+		req.SetPathValue("path", "repo/ensure-refs")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		var resp git.EnsureRefsResponse
+		if w.Code == http.StatusOK {
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		}
+		return w, resp
+	}
+
+	// Fresh mirror already has main → no fetch.
+	w, resp := doRequest(map[string]string{"refs/heads/main": ""})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, resp.Fetched)
+	assert.NotEqual(t, "", resp.Refs["refs/heads/main"])
+
+	// Push a new commit upstream to make the mirror stale.
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "f.txt"), []byte("v2"), 0o644))
+	for _, args := range [][]string{
+		{"-C", workPath, "commit", "-am", "v2"},
+		{"-C", workPath, "push", "origin", "HEAD:main"},
+	} {
+		assert.NoError(t, exec.Command("git", args...).Run())
+	}
+	newSHAOut, err := exec.Command("git", "-C", workPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	newSHA := strings.TrimSpace(string(newSHAOut))
+
+	// Asking for the new SHA forces a fetch and returns the fresh value.
+	w, resp = doRequest(map[string]string{"refs/heads/main": newSHA})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, resp.Fetched)
+	assert.Equal(t, newSHA, resp.Refs["refs/heads/main"])
+
+	// Empty refs map → 400.
+	w, _ = doRequest(map[string]string{})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}


### PR DESCRIPTION
The git strategy rate-limits ls-remote against upstream via RefCheckInterval (default 10s), which can cause stale refs to be served. The git smart HTTP protocol has no clean way to express "ensure these refs are fresh" before the ref advertisement is served, so add a dedicated out-of-band endpoint.

POST /git/{host}/{path}/ensure-refs accepts a JSON map of required refs to expected SHAs (empty SHA means "any"). The server checks the local mirror, synchronously fetches once via the existing fetch semaphore if anything is missing or stale, and returns the resolved local SHAs along with whether a fetch ran. Cold mirrors are restored via the usual snapshot-or-clone path.

Client helpers (EnsureGitRefs, OpenGitSnapshot, OpenGitLFSSnapshot, OpenGitBundle) cover this endpoint plus the existing snapshot/bundle endpoints, and cachew git restore now uses them.

cachew git restore gains a --ref name=sha flag. When set, after the snapshot+bundle restore it calls /ensure-refs and then runs git pull --ff-only from origin, so the working tree is brought up to upstream's current tip on those refs. Without --ref the working tree is left at whatever the bundle (which can be cached and stale) brought it to.