### PR TITLE
feat(git): support commit-set in /ensure-refs

### DIFF
--- a/client/git.go
+++ b/client/git.go
@@ -25,33 +25,45 @@ const SnapshotCommitHeader = "X-Cachew-Snapshot-Commit"
 // mirror's current HEAD.
 const BundleURLHeader = "X-Cachew-Bundle-Url"
 
+// EnsureGitRefsRequest specifies what the caller wants present on the
+// server's mirror. At least one of Refs or Commits must be non-empty.
+//
+// Refs maps each required ref (e.g. "refs/heads/main") to the expected SHA;
+// an empty SHA means "require the ref to exist at any SHA". Commits lists
+// individual commit SHAs that must exist in the mirror's object database,
+// regardless of which ref points at them.
+type EnsureGitRefsRequest struct {
+	Refs    map[string]string `json:"refs,omitempty"`
+	Commits []string          `json:"commits,omitempty"`
+}
+
 // EnsureGitRefsResponse is the response returned by EnsureGitRefs.
 //
 // Refs contains the resolved local SHA for each requested ref (empty if the
-// ref is still missing on the server after the fetch). Fetched reports
-// whether the server performed an upstream fetch to satisfy the request.
+// ref is still missing on the server after the fetch). MissingCommits lists
+// the requested commits that are still absent from the server's object
+// database. Fetched reports whether the server performed an upstream fetch.
 type EnsureGitRefsResponse struct {
-	Refs    map[string]string `json:"refs"`
-	Fetched bool              `json:"fetched"`
+	Refs           map[string]string `json:"refs,omitempty"`
+	MissingCommits []string          `json:"missing_commits,omitempty"`
+	Fetched        bool              `json:"fetched"`
 }
 
 // EnsureGitRefs asks the cachew server to ensure its local mirror of repoURL
-// contains the listed refs at the given SHAs before the caller fetches. An
-// empty SHA means "require the ref to exist, at any SHA". The server will
-// synchronously fetch from upstream if any requested ref is missing or stale.
+// satisfies the request before the caller fetches. The server synchronously
+// fetches from upstream if any requested ref is missing/stale or any
+// requested commit is absent from its object database.
 //
 // Use this before issuing a git fetch/clone against cachew when fresh refs
-// are required and the default ref-check rate-limit window would otherwise
-// allow stale refs to be served.
-func (c *Client) EnsureGitRefs(ctx context.Context, repoURL string, refs map[string]string) (EnsureGitRefsResponse, error) {
+// or specific commits are required and the default ref-check rate-limit
+// window would otherwise allow stale data to be served.
+func (c *Client) EnsureGitRefs(ctx context.Context, repoURL string, request EnsureGitRefsRequest) (EnsureGitRefsResponse, error) {
 	endpoint, err := gitEndpointURL(c.baseURL, repoURL, "ensure-refs")
 	if err != nil {
 		return EnsureGitRefsResponse{}, err
 	}
 
-	body, err := json.Marshal(struct {
-		Refs map[string]string `json:"refs"`
-	}{Refs: refs})
+	body, err := json.Marshal(request)
 	if err != nil {
 		return EnsureGitRefsResponse{}, errors.Wrap(err, "encode request")
 	}

--- a/client/git_test.go
+++ b/client/git_test.go
@@ -24,8 +24,9 @@ func TestEnsureGitRefs(t *testing.T) {
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&receivedBody))
 		w.Header().Set("Content-Type", "application/json")
 		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
-			"refs":    map[string]string{"refs/heads/main": "abc123"},
-			"fetched": true,
+			"refs":            map[string]string{"refs/heads/main": "abc123"},
+			"missing_commits": []string{"deadbeef"},
+			"fetched":         true,
 		}))
 	}))
 	defer srv.Close()
