### PR TITLE
fix(git): wait for warm-up goroutine in not-our-ref integration test

### DIFF
--- a/internal/strategy/git/integration_test.go
+++ b/internal/strategy/git/integration_test.go
@@ -524,6 +524,9 @@ func TestIntegrationNotOurRefFallsBackToUpstream(t *testing.T) {
 	strategy, err := git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, gc,
 		func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
 	assert.NoError(t, err)
+	// The warm-up goroutine uses context.WithoutCancel so it survives
+	// t.Context() cancellation. Wait for it before TempDir cleanup.
+	t.Cleanup(func() { waitForReady(t, strategy) })
 
 	// Redirect all upstream proxy requests to the mock server.
 	var redirectHits atomic.Int32


### PR DESCRIPTION
The TestIntegrationNotOurRefFallsBackToUpstream test was racing with the
background warmExistingRepos goroutine (started by git.New with
context.WithoutCancel), causing flaky 'TempDir RemoveAll cleanup:
directory not empty' failures in CI.

Add the t.Cleanup(waitForReady) pattern already used by other tests in
the package.
