### PR TITLE
feat(cli): skip redundant /ensure-refs and pull in cachew git restore

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,7 @@ _help:
 
 # Run tests
 test:
-    gotestsum --hide-summary skipped --format-hide-empty-pkg ${CI:+--format=github-actions} ./... ${CI:+--tags=integration} -race -timeout 60s
+    gotestsum --hide-summary skipped --format-hide-empty-pkg ${CI:+--format=github-actions} ./... ${CI:+--tags=integration} -race -timeout 180s
 
 # Lint code
 lint:

--- a/cmd/cachew/git.go
+++ b/cmd/cachew/git.go
@@ -62,24 +62,75 @@ func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
 	// Snapshot + bundle leave the working tree at whatever the mirror had
 	// when the bundle was last generated, which may be arbitrarily old. If
 	// the caller asked for specific refs to be fresh, freshen the mirror
-	// and then pull from origin to catch the working tree up.
+	// (if needed) and pull from origin (if needed) to catch up.
 	if len(c.Ref) > 0 {
-		fmt.Fprintf(os.Stderr, "Ensuring %d ref(s) are fresh for %s\n", len(c.Ref), c.RepoURL) //nolint:forbidigo
-		resp, err := api.EnsureGitRefs(ctx, c.RepoURL, c.Ref)
-		if err != nil {
-			return errors.Wrap(err, "ensure refs")
-		}
-		if resp.Fetched {
-			fmt.Fprintf(os.Stderr, "Server fetched fresh refs from upstream\n") //nolint:forbidigo
-		}
-
-		fmt.Fprintf(os.Stderr, "Pulling from origin...\n") //nolint:forbidigo
-		if err := gitPullOrigin(ctx, c.Directory); err != nil {
-			return errors.Wrap(err, "git pull from origin")
+		if err := c.satisfyRefs(ctx, api); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// satisfyRefs ensures the working tree contains every requested ref. It
+// short-circuits whenever the local clone already has what was asked for,
+// avoiding both /ensure-refs and git pull when the snapshot+bundle already
+// brought down the requested SHAs.
+func (c *GitRestoreCmd) satisfyRefs(ctx context.Context, api *client.Client) error {
+	// Fast path: if every ref is pinned to a specific SHA and the local
+	// clone already has all those commits, we're done.
+	if allPinned(c.Ref) && localHasAllCommits(ctx, c.Directory, c.Ref) {
+		fmt.Fprintf(os.Stderr, "All requested refs already present locally\n") //nolint:forbidigo
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Ensuring %d ref(s) are fresh for %s\n", len(c.Ref), c.RepoURL) //nolint:forbidigo
+	resp, err := api.EnsureGitRefs(ctx, c.RepoURL, c.Ref)
+	if err != nil {
+		return errors.Wrap(err, "ensure refs")
+	}
+	if resp.Fetched {
+		fmt.Fprintf(os.Stderr, "Server fetched fresh refs from upstream\n") //nolint:forbidigo
+	}
+
+	// If the server's resolved SHAs are already in our local clone (e.g.
+	// the bundle brought them in), there's nothing new to pull.
+	if len(resp.Refs) > 0 && localHasAllCommits(ctx, c.Directory, resp.Refs) {
+		fmt.Fprintf(os.Stderr, "Local clone already contains the server's resolved refs\n") //nolint:forbidigo
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Pulling from origin...\n") //nolint:forbidigo
+	if err := gitPullOrigin(ctx, c.Directory); err != nil {
+		return errors.Wrap(err, "git pull from origin")
+	}
+	return nil
+}
+
+// allPinned reports whether every entry in refs has a non-empty SHA.
+func allPinned(refs map[string]string) bool {
+	for _, sha := range refs {
+		if sha == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// localHasAllCommits reports whether every non-empty SHA in refs exists in
+// the working clone's object database. Refs with empty SHAs cause it to
+// return false, since there's no SHA to look for.
+func localHasAllCommits(ctx context.Context, directory string, refs map[string]string) bool {
+	for _, sha := range refs {
+		if sha == "" {
+			return false
+		}
+		// #nosec G204 - directory and sha are controlled by us
+		if err := exec.CommandContext(ctx, "git", "-C", directory, "cat-file", "-e", sha).Run(); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func applyBundle(ctx context.Context, api *client.Client, bundleURL, directory string) error {

--- a/cmd/cachew/git_test.go
+++ b/cmd/cachew/git_test.go
@@ -292,6 +292,83 @@ func TestGitRestoreWithRef(t *testing.T) {
 	assert.Equal(t, "abc123", refs["refs/heads/main"])
 }
 
+func TestGitRestoreSkipsEnsureRefsWhenLocalHasSHA(t *testing.T) {
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir, map[string]string{"file.txt": "v1"})
+	localSHA := gitRevParse(t, srcDir, "HEAD")
+
+	snapshotData := createTarZst(t, srcDir)
+
+	var ensureCalled atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst"):
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Write(snapshotData) //nolint:errcheck
+
+		case strings.HasSuffix(r.URL.Path, "/ensure-refs"):
+			ensureCalled.Store(true)
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	restoreCmd := &GitRestoreCmd{
+		RepoURL:   "https://github.com/test/repo",
+		Directory: dstDir,
+		Ref:       map[string]string{"refs/heads/main": localSHA},
+		NoBundle:  true,
+	}
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	assert.NoError(t, restoreCmd.Run(context.Background(), api))
+	assert.False(t, ensureCalled.Load(), "ensure-refs should be skipped when local clone has the requested SHA")
+}
+
+func TestGitRestoreSkipsPullWhenLocalHasResolvedSHA(t *testing.T) {
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir, map[string]string{"file.txt": "v1"})
+	localSHA := gitRevParse(t, srcDir, "HEAD")
+
+	snapshotData := createTarZst(t, srcDir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst"):
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Write(snapshotData) //nolint:errcheck
+
+		case strings.HasSuffix(r.URL.Path, "/ensure-refs"):
+			// Resolve the unpinned ref to the SHA the local clone already has.
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"refs":    map[string]string{"refs/heads/main": localSHA},
+				"fetched": false,
+			})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	restoreCmd := &GitRestoreCmd{
+		RepoURL:   "https://github.com/test/repo",
+		Directory: dstDir,
+		Ref:       map[string]string{"refs/heads/main": ""}, // unpinned
+		NoBundle:  true,
+	}
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	// The snapshot has no origin remote, so a real pull would fail. The test
+	// passes only if pull is skipped because the server's resolved SHA is
+	// already in the local clone.
+	assert.NoError(t, restoreCmd.Run(context.Background(), api))
+}
+
 func TestGitRestorePullsFromOrigin(t *testing.T) {
 	// Build an "upstream" repo whose snapshot we serve, plus a bare clone of
 	// it that the working tree's origin will point at after restore. The


### PR DESCRIPTION
Previously, passing --ref always called /ensure-refs and ran git pull from origin even when the snapshot+bundle had already brought the requested SHAs down locally.

Now restore first checks the local clone. If every --ref entry is pinned to a specific SHA and all of those commits already exist in the working clone, both /ensure-refs and the pull are skipped. After /ensure-refs, if the server's resolved SHAs are already present locally (e.g. the bundle covered them) the pull is also skipped.