@@ -33,14 +34,45 @@ func TestEnsureGitRefs(t *testing.T) {
 	api := client.NewWithHTTPClient(srv.URL, srv.Client())
 	resp, err := api.EnsureGitRefs(context.Background(),
 		"https://github.com/org/repo",
-		map[string]string{"refs/heads/main": ""})
+		client.EnsureGitRefsRequest{
+			Refs:    map[string]string{"refs/heads/main": ""},
+			Commits: []string{"abc", "deadbeef"},
+		})
 	assert.NoError(t, err)
 	assert.True(t, resp.Fetched)
 	assert.Equal(t, "abc123", resp.Refs["refs/heads/main"])
+	assert.Equal(t, []string{"deadbeef"}, resp.MissingCommits)
 
 	refs, ok := receivedBody["refs"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "", refs["refs/heads/main"])
+
+	commits, ok := receivedBody["commits"].([]any)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(commits))
+}
+
+func TestEnsureGitRefsCommitsOnly(t *testing.T) {
+	var receivedBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&receivedBody))
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"fetched": false,
+		}))
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	resp, err := api.EnsureGitRefs(context.Background(),
+		"https://github.com/org/repo",
+		client.EnsureGitRefsRequest{Commits: []string{"abc"}})
+	assert.NoError(t, err)
+	assert.False(t, resp.Fetched)
+	assert.Equal(t, 0, len(resp.MissingCommits))
+
+	_, ok := receivedBody["refs"]
+	assert.False(t, ok, "refs field should be omitted when empty")
 }
 
 func TestEnsureGitRefsServerError(t *testing.T) {
@@ -52,7 +84,7 @@ func TestEnsureGitRefsServerError(t *testing.T) {
 	api := client.NewWithHTTPClient(srv.URL, srv.Client())
 	_, err := api.EnsureGitRefs(context.Background(),
 		"https://github.com/org/repo",
-		map[string]string{"refs/heads/main": ""})
+		client.EnsureGitRefsRequest{Refs: map[string]string{"refs/heads/main": ""}})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "status 400")
 }
@@ -60,10 +92,10 @@ func TestEnsureGitRefsServerError(t *testing.T) {
 func TestEnsureGitRefsInvalidRepoURL(t *testing.T) {
 	api := client.New("http://example.com", nil)
 
-	_, err := api.EnsureGitRefs(context.Background(), "not-a-url", nil)
+	_, err := api.EnsureGitRefs(context.Background(), "not-a-url", client.EnsureGitRefsRequest{})
 	assert.Error(t, err)
 
-	_, err = api.EnsureGitRefs(context.Background(), "https://github.com/", nil)
+	_, err = api.EnsureGitRefs(context.Background(), "https://github.com/", client.EnsureGitRefsRequest{})
 	assert.Error(t, err)
 }
 

--- a/cmd/cachew/git.go
+++ b/cmd/cachew/git.go
@@ -21,13 +21,14 @@ type GitCmd struct {
 }
 
 // GitRestoreCmd fetches a git snapshot, extracts it, and optionally applies
-// a delta bundle. If --ref is set it then asks the server to ensure those
-// refs are fresh and runs `git pull --ff-only` so the working tree catches
-// up to upstream.
+// a delta bundle. If --ref or --commit is set it then asks the server to
+// ensure those refs/commits are fresh and runs `git pull --ff-only` so the
+// working tree catches up to upstream.
 type GitRestoreCmd struct {
 	RepoURL     string            `arg:"" help:"Repository URL (e.g. https://github.com/org/repo)."`
 	Directory   string            `arg:"" help:"Target directory for the clone." type:"path"`
-	Ref         map[string]string `help:"Required refs to freshen on the server before pulling, in the form 'name=sha' (e.g. 'refs/heads/main=abc123'). An empty SHA means any SHA is acceptable. Setting this also runs a final 'git pull' from origin so the working tree is brought up to date."`
+	Ref         map[string]string `help:"Required refs to freshen on the server before pulling, in the form 'name=sha' (e.g. 'refs/heads/main=abc123'). An empty SHA means any SHA is acceptable. Setting this (or --commit) runs a final 'git pull' from origin so the working tree is brought up to date."`
+	Commit      []string          `help:"Required commit SHAs that must exist on the server, regardless of which ref points at them. May be repeated."`
 	NoBundle    bool              `help:"Skip applying delta bundle."`
 	ZstdThreads int               `help:"Threads for zstd decompression (0 = all CPU cores)." default:"0"`
 }
@@ -61,9 +62,9 @@ func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
 
 	// Snapshot + bundle leave the working tree at whatever the mirror had
 	// when the bundle was last generated, which may be arbitrarily old. If
-	// the caller asked for specific refs to be fresh, freshen the mirror
-	// (if needed) and pull from origin (if needed) to catch up.
-	if len(c.Ref) > 0 {
+	// the caller asked for specific refs or commits to be fresh, freshen
+	// the mirror (if needed) and pull from origin (if needed) to catch up.
+	if len(c.Ref) > 0 || len(c.Commit) > 0 {
 		if err := c.satisfyRefs(ctx, api); err != nil {
 			return err
 		}
@@ -72,31 +73,47 @@ func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
 	return nil
 }
 
-// satisfyRefs ensures the working tree contains every requested ref. It
-// short-circuits whenever the local clone already has what was asked for,
-// avoiding both /ensure-refs and git pull when the snapshot+bundle already
-// brought down the requested SHAs.
+// satisfyRefs ensures the working tree contains every requested ref and
+// commit. It short-circuits whenever the local clone already has what was
+// asked for, avoiding both /ensure-refs and git pull when the snapshot+bundle
+// already brought down the required SHAs.
 func (c *GitRestoreCmd) satisfyRefs(ctx context.Context, api *client.Client) error {
-	// Fast path: if every ref is pinned to a specific SHA and the local
-	// clone already has all those commits, we're done.
-	if allPinned(c.Ref) && localHasAllCommits(ctx, c.Directory, c.Ref) {
-		fmt.Fprintf(os.Stderr, "All requested refs already present locally\n") //nolint:forbidigo
+	// Fast path: if every ref is pinned and the local clone has every ref
+	// SHA and every requested commit, we're done.
+	if allPinned(c.Ref) &&
+		localHasAllRefSHAs(ctx, c.Directory, c.Ref) &&
+		localHasAllSHAs(ctx, c.Directory, c.Commit) {
+		fmt.Fprintf(os.Stderr, "All requested refs/commits already present locally\n") //nolint:forbidigo
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "Ensuring %d ref(s) are fresh for %s\n", len(c.Ref), c.RepoURL) //nolint:forbidigo
-	resp, err := api.EnsureGitRefs(ctx, c.RepoURL, c.Ref)
+	fmt.Fprintf(os.Stderr, "Ensuring %d ref(s) and %d commit(s) are fresh for %s\n", //nolint:forbidigo
+		len(c.Ref), len(c.Commit), c.RepoURL)
+	resp, err := api.EnsureGitRefs(ctx, c.RepoURL, client.EnsureGitRefsRequest{
+		Refs:    c.Ref,
+		Commits: c.Commit,
+	})
 	if err != nil {
 		return errors.Wrap(err, "ensure refs")
 	}
 	if resp.Fetched {
 		fmt.Fprintf(os.Stderr, "Server fetched fresh refs from upstream\n") //nolint:forbidigo
 	}
+	if len(resp.MissingCommits) > 0 {
+		return errors.Errorf("server is missing %d commit(s) after fetch: %v",
+			len(resp.MissingCommits), resp.MissingCommits)
+	}
 
-	// If the server's resolved SHAs are already in our local clone (e.g.
-	// the bundle brought them in), there's nothing new to pull.
-	if len(resp.Refs) > 0 && localHasAllCommits(ctx, c.Directory, resp.Refs) {
-		fmt.Fprintf(os.Stderr, "Local clone already contains the server's resolved refs\n") //nolint:forbidigo
+	// If the server's resolved SHAs and all requested commits are already
+	// in our local clone (e.g. the bundle brought them in), there's nothing
+	// new to pull. We only treat refs as "satisfied" when the server
+	// actually resolved them; an empty resp.Refs (e.g. unknown ref) leaves
+	// us no positive evidence, so fall through to the pull.
+	refsSatisfied := len(c.Ref) == 0 ||
+		(len(resp.Refs) == len(c.Ref) && localHasAllRefSHAs(ctx, c.Directory, resp.Refs))
+	commitsSatisfied := localHasAllSHAs(ctx, c.Directory, c.Commit)
+	if refsSatisfied && commitsSatisfied {
+		fmt.Fprintf(os.Stderr, "Local clone already contains the server's resolved refs and commits\n") //nolint:forbidigo
 		return nil
 	}
 
@@ -117,20 +134,36 @@ func allPinned(refs map[string]string) bool {
 	return true
 }
 
-// localHasAllCommits reports whether every non-empty SHA in refs exists in
-// the working clone's object database. Refs with empty SHAs cause it to
-// return false, since there's no SHA to look for.
-func localHasAllCommits(ctx context.Context, directory string, refs map[string]string) bool {
+// localHasAllRefSHAs reports whether every non-empty SHA in refs exists in
+// the working clone's object database. An empty refs map returns true
+// (nothing to check); a ref with an empty SHA causes it to return false
+// because we don't know what to look for.
+func localHasAllRefSHAs(ctx context.Context, directory string, refs map[string]string) bool {
 	for _, sha := range refs {
 		if sha == "" {
 			return false
 		}
-		// #nosec G204 - directory and sha are controlled by us
-		if err := exec.CommandContext(ctx, "git", "-C", directory, "cat-file", "-e", sha).Run(); err != nil {
+		if !localHasSHA(ctx, directory, sha) {
 			return false
 		}
 	}
 	return true
+}
+
+// localHasAllSHAs reports whether every commit SHA exists in the working
+// clone's object database. An empty slice returns true.
+func localHasAllSHAs(ctx context.Context, directory string, shas []string) bool {
+	for _, sha := range shas {
+		if !localHasSHA(ctx, directory, sha) {
+			return false
+		}
+	}
+	return true
+}
+
+func localHasSHA(ctx context.Context, directory, sha string) bool {
+	// #nosec G204 - directory and sha are controlled by us
+	return exec.CommandContext(ctx, "git", "-C", directory, "cat-file", "-e", sha).Run() == nil
 }
 
 func applyBundle(ctx context.Context, api *client.Client, bundleURL, directory string) error {

--- a/cmd/cachew/git_test.go
+++ b/cmd/cachew/git_test.go
@@ -60,7 +60,7 @@ func createTarZst(t *testing.T, dir string) []byte {
 	return buf.Bytes()
 }
 
-func gitRevParse(t *testing.T, dir, ref string) string {
+func gitRevParse(t *testing.T, dir, ref string) string { //nolint:unparam // helper accepts any ref
 	t.Helper()
 	out, err := exec.Command("git", "-C", dir, "rev-parse", ref).Output() //nolint:gosec
 	assert.NoError(t, err)
@@ -326,6 +326,80 @@ func TestGitRestoreSkipsEnsureRefsWhenLocalHasSHA(t *testing.T) {
 	api := client.NewWithHTTPClient(srv.URL, srv.Client())
 	assert.NoError(t, restoreCmd.Run(context.Background(), api))
 	assert.False(t, ensureCalled.Load(), "ensure-refs should be skipped when local clone has the requested SHA")
+}
+
+func TestGitRestoreSkipsEnsureRefsWhenLocalHasCommit(t *testing.T) {
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir, map[string]string{"file.txt": "v1"})
+	localSHA := gitRevParse(t, srcDir, "HEAD")
+
+	snapshotData := createTarZst(t, srcDir)
+
+	var ensureCalled atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst"):
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Write(snapshotData) //nolint:errcheck
+
+		case strings.HasSuffix(r.URL.Path, "/ensure-refs"):
+			ensureCalled.Store(true)
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	restoreCmd := &GitRestoreCmd{
+		RepoURL:   "https://github.com/test/repo",
+		Directory: dstDir,
+		Commit:    []string{localSHA},
+		NoBundle:  true,
+	}
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	assert.NoError(t, restoreCmd.Run(context.Background(), api))
+	assert.False(t, ensureCalled.Load(), "ensure-refs should be skipped when local clone has the requested commit")
+}
+
+func TestGitRestoreCommitMissingAfterFetchIsFatal(t *testing.T) {
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir, map[string]string{"file.txt": "v1"})
+	snapshotData := createTarZst(t, srcDir)
+	missingSHA := "0000000000000000000000000000000000000000"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst"):
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Write(snapshotData) //nolint:errcheck
+
+		case strings.HasSuffix(r.URL.Path, "/ensure-refs"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"missing_commits": []string{missingSHA},
+				"fetched":         true,
+			})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	restoreCmd := &GitRestoreCmd{
+		RepoURL:   "https://github.com/test/repo",
+		Directory: dstDir,
+		Commit:    []string{missingSHA},
+		NoBundle:  true,
+	}
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	err := restoreCmd.Run(context.Background(), api)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "server is missing")
 }
 
 func TestGitRestoreSkipsPullWhenLocalHasResolvedSHA(t *testing.T) {

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -672,27 +672,36 @@ func (r *Repository) EnsureRefsUpToDate(ctx context.Context) (needsFetch bool, e
 	return false, nil
 }
 
-// EnsureRefs guarantees the local mirror contains each ref in expect at the
-// given SHA. If a SHA is empty, it only requires the ref to exist. When a
-// requested ref does not match the local mirror, EnsureRefs synchronously
-// fetches from upstream once and then re-checks. The returned map contains
-// the resulting local SHAs for the requested refs (empty string if still
-// missing after fetch).
+// EnsureRefs guarantees the local mirror satisfies the caller's freshness
+// requirements. A ref entry is satisfied when the local mirror has the ref
+// at the given SHA (or any SHA, if the value is empty). A commit entry is
+// satisfied when the commit exists in the local object database, regardless
+// of which ref points at it. If anything is unsatisfied, EnsureRefs
+// synchronously fetches from upstream once and then re-checks.
+//
+// Resolved maps each requested ref to its current local SHA (empty if the
+// ref is still missing after the fetch). MissingCommits lists requested
+// commits that still are not present locally after the fetch.
 //
 // This bypasses RefCheckInterval because callers are explicitly asserting
-// they require these refs to be fresh right now.
-func (r *Repository) EnsureRefs(ctx context.Context, expect map[string]string) (resolved map[string]string, fetched bool, err error) {
+// they require these refs/commits to be fresh right now.
+func (r *Repository) EnsureRefs(
+	ctx context.Context, refs map[string]string, commits []string,
+) (resolved map[string]string, missingCommits []string, fetched bool, err error) {
 	localRefs, err := r.GetLocalRefs(ctx)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "get local refs")
+		return nil, nil, false, errors.Wrap(err, "get local refs")
 	}
 
-	if refsSatisfied(localRefs, expect) {
-		return resolvedRefs(localRefs, expect), false, nil
+	if refsSatisfied(localRefs, refs) {
+		missing := r.missingCommitsLocked(ctx, commits)
+		if len(missing) == 0 {
+			return resolvedRefs(localRefs, refs), nil, false, nil
+		}
 	}
 
 	if err := r.FetchWithTimeout(ctx, r.config.FetchTimeout); err != nil {
-		return nil, false, errors.Wrap(err, "fetch upstream")
+		return nil, nil, false, errors.Wrap(err, "fetch upstream")
 	}
 
 	// Invalidate the cached ref-check so the normal transparent path also
@@ -703,9 +712,32 @@ func (r *Repository) EnsureRefs(ctx context.Context, expect map[string]string) (
 
 	localRefs, err = r.GetLocalRefs(ctx)
 	if err != nil {
-		return nil, true, errors.Wrap(err, "get local refs after fetch")
+		return nil, nil, true, errors.Wrap(err, "get local refs after fetch")
 	}
-	return resolvedRefs(localRefs, expect), true, nil
+	return resolvedRefs(localRefs, refs), r.missingCommitsLocked(ctx, commits), true, nil
+}
+
+// missingCommitsLocked returns the subset of commits that are absent from
+// the local object database. It takes the repository's read lock to stay
+// consistent with concurrent fetches.
+func (r *Repository) missingCommitsLocked(ctx context.Context, commits []string) []string {
+	if len(commits) == 0 {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var missing []string
+	for _, sha := range commits {
+		if sha == "" {
+			continue
+		}
+		// #nosec G204 - r.path and sha are controlled by us
+		cmd := exec.CommandContext(ctx, "git", "-C", r.path, "cat-file", "-e", sha)
+		if err := cmd.Run(); err != nil {
+			missing = append(missing, sha)
+		}
+	}
+	return missing
 }
 
 // refsSatisfied reports whether every ref in expect is present in localRefs at
@@ -724,6 +756,9 @@ func refsSatisfied(localRefs, expect map[string]string) bool {
 }
 
 func resolvedRefs(localRefs, expect map[string]string) map[string]string {
+	if len(expect) == 0 {
+		return nil
+	}
 	out := make(map[string]string, len(expect))
 	for ref := range expect {
 		out[ref] = localRefs[ref]

--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -519,9 +519,10 @@ func TestRepository_EnsureRefs(t *testing.T) {
 	}
 
 	// Mirror already satisfies the request → no fetch.
-	resolved, fetched, err := repo.EnsureRefs(ctx, map[string]string{head: mainSHA})
+	resolved, missing, fetched, err := repo.EnsureRefs(ctx, map[string]string{head: mainSHA}, nil)
 	assert.NoError(t, err)
 	assert.False(t, fetched)
+	assert.Equal(t, 0, len(missing))
 	assert.Equal(t, mainSHA, resolved[head])
 
 	// Add a new commit to upstream so the mirror is now behind.
@@ -540,22 +541,46 @@ func TestRepository_EnsureRefs(t *testing.T) {
 	assert.NotEqual(t, mainSHA, newSHA)
 
 	// Asking for the new SHA triggers a fetch and the mirror catches up.
-	resolved, fetched, err = repo.EnsureRefs(ctx, map[string]string{head: newSHA})
+	resolved, missing, fetched, err = repo.EnsureRefs(ctx, map[string]string{head: newSHA}, nil)
 	assert.NoError(t, err)
 	assert.True(t, fetched)
+	assert.Equal(t, 0, len(missing))
 	assert.Equal(t, newSHA, resolved[head])
 
 	// Empty SHA means "any": already satisfied without fetching.
-	resolved, fetched, err = repo.EnsureRefs(ctx, map[string]string{head: ""})
+	resolved, _, fetched, err = repo.EnsureRefs(ctx, map[string]string{head: ""}, nil)
 	assert.NoError(t, err)
 	assert.False(t, fetched)
 	assert.Equal(t, newSHA, resolved[head])
 
 	// Missing ref: fetch runs but ref remains missing → empty resolved SHA.
-	resolved, fetched, err = repo.EnsureRefs(ctx, map[string]string{"refs/heads/does-not-exist": ""})
+	resolved, _, fetched, err = repo.EnsureRefs(ctx, map[string]string{"refs/heads/does-not-exist": ""}, nil)
 	assert.NoError(t, err)
 	assert.True(t, fetched)
 	assert.Equal(t, "", resolved["refs/heads/does-not-exist"])
+
+	// Commit-only request that's already present → no fetch.
+	resolved, missing, fetched, err = repo.EnsureRefs(ctx, nil, []string{newSHA})
+	assert.NoError(t, err)
+	assert.False(t, fetched)
+	assert.Equal(t, 0, len(missing))
+	assert.Equal(t, 0, len(resolved))
+
+	// Commit-only request that's missing → fetch runs and commit is reported missing.
+	resolved, missing, fetched, err = repo.EnsureRefs(ctx, nil,
+		[]string{"0000000000000000000000000000000000000000"})
+	assert.NoError(t, err)
+	assert.True(t, fetched)
+	assert.Equal(t, []string{"0000000000000000000000000000000000000000"}, missing)
+	assert.Equal(t, 0, len(resolved))
+
+	// Mixed request, both already satisfied.
+	resolved, missing, fetched, err = repo.EnsureRefs(ctx,
+		map[string]string{head: newSHA}, []string{newSHA})
+	assert.NoError(t, err)
+	assert.False(t, fetched)
+	assert.Equal(t, 0, len(missing))
+	assert.Equal(t, newSHA, resolved[head])
 }
 
 // TestMirrorConfigAllowsUnreachableSHA verifies that the mirror config lets

--- a/internal/strategy/git/refs.go
+++ b/internal/strategy/git/refs.go
@@ -16,22 +16,29 @@ import (
 // mirror contains the listed refs before they fetch.
 const EnsureRefsPath = "/ensure-refs"
 
-// EnsureRefsRequest is the JSON request body for POST .../ensure-refs.
+// EnsureRefsRequest is the JSON request body for POST .../ensure-refs. At
+// least one of Refs or Commits must be non-empty.
 //
 // Refs maps each required ref (e.g. "refs/heads/main") to the expected SHA.
 // An empty SHA means "require the ref to exist, at any SHA".
+//
+// Commits lists individual commit SHAs that must exist in the mirror's
+// object database, regardless of which ref points at them.
 type EnsureRefsRequest struct {
-	Refs map[string]string `json:"refs"`
+	Refs    map[string]string `json:"refs,omitempty"`
+	Commits []string          `json:"commits,omitempty"`
 }
 
 // EnsureRefsResponse is the JSON response body for POST .../ensure-refs.
 //
 // Refs contains the resolved local SHA for each requested ref (empty if the
-// ref is still missing after the fetch). Fetched reports whether an upstream
-// fetch was performed to satisfy the request.
+// ref is still missing after the fetch). MissingCommits lists the requested
+// commits that are still absent from the local object database after the
+// fetch. Fetched reports whether an upstream fetch was performed.
 type EnsureRefsResponse struct {
-	Refs    map[string]string `json:"refs"`
-	Fetched bool              `json:"fetched"`
+	Refs           map[string]string `json:"refs,omitempty"`
+	MissingCommits []string          `json:"missing_commits,omitempty"`
+	Fetched        bool              `json:"fetched"`
 }
 
 func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host, pathValue string) {
@@ -50,8 +57,8 @@ func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host
 		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if len(req.Refs) == 0 {
-		http.Error(w, "refs is required and must be non-empty", http.StatusBadRequest)
+	if len(req.Refs) == 0 && len(req.Commits) == 0 {
+		http.Error(w, "at least one of refs or commits must be provided", http.StatusBadRequest)
 		return
 	}
 
@@ -74,7 +81,7 @@ func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host
 		}
 	}
 
-	resolved, fetched, err := repo.EnsureRefs(ctx, req.Refs)
+	resolved, missingCommits, fetched, err := repo.EnsureRefs(ctx, req.Refs, req.Commits)
 	if err != nil {
 		logger.ErrorContext(ctx, "EnsureRefs failed", "error", errors.WithStack(err), "upstream", upstreamURL)
 		http.Error(w, "ensure refs: "+err.Error(), http.StatusBadGateway)
@@ -82,10 +89,12 @@ func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host
 	}
 
 	logger.DebugContext(ctx, "EnsureRefs completed", "upstream", upstreamURL,
-		"requested", len(req.Refs), "fetched", fetched)
+		"requested_refs", len(req.Refs), "requested_commits", len(req.Commits),
+		"missing_commits", len(missingCommits), "fetched", fetched)
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(EnsureRefsResponse{Refs: resolved, Fetched: fetched}); err != nil {
+	resp := EnsureRefsResponse{Refs: resolved, MissingCommits: missingCommits, Fetched: fetched}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		logger.ErrorContext(ctx, "Failed to encode response", "error", err)
 	}
 }

--- a/internal/strategy/git/refs_test.go
+++ b/internal/strategy/git/refs_test.go
@@ -68,11 +68,11 @@ func TestEnsureRefsHandler(t *testing.T) {
 	handler := mux.handlers["POST /git/{host}/{path...}"]
 	assert.NotZero(t, handler)
 
-	doRequest := func(refs map[string]string) (*httptest.ResponseRecorder, git.EnsureRefsResponse) {
-		body, err := json.Marshal(map[string]any{"refs": refs})
+	doRequest := func(body map[string]any) (*httptest.ResponseRecorder, git.EnsureRefsResponse) {
+		raw, err := json.Marshal(body)
 		assert.NoError(t, err)
 		req := httptest.NewRequestWithContext(ctx, http.MethodPost,
-			"/git/local/repo/ensure-refs", bytes.NewReader(body))
+			"/git/local/repo/ensure-refs", bytes.NewReader(raw))
 		req.SetPathValue("host", "local")
 		req.SetPathValue("path", "repo/ensure-refs")
 		w := httptest.NewRecorder()
@@ -84,11 +84,21 @@ func TestEnsureRefsHandler(t *testing.T) {
 		return w, resp
 	}
 
+	initialSHAOut, err := exec.Command("git", "-C", workPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	initialSHA := strings.TrimSpace(string(initialSHAOut))
+
 	// Fresh mirror already has main → no fetch.
-	w, resp := doRequest(map[string]string{"refs/heads/main": ""})
+	w, resp := doRequest(map[string]any{"refs": map[string]string{"refs/heads/main": ""}})
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.False(t, resp.Fetched)
 	assert.NotEqual(t, "", resp.Refs["refs/heads/main"])
+
+	// Commit-only request for an already-present commit → no fetch.
+	w, resp = doRequest(map[string]any{"commits": []string{initialSHA}})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, resp.Fetched)
+	assert.Equal(t, 0, len(resp.MissingCommits))
 
 	// Push a new commit upstream to make the mirror stale.
 	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "f.txt"), []byte("v2"), 0o644))
@@ -102,13 +112,18 @@ func TestEnsureRefsHandler(t *testing.T) {
 	assert.NoError(t, err)
 	newSHA := strings.TrimSpace(string(newSHAOut))
 
-	// Asking for the new SHA forces a fetch and returns the fresh value.
-	w, resp = doRequest(map[string]string{"refs/heads/main": newSHA})
+	// Commit-only request for a commit only present upstream → fetch and find it.
+	w, resp = doRequest(map[string]any{"commits": []string{newSHA}})
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.True(t, resp.Fetched)
+	assert.Equal(t, 0, len(resp.MissingCommits))
+
+	// Asking for the new SHA forces a fetch and returns the fresh value.
+	w, resp = doRequest(map[string]any{"refs": map[string]string{"refs/heads/main": newSHA}})
+	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, newSHA, resp.Refs["refs/heads/main"])
 
-	// Empty refs map → 400.
-	w, _ = doRequest(map[string]string{})
+	// Empty body → 400.
+	w, _ = doRequest(map[string]any{})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }


### PR DESCRIPTION
EnsureRefs previously only accepted a refs map and required keys to be ref names. To pre-warm individual commits (e.g. a PR head SHA that may not yet point at any named ref), callers had to construct a fake ref. Extend the request to accept an explicit commits list.

The endpoint now accepts {"refs":..., "commits":[...]}, with at least one populated. The server fetches once if any ref is wrong or any commit is missing from the local object database, then reports resolved ref SHAs and any commits still missing after the fetch.

The client API takes an EnsureGitRefsRequest struct so the field set can grow without further breaking changes. cachew git restore gains a --commit flag (repeatable) and treats the local short-circuit symmetrically across refs and commits; a server response with missing_commits is fatal.
