### PR TITLE
feat(observability): metrics and spans for git snapshot/bundle/ensure-refs paths

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/errors"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // HTTPStatusError is returned when the server responds with an unexpected
@@ -57,14 +58,19 @@ type HeaderFunc func() http.Header
 // NewHTTPClient creates an *http.Client that attaches headerFunc headers
 // to every outgoing request. Useful for callers that need to talk to
 // non-API endpoints (e.g. /git/) with the same auth as the cache client.
+//
+// The returned client is instrumented with otelhttp so each outgoing request
+// produces a child span and propagates the W3C traceparent header. When no
+// tracer provider is configured, otelhttp falls back to a no-op tracer, so
+// this is cost-free for callers that have not opted in to tracing.
 func NewHTTPClient(headerFunc HeaderFunc) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:errcheck
 	transport.MaxIdleConns = 100
 	transport.MaxIdleConnsPerHost = 100
 
-	var rt http.RoundTripper = transport
+	var rt http.RoundTripper = otelhttp.NewTransport(transport)
 	if headerFunc != nil {
-		rt = &headerTransport{base: transport, headerFunc: headerFunc}
+		rt = &headerTransport{base: rt, headerFunc: headerFunc}
 	}
 	return &http.Client{Transport: rt}
 }

--- a/cmd/cachew/git.go
+++ b/cmd/cachew/git.go
@@ -7,12 +7,33 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/alecthomas/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/block/cachew/client"
 	"github.com/block/cachew/internal/snapshot"
 )
+
+//nolint:gochecknoglobals // OTel tracer instances are package-scoped by convention
+var tracer = otel.Tracer("github.com/block/cachew/cmd/cachew")
+
+// inSpan runs fn inside a named child span and records the error returned by
+// fn on the span before propagating it.
+func inSpan(ctx context.Context, name string, attrs []attribute.KeyValue, fn func(ctx context.Context) error) error {
+	ctx, span := tracer.Start(ctx, name, trace.WithAttributes(attrs...))
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
 
 // GitCmd groups git-aware subcommands that talk directly to cachew's
 // /git/ strategy endpoints (not the generic object-store API).
@@ -34,29 +55,77 @@ type GitRestoreCmd struct {
 }
 
 func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
+	ctx, span := tracer.Start(ctx, "cachew.git_restore",
+		trace.WithAttributes(
+			attribute.String("cachew.repo_url", c.RepoURL),
+			attribute.String("cachew.directory", c.Directory),
+			attribute.Bool("cachew.no_bundle", c.NoBundle),
+			attribute.Int("cachew.zstd_threads", c.ZstdThreads),
+		),
+	)
+	defer span.End()
+
+	totalStart := time.Now()
+	defer func() {
+		fmt.Fprintf(os.Stderr, "cachew git restore total elapsed=%s\n", time.Since(totalStart)) //nolint:forbidigo
+	}()
+
 	fmt.Fprintf(os.Stderr, "Fetching snapshot for %s\n", c.RepoURL) //nolint:forbidigo
 
-	snap, err := api.OpenGitSnapshot(ctx, c.RepoURL)
-	if err != nil {
+	var snap *client.GitSnapshot
+	if err := inSpan(ctx, "cachew.download_snapshot",
+		[]attribute.KeyValue{attribute.String("cachew.repo_url", c.RepoURL)},
+		func(ctx context.Context) error {
+			downloadStart := time.Now()
+			s, err := api.OpenGitSnapshot(ctx, c.RepoURL)
+			if err != nil {
+				return err //nolint:wrapcheck // wrapped by caller
+			}
+			snap = s
+			trace.SpanFromContext(ctx).SetAttributes(
+				attribute.String("cachew.snapshot_commit", s.Commit),
+				attribute.String("cachew.bundle_url", s.BundleURL),
+				attribute.Float64("cachew.elapsed_seconds", time.Since(downloadStart).Seconds()),
+			)
+			return nil
+		}); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return errors.Errorf("no snapshot available for %s", c.RepoURL)
 		}
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return errors.Wrap(err, "fetch snapshot")
 	}
 	defer snap.Close()
+	span.SetAttributes(attribute.String("cachew.snapshot_commit", snap.Commit))
 
 	fmt.Fprintf(os.Stderr, "Extracting to %s...\n", c.Directory) //nolint:forbidigo
-	if err := snapshot.Extract(ctx, snap.Body, c.Directory, c.ZstdThreads); err != nil {
+	if err := inSpan(ctx, "cachew.extract",
+		[]attribute.KeyValue{attribute.String("cachew.directory", c.Directory)},
+		func(ctx context.Context) error {
+			extractStart := time.Now()
+			if err := snapshot.Extract(ctx, snap.Body, c.Directory, c.ZstdThreads); err != nil {
+				return err //nolint:wrapcheck // wrapped by caller
+			}
+			elapsed := time.Since(extractStart)
+			trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("cachew.elapsed_seconds", elapsed.Seconds()))
+			fmt.Fprintf(os.Stderr, "Snapshot extracted in %s\n", elapsed) //nolint:forbidigo
+			return nil
+		}); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return errors.Wrap(err, "extract snapshot")
 	}
 	fmt.Fprintf(os.Stderr, "Snapshot restored to %s\n", c.Directory) //nolint:forbidigo
 
 	if snap.BundleURL != "" && !c.NoBundle {
 		fmt.Fprintf(os.Stderr, "Applying delta bundle...\n") //nolint:forbidigo
+		bundleStart := time.Now()
 		if err := applyBundle(ctx, api, snap.BundleURL, c.Directory); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to apply delta bundle: %v\n", err) //nolint:forbidigo
+			span.RecordError(err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Delta bundle applied\n") //nolint:forbidigo
+			fmt.Fprintf(os.Stderr, "Delta bundle applied in %s\n", time.Since(bundleStart)) //nolint:forbidigo
 		}
 	}
 
@@ -66,6 +135,8 @@ func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
 	// the mirror (if needed) and pull from origin (if needed) to catch up.
 	if len(c.Ref) > 0 || len(c.Commit) > 0 {
 		if err := c.satisfyRefs(ctx, api); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 	}
@@ -78,22 +149,44 @@ func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
 // asked for, avoiding both /ensure-refs and git pull when the snapshot+bundle
 // already brought down the required SHAs.
 func (c *GitRestoreCmd) satisfyRefs(ctx context.Context, api *client.Client) error {
+	ctx, span := tracer.Start(ctx, "cachew.satisfy_refs",
+		trace.WithAttributes(
+			attribute.Int("cachew.requested_refs", len(c.Ref)),
+			attribute.Int("cachew.requested_commits", len(c.Commit)),
+		),
+	)
+	defer span.End()
+
 	// Fast path: if every ref is pinned and the local clone has every ref
 	// SHA and every requested commit, we're done.
 	if allPinned(c.Ref) &&
 		localHasAllRefSHAs(ctx, c.Directory, c.Ref) &&
 		localHasAllSHAs(ctx, c.Directory, c.Commit) {
 		fmt.Fprintf(os.Stderr, "All requested refs/commits already present locally\n") //nolint:forbidigo
+		span.SetAttributes(attribute.String("cachew.result", "local_hit"))
 		return nil
 	}
 
 	fmt.Fprintf(os.Stderr, "Ensuring %d ref(s) and %d commit(s) are fresh for %s\n", //nolint:forbidigo
 		len(c.Ref), len(c.Commit), c.RepoURL)
-	resp, err := api.EnsureGitRefs(ctx, c.RepoURL, client.EnsureGitRefsRequest{
-		Refs:    c.Ref,
-		Commits: c.Commit,
-	})
-	if err != nil {
+	var resp client.EnsureGitRefsResponse
+	if err := inSpan(ctx, "cachew.ensure_refs", nil, func(ctx context.Context) error {
+		r, err := api.EnsureGitRefs(ctx, c.RepoURL, client.EnsureGitRefsRequest{
+			Refs:    c.Ref,
+			Commits: c.Commit,
+		})
+		if err != nil {
+			return err //nolint:wrapcheck // wrapped by caller
+		}
+		resp = r
+		trace.SpanFromContext(ctx).SetAttributes(
+			attribute.Bool("cachew.fetched", r.Fetched),
+			attribute.Int("cachew.missing_commits", len(r.MissingCommits)),
+		)
+		return nil
+	}); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return errors.Wrap(err, "ensure refs")
 	}
 	if resp.Fetched {
@@ -167,23 +260,42 @@ func localHasSHA(ctx context.Context, directory, sha string) bool {
 }
 
 func applyBundle(ctx context.Context, api *client.Client, bundleURL, directory string) error {
+	ctx, span := tracer.Start(ctx, "cachew.apply_bundle",
+		trace.WithAttributes(
+			attribute.String("cachew.bundle_url", bundleURL),
+			attribute.String("cachew.directory", directory),
+		),
+	)
+	defer span.End()
+
 	body, err := api.OpenGitBundle(ctx, bundleURL)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return errors.Wrap(err, "fetch bundle")
 	}
 	defer body.Close()
 
 	tmpFile, err := os.CreateTemp("", "cachew-bundle-*.bundle")
 	if err != nil {
+		span.RecordError(err)
 		return errors.Wrap(err, "create temp bundle file")
 	}
 	defer os.Remove(tmpFile.Name()) //nolint:errcheck
 
-	if _, err := io.Copy(tmpFile, body); err != nil {
+	downloadStart := time.Now()
+	bytes, err := io.Copy(tmpFile, body)
+	if err != nil {
 		_ = tmpFile.Close()
+		span.RecordError(err)
 		return errors.Wrap(err, "download bundle")
 	}
+	span.SetAttributes(
+		attribute.Int64("cachew.bundle_bytes", bytes),
+		attribute.Float64("cachew.download_seconds", time.Since(downloadStart).Seconds()),
+	)
 	if err := tmpFile.Close(); err != nil {
+		span.RecordError(err)
 		return errors.Wrap(err, "close temp bundle file")
 	}
 
@@ -191,15 +303,21 @@ func applyBundle(ctx context.Context, api *client.Client, bundleURL, directory s
 	branchCmd := exec.CommandContext(ctx, "git", "-C", directory, "symbolic-ref", "--short", "HEAD") //nolint:gosec
 	branchOut, err := branchCmd.Output()
 	if err != nil {
+		span.RecordError(err)
 		return errors.Wrap(err, "determine current branch")
 	}
 	branch := strings.TrimSpace(string(branchOut))
+	span.SetAttributes(attribute.String("cachew.branch", branch))
 
 	// Pull the bundle's branch into the working tree via fast-forward.
+	applyStart := time.Now()
 	cmd := exec.CommandContext(ctx, "git", "-C", directory, "pull", "--ff-only", tmpFile.Name(), branch) //nolint:gosec
 	if output, err := cmd.CombinedOutput(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return errors.Wrapf(err, "git pull from bundle: %s", string(output))
 	}
+	span.SetAttributes(attribute.Float64("cachew.git_pull_seconds", time.Since(applyStart).Seconds()))
 
 	return nil
 }
@@ -209,9 +327,17 @@ func applyBundle(ctx context.Context, api *client.Client, bundleURL, directory s
 // after the bundle was generated. The clone's origin is the upstream URL,
 // so this respects the user's git insteadOf config to route through cachew.
 func gitPullOrigin(ctx context.Context, directory string) error {
+	ctx, span := tracer.Start(ctx, "cachew.pull_origin",
+		trace.WithAttributes(attribute.String("cachew.directory", directory)),
+	)
+	defer span.End()
+	start := time.Now()
 	cmd := exec.CommandContext(ctx, "git", "-C", directory, "pull", "--ff-only") //nolint:gosec
 	if output, err := cmd.CombinedOutput(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return errors.Wrapf(err, "git pull: %s", string(output))
 	}
+	span.SetAttributes(attribute.Float64("cachew.elapsed_seconds", time.Since(start).Seconds()))
 	return nil
 }

--- a/cmd/cachew/main.go
+++ b/cmd/cachew/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/block/cachew/client"
 	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/tracing"
 )
 
 type CLI struct {
@@ -46,6 +47,16 @@ func run() int {
 	ctx := context.Background()
 	_, ctx = logging.Configure(ctx, cli.LoggingConfig)
 
+	// Wire up tracing for the short-lived CLI. tracing.New is env-driven:
+	// it only installs an exporter when OTEL_EXPORTER_OTLP_ENDPOINT is set,
+	// so this is a no-op for users who haven't opted in.
+	stopTracing, err := tracing.New(ctx, tracing.Config{Enabled: true})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to initialize tracing: %v\n", err) //nolint:forbidigo
+	} else {
+		defer stopTracing()
+	}
+
 	var headerFunc client.HeaderFunc
 	if cli.Authorization != "" {
 		headerFunc = func() http.Header {
@@ -58,7 +69,7 @@ func run() int {
 	kctx.BindTo(ctx, (*context.Context)(nil))
 	kctx.Bind(c)
 	kctx.Bind(c.HTTP())
-	err := kctx.Run(ctx)
+	err = kctx.Run(ctx)
 	if errors.Is(err, errCacheMiss) {
 		return 2
 	}

--- a/internal/jobscheduler/metrics.go
+++ b/internal/jobscheduler/metrics.go
@@ -22,6 +22,6 @@ func newSchedulerMetrics() *schedulerMetrics {
 		activeWorkers: metrics.NewMetric[metric.Int64Gauge](meter, "cachew.scheduler.active_workers", "{workers}", "Number of workers currently executing jobs"),
 		activeClones:  metrics.NewMetric[metric.Int64Gauge](meter, "cachew.scheduler.active_clones", "{jobs}", "Number of clone jobs currently executing"),
 		jobsTotal:     metrics.NewMetric[metric.Int64Counter](meter, "cachew.scheduler.jobs_total", "{jobs}", "Total number of completed scheduler jobs"),
-		jobDuration:   metrics.NewMetric[metric.Float64Histogram](meter, "cachew.scheduler.job_duration", "s", "Histogram of job durations in seconds"),
+		jobDuration:   metrics.NewHistogram(meter, "cachew.scheduler.job_duration", "s", "Histogram of job durations in seconds", metrics.LatencyBuckets()),
 	}
 }

--- a/internal/metrics/helper.go
+++ b/internal/metrics/helper.go
@@ -6,6 +6,72 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+// LatencyBuckets covers operations that span sub-millisecond cache hits all
+// the way to multi-minute clone/repack/generation work. The default OTel
+// histogram boundaries (0..10 seconds) compress everything beyond 10s into
+// the +Inf bucket, which makes p50/p90/avg unusable for cachew's git path.
+func LatencyBuckets() []float64 {
+	return []float64{
+		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+		1, 2.5, 5, 10, 30, 60, 120, 300, 600,
+	}
+}
+
+// FastLatencyBuckets is for operations expected to complete in well under
+// a minute (spool follower waits, ensure-refs round trips).
+func FastLatencyBuckets() []float64 {
+	return []float64{
+		0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+		1, 2.5, 5, 10, 30,
+	}
+}
+
+// ByteBuckets covers cachew payload sizes, which range from tiny bundles
+// (a few KiB) to multi-GiB snapshot tarballs.
+func ByteBuckets() []float64 {
+	return []float64{
+		1 << 10, // 1 KiB
+		1 << 14, // 16 KiB
+		1 << 16, // 64 KiB
+		1 << 18, // 256 KiB
+		1 << 20, // 1 MiB
+		1 << 22, // 4 MiB
+		1 << 24, // 16 MiB
+		1 << 26, // 64 MiB
+		1 << 28, // 256 MiB
+		1 << 30, // 1 GiB
+		1 << 32, // 4 GiB
+		1 << 33, // 8 GiB
+		1 << 34, // 16 GiB
+		1 << 35, // 32 GiB
+	}
+}
+
+// SmallCountBuckets is for low-cardinality integer counts (e.g. number of
+// pack files on a mirror), where the values of interest are mostly in the
+// 1–100 range with a long tail.
+func SmallCountBuckets() []float64 {
+	return []float64{
+		1, 2, 5, 10, 25, 50, 100, 250, 500, 1000,
+	}
+}
+
+// NewHistogram creates a Float64Histogram with explicit bucket boundaries.
+// Prefer this over NewMetric for histograms: the OTel SDK default boundaries
+// only go up to 10 seconds, which is far too narrow for most cachew metrics.
+func NewHistogram(meter metric.Meter, path, unit, description string, buckets []float64) metric.Float64Histogram {
+	h, err := meter.Float64Histogram(
+		path,
+		metric.WithUnit(unit),
+		metric.WithDescription(description),
+		metric.WithExplicitBucketBoundaries(buckets...),
+	)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
 func NewMetric[OM any](meter metric.Meter, path, unit, description string) OM {
 	u := metric.WithUnit(unit)
 	d := metric.WithDescription(description)

--- a/internal/strategy/git/metrics.go
+++ b/internal/strategy/git/metrics.go
@@ -12,21 +12,41 @@ import (
 )
 
 type gitMetrics struct {
-	operationDuration  metric.Float64Histogram
-	operationTotal     metric.Int64Counter
-	requestTotal       metric.Int64Counter
-	snapshotServeTotal metric.Int64Counter
-	snapshotServeSize  metric.Float64Histogram
+	operationDuration      metric.Float64Histogram
+	operationTotal         metric.Int64Counter
+	requestTotal           metric.Int64Counter
+	snapshotServeTotal     metric.Int64Counter
+	snapshotServeSize      metric.Float64Histogram
+	snapshotServeDuration  metric.Float64Histogram
+	bundleServeTotal       metric.Int64Counter
+	bundleServeSize        metric.Float64Histogram
+	bundleServeDuration    metric.Float64Histogram
+	ensureRefsTotal        metric.Int64Counter
+	ensureRefsDuration     metric.Float64Histogram
+	spoolWriterDuration    metric.Float64Histogram
+	spoolFollowerWaitTotal metric.Int64Counter
+	spoolFollowerWait      metric.Float64Histogram
+	repackPackCount        metric.Float64Histogram
 }
 
 func newGitMetrics() *gitMetrics {
 	meter := otel.Meter("cachew.git")
 	return &gitMetrics{
-		operationDuration:  metrics.NewMetric[metric.Float64Histogram](meter, "cachew.git.operation_duration_seconds", "s", "Duration of git operations (clone, fetch, repack, snapshot)"),
-		operationTotal:     metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.operations_total", "{operations}", "Total number of git operations"),
-		requestTotal:       metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.requests_total", "{requests}", "Total number of git HTTP requests by type"),
-		snapshotServeTotal: metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.snapshot_serves_total", "{serves}", "Snapshot serve events by source (cache, spool, cold_cache) and repository"),
-		snapshotServeSize:  metrics.NewMetric[metric.Float64Histogram](meter, "cachew.git.snapshot_serve_bytes", "By", "Size of served snapshots in bytes"),
+		operationDuration:      metrics.NewHistogram(meter, "cachew.git.operation_duration_seconds", "s", "Duration of git operations (clone, fetch, repack, snapshot)", metrics.LatencyBuckets()),
+		operationTotal:         metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.operations_total", "{operations}", "Total number of git operations"),
+		requestTotal:           metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.requests_total", "{requests}", "Total number of git HTTP requests by type"),
+		snapshotServeTotal:     metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.snapshot_serves_total", "{serves}", "Snapshot serve events by source (cache, spool, cold_cache, generated) and repository"),
+		snapshotServeSize:      metrics.NewHistogram(meter, "cachew.git.snapshot_serve_bytes", "By", "Size of served snapshots in bytes", metrics.ByteBuckets()),
+		snapshotServeDuration:  metrics.NewHistogram(meter, "cachew.git.snapshot_serve_duration_seconds", "s", "Wall-clock duration of snapshot serves, from handler entry to last byte sent", metrics.LatencyBuckets()),
+		bundleServeTotal:       metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.bundle_serves_total", "{serves}", "Bundle serve events by source (cache, generated, miss) and repository"),
+		bundleServeSize:        metrics.NewHistogram(meter, "cachew.git.bundle_serve_bytes", "By", "Size of served bundles in bytes", metrics.ByteBuckets()),
+		bundleServeDuration:    metrics.NewHistogram(meter, "cachew.git.bundle_serve_duration_seconds", "s", "Wall-clock duration of bundle serves, including any on-demand generation", metrics.LatencyBuckets()),
+		ensureRefsTotal:        metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.ensure_refs_total", "{requests}", "EnsureRefs requests by fetched and status"),
+		ensureRefsDuration:     metrics.NewHistogram(meter, "cachew.git.ensure_refs_duration_seconds", "s", "Duration of EnsureRefs requests, including any upstream fetch", metrics.FastLatencyBuckets()),
+		spoolWriterDuration:    metrics.NewHistogram(meter, "cachew.git.spool_writer_duration_seconds", "s", "Time the snapshot spool writer spent producing the stream", metrics.LatencyBuckets()),
+		spoolFollowerWaitTotal: metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.spool_follower_waits_total", "{waits}", "Snapshot spool follower events, by outcome (served, writer_failed)"),
+		spoolFollowerWait:      metrics.NewHistogram(meter, "cachew.git.spool_follower_wait_seconds", "s", "Time a snapshot spool follower spent waiting for the writer to publish headers", metrics.FastLatencyBuckets()),
+		repackPackCount:        metrics.NewHistogram(meter, "cachew.git.repack_pack_count", "{packs}", "Pack file count observed before and after repack, by stage (before, after)", metrics.SmallCountBuckets()),
 	}
 }
 
@@ -44,9 +64,9 @@ func (m *gitMetrics) recordRequest(ctx context.Context, requestType string) {
 	m.requestTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("type", requestType)))
 }
 
-// recordSnapshotServe records a snapshot serve event with its source and repository.
+// recordSnapshotServe records a snapshot serve event with its source, repository, size and wall-clock duration.
 // Source is one of: "cache", "cold_cache", "spool", "generated".
-func (m *gitMetrics) recordSnapshotServe(ctx context.Context, source, repo string, sizeBytes int64) {
+func (m *gitMetrics) recordSnapshotServe(ctx context.Context, source, repo string, sizeBytes int64, duration time.Duration) {
 	attrs := metric.WithAttributes(
 		attribute.String("source", source),
 		attribute.String("repository", repo),
@@ -55,4 +75,65 @@ func (m *gitMetrics) recordSnapshotServe(ctx context.Context, source, repo strin
 	if sizeBytes > 0 {
 		m.snapshotServeSize.Record(ctx, float64(sizeBytes), attrs)
 	}
+	if duration > 0 {
+		m.snapshotServeDuration.Record(ctx, duration.Seconds(), attrs)
+	}
+}
+
+// recordBundleServe records a bundle serve event. Source is one of:
+// "cache" (served from object cache), "generated" (created on demand from the
+// local mirror), or "miss" (no bundle could be produced).
+func (m *gitMetrics) recordBundleServe(ctx context.Context, source, repo string, sizeBytes int64, duration time.Duration) {
+	attrs := metric.WithAttributes(
+		attribute.String("source", source),
+		attribute.String("repository", repo),
+	)
+	m.bundleServeTotal.Add(ctx, 1, attrs)
+	if sizeBytes > 0 {
+		m.bundleServeSize.Record(ctx, float64(sizeBytes), attrs)
+	}
+	if duration > 0 {
+		m.bundleServeDuration.Record(ctx, duration.Seconds(), attrs)
+	}
+}
+
+// recordEnsureRefs records an EnsureRefs request, including whether it
+// triggered an upstream fetch.
+func (m *gitMetrics) recordEnsureRefs(ctx context.Context, status string, fetched bool, repo string, duration time.Duration) {
+	attrs := metric.WithAttributes(
+		attribute.String("status", status),
+		attribute.Bool("fetched", fetched),
+		attribute.String("repository", repo),
+	)
+	m.ensureRefsTotal.Add(ctx, 1, attrs)
+	m.ensureRefsDuration.Record(ctx, duration.Seconds(), attrs)
+}
+
+// recordSpoolWriter records how long the snapshot-spool writer goroutine
+// spent producing the stream from cloneForSnapshot through MarkComplete.
+func (m *gitMetrics) recordSpoolWriter(ctx context.Context, repo, status string, duration time.Duration) {
+	m.spoolWriterDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(
+		attribute.String("repository", repo),
+		attribute.String("status", status),
+	))
+}
+
+// recordSpoolFollowerWait records how long a follower waited on the writer
+// to publish spool headers, and the outcome of the follower's serve attempt.
+func (m *gitMetrics) recordSpoolFollowerWait(ctx context.Context, repo, outcome string, wait time.Duration) {
+	attrs := metric.WithAttributes(
+		attribute.String("repository", repo),
+		attribute.String("outcome", outcome),
+	)
+	m.spoolFollowerWaitTotal.Add(ctx, 1, attrs)
+	m.spoolFollowerWait.Record(ctx, wait.Seconds(), attrs)
+}
+
+// recordRepackPackCount records the pack-file count observed on a mirror at
+// a given stage of a repack. Stage is "before" or "after".
+func (m *gitMetrics) recordRepackPackCount(ctx context.Context, repo, stage string, count int) {
+	m.repackPackCount.Record(ctx, float64(count), metric.WithAttributes(
+		attribute.String("repository", repo),
+		attribute.String("stage", stage),
+	))
 }

--- a/internal/strategy/git/refs.go
+++ b/internal/strategy/git/refs.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/alecthomas/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/logging"
@@ -41,35 +45,64 @@ type EnsureRefsResponse struct {
 	Fetched        bool              `json:"fetched"`
 }
 
-func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host, pathValue string) {
-	ctx := r.Context()
+func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host, pathValue string) { //nolint:funlen
+	start := time.Now()
+	repoPath := strings.TrimSuffix(pathValue, EnsureRefsPath)
+	repoPath = strings.TrimSuffix(repoPath, ".git")
+	upstreamURL := "https://" + host + "/" + repoPath
+	repoName := host + "/" + repoPath
+
+	ctx, span := tracer.Start(r.Context(), "git.ensure_refs",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "ensure_refs"),
+			attribute.String("cachew.upstream", upstreamURL),
+			attribute.String("cachew.repository", repoName),
+		),
+	)
+	defer span.End()
 	logger := logging.FromContext(ctx)
 
 	s.metrics.recordRequest(ctx, "ensure-refs")
 
+	// status and fetched are mutated by the handler and read by the deferred
+	// metric. Default to "error" so that any early return without explicit
+	// classification is treated as a failure.
+	status := "error"
+	fetched := false
+	defer func() {
+		span.SetAttributes(attribute.String("cachew.status", status), attribute.Bool("cachew.fetched", fetched))
+		s.metrics.recordEnsureRefs(ctx, status, fetched, repoName, time.Since(start))
+	}()
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		status = "method_not_allowed"
 		return
 	}
 
 	var req EnsureRefsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		status = "bad_request"
+		span.RecordError(err)
 		return
 	}
 	if len(req.Refs) == 0 && len(req.Commits) == 0 {
 		http.Error(w, "at least one of refs or commits must be provided", http.StatusBadRequest)
+		status = "bad_request"
 		return
 	}
-
-	repoPath := strings.TrimSuffix(pathValue, EnsureRefsPath)
-	repoPath = strings.TrimSuffix(repoPath, ".git")
-	upstreamURL := "https://" + host + "/" + repoPath
+	span.SetAttributes(
+		attribute.Int("cachew.requested_refs", len(req.Refs)),
+		attribute.Int("cachew.requested_commits", len(req.Commits)),
+	)
 
 	repo, err := s.cloneManager.GetOrCreate(ctx, upstreamURL)
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to get or create clone", "error", err, "upstream", upstreamURL)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return
 	}
 
@@ -77,24 +110,37 @@ func (s *Strategy) handleEnsureRefs(w http.ResponseWriter, r *http.Request, host
 		if err := s.ensureCloneReady(ctx, repo); err != nil {
 			logger.ErrorContext(ctx, "Clone not ready", "error", err, "upstream", upstreamURL)
 			http.Error(w, "clone not ready: "+err.Error(), http.StatusBadGateway)
+			status = "clone_not_ready"
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return
 		}
 	}
 
-	resolved, missingCommits, fetched, err := repo.EnsureRefs(ctx, req.Refs, req.Commits)
+	resolved, missingCommits, didFetch, err := repo.EnsureRefs(ctx, req.Refs, req.Commits)
+	fetched = didFetch
 	if err != nil {
 		logger.ErrorContext(ctx, "EnsureRefs failed", "error", errors.WithStack(err), "upstream", upstreamURL)
 		http.Error(w, "ensure refs: "+err.Error(), http.StatusBadGateway)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return
 	}
 
 	logger.DebugContext(ctx, "EnsureRefs completed", "upstream", upstreamURL,
 		"requested_refs", len(req.Refs), "requested_commits", len(req.Commits),
 		"missing_commits", len(missingCommits), "fetched", fetched)
+	span.SetAttributes(attribute.Int("cachew.missing_commits", len(missingCommits)))
 
 	w.Header().Set("Content-Type", "application/json")
 	resp := EnsureRefsResponse{Refs: resolved, MissingCommits: missingCommits, Fetched: fetched}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		logger.ErrorContext(ctx, "Failed to encode response", "error", err)
+		span.RecordError(err)
+	}
+	if len(missingCommits) > 0 {
+		status = "missing_commits"
+	} else {
+		status = "success"
 	}
 }

--- a/internal/strategy/git/repack.go
+++ b/internal/strategy/git/repack.go
@@ -2,15 +2,44 @@ package git
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/block/cachew/internal/gitclone"
 )
 
 func (s *Strategy) scheduleRepackJobs(repo *gitclone.Repository) {
-	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "repack-periodic", s.config.RepackInterval, func(ctx context.Context) error {
+	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "repack-periodic", s.config.RepackInterval, func(ctx context.Context) (returnErr error) {
+		upstream := repo.UpstreamURL()
+		ctx, span := tracer.Start(ctx, "git.repack",
+			trace.WithAttributes(
+				attribute.String("cachew.operation", "repack"),
+				attribute.String("cachew.upstream", upstream),
+			),
+		)
+		defer func() {
+			if returnErr != nil {
+				span.RecordError(returnErr)
+				span.SetStatus(codes.Error, returnErr.Error())
+			}
+			span.End()
+		}()
+
+		// Pack count before and after gives us a direct view of how much
+		// the geometric repack actually consolidated. A flat before/after
+		// ratio over time means fragmentation is outpacing the schedule.
+		if before, err := countPackFiles(repo.Path()); err == nil {
+			s.metrics.recordRepackPackCount(ctx, upstream, "before", before)
+			span.SetAttributes(attribute.Int("cachew.pack_count_before", before))
+		}
+
 		start := time.Now()
 		err := repo.Repack(ctx)
 		status := "success"
@@ -18,6 +47,31 @@ func (s *Strategy) scheduleRepackJobs(repo *gitclone.Repository) {
 			status = "error"
 		}
 		s.metrics.recordOperation(ctx, "repack", status, time.Since(start))
+
+		if after, countErr := countPackFiles(repo.Path()); countErr == nil {
+			s.metrics.recordRepackPackCount(ctx, upstream, "after", after)
+			span.SetAttributes(attribute.Int("cachew.pack_count_after", after))
+		}
+
 		return errors.Wrap(err, "repack")
 	})
+}
+
+// countPackFiles returns the number of .pack files in the mirror's
+// objects/pack directory. Returns 0, nil if the directory is missing.
+func countPackFiles(repoPath string) (int, error) {
+	entries, err := os.ReadDir(filepath.Join(repoPath, "objects", "pack"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, errors.Wrap(err, "read pack dir")
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".pack") {
+			count++
+		}
+	}
+	return count, nil
 }

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -13,6 +13,9 @@ import (
 	"time"
 
 	"github.com/alecthomas/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/gitclone"
@@ -102,9 +105,23 @@ func (s *Strategy) withSnapshotClone(ctx context.Context, repo *gitclone.Reposit
 	return fn(workDir)
 }
 
-func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone.Repository) error {
-	logger := logging.FromContext(ctx)
+func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone.Repository) (returnErr error) {
 	upstream := repo.UpstreamURL()
+	ctx, span := tracer.Start(ctx, "git.snapshot.generate",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "snapshot_generate"),
+			attribute.String("cachew.upstream", upstream),
+		),
+	)
+	defer func() {
+		if returnErr != nil {
+			span.RecordError(returnErr)
+			span.SetStatus(codes.Error, returnErr.Error())
+		}
+		span.End()
+	}()
+
+	logger := logging.FromContext(ctx)
 	start := time.Now()
 
 	logger.InfoContext(ctx, "Snapshot generation started", "upstream", upstream)
@@ -139,9 +156,23 @@ func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone
 // restored directly as a mirror without any conversion. This is used for
 // pod-to-pod bootstrap: a new cachew pod restores the mirror snapshot and
 // is immediately ready to serve, with background fetch handling freshening.
-func (s *Strategy) generateAndUploadMirrorSnapshot(ctx context.Context, repo *gitclone.Repository) error {
-	logger := logging.FromContext(ctx)
+func (s *Strategy) generateAndUploadMirrorSnapshot(ctx context.Context, repo *gitclone.Repository) (returnErr error) {
 	upstream := repo.UpstreamURL()
+	ctx, span := tracer.Start(ctx, "git.snapshot.generate_mirror",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "mirror_snapshot_generate"),
+			attribute.String("cachew.upstream", upstream),
+		),
+	)
+	defer func() {
+		if returnErr != nil {
+			span.RecordError(returnErr)
+			span.SetStatus(codes.Error, returnErr.Error())
+		}
+		span.End()
+	}()
+
+	logger := logging.FromContext(ctx)
 
 	logger.InfoContext(ctx, "Mirror snapshot generation started", "upstream", upstream)
 
@@ -188,13 +219,22 @@ func (s *Strategy) snapshotMutexFor(upstreamURL string) *sync.Mutex {
 	return mu.(*sync.Mutex)
 }
 
-func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request, host, pathValue string) {
-	ctx := r.Context()
-	logger := logging.FromContext(ctx)
-
+func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request, host, pathValue string) { //nolint:funlen
+	start := time.Now()
 	repoPath := ExtractRepoPath(strings.TrimSuffix(pathValue, "/snapshot.tar.zst"))
 	upstreamURL := "https://" + host + "/" + repoPath
 	repoName := host + "/" + repoPath
+
+	ctx, span := tracer.Start(r.Context(), "git.snapshot.serve",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "snapshot_serve"),
+			attribute.String("cachew.upstream", upstreamURL),
+			attribute.String("cachew.repository", repoName),
+		),
+	)
+	defer span.End()
+	r = r.WithContext(ctx)
+	logger := logging.FromContext(ctx)
 
 	repo, repoErr := s.cloneManager.GetOrCreate(ctx, upstreamURL)
 	if repoErr != nil {
@@ -224,9 +264,12 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 				logger.InfoContext(ctx, "Serving locally cached snapshot after waiting for in-flight fill", "upstream", upstreamURL)
 				w.Header().Set("Content-Type", "application/zstd")
 				n, err := serveReaderFast(w, r, reader)
-				s.metrics.recordSnapshotServe(ctx, "cold_cache", repoName, n)
+				s.metrics.recordSnapshotServe(ctx, "cold_cache", repoName, n, time.Since(start))
+				span.SetAttributes(attribute.String("cachew.source", "cold_cache"), attribute.Int64("cachew.bytes", n))
 				if err != nil {
 					logger.WarnContext(ctx, "Failed to stream locally cached snapshot", "upstream", upstreamURL, "error", err)
+					span.RecordError(err)
+					span.SetStatus(codes.Error, err.Error())
 				}
 				return
 			}
@@ -240,9 +283,12 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 				logger.InfoContext(ctx, "Serving cached snapshot while mirror warms up", "upstream", upstreamURL)
 				w.Header().Set("Content-Type", "application/zstd")
 				n, err := serveReaderFast(w, r, reader)
-				s.metrics.recordSnapshotServe(ctx, "cold_cache", repoName, n)
+				s.metrics.recordSnapshotServe(ctx, "cold_cache", repoName, n, time.Since(start))
+				span.SetAttributes(attribute.String("cachew.source", "cold_cache"), attribute.Int64("cachew.bytes", n))
 				if err != nil {
 					logger.WarnContext(ctx, "Failed to stream cached snapshot", "upstream", upstreamURL, "error", err)
+					span.RecordError(err)
+					span.SetStatus(codes.Error, err.Error())
 				}
 				_ = reader.Close()
 				s.scheduleDeferredMirrorRestore(ctx, repo, entry)
@@ -271,15 +317,19 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 	}
 
 	if reader == nil {
-		if err := s.serveSnapshotWithSpool(w, r, repo, upstreamURL, repoName); err != nil {
+		if err := s.serveSnapshotWithSpool(w, r, repo, upstreamURL, repoName, start); err != nil {
 			logger.ErrorContext(ctx, "Failed to serve snapshot via spool", "upstream", upstreamURL, "error", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 		}
 		return
 	}
 	defer reader.Close()
 
-	if err := s.serveSnapshotWithBundle(ctx, w, r, reader, headers, repo, upstreamURL, repoName); err != nil {
+	if err := s.serveSnapshotWithBundle(ctx, w, r, reader, headers, repo, upstreamURL, repoName, start); err != nil {
 		logger.ErrorContext(ctx, "Failed to serve snapshot", "upstream", upstreamURL, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 	}
 }
 
@@ -314,27 +364,50 @@ func serveReaderFast(w http.ResponseWriter, r *http.Request, reader io.Reader) (
 	return n, errors.Wrap(err, "copy to response")
 }
 
-func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, host, pathValue string) {
-	ctx := r.Context()
-	logger := logging.FromContext(ctx)
-
+func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, host, pathValue string) { //nolint:funlen
+	start := time.Now()
 	repoPath := ExtractRepoPath(strings.TrimSuffix(pathValue, "/snapshot.bundle"))
 	upstreamURL := "https://" + host + "/" + repoPath
+	repoName := host + "/" + repoPath
+
+	ctx, span := tracer.Start(r.Context(), "git.bundle.serve",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "bundle_serve"),
+			attribute.String("cachew.upstream", upstreamURL),
+			attribute.String("cachew.repository", repoName),
+		),
+	)
+	defer span.End()
+	logger := logging.FromContext(ctx)
 
 	base := r.URL.Query().Get("base")
 	if base == "" {
 		http.Error(w, "missing base query parameter", http.StatusBadRequest)
+		span.SetAttributes(attribute.String("cachew.source", "bad_request"))
 		return
 	}
+	span.SetAttributes(attribute.String("cachew.base_commit", base))
 
 	bKey := bundleCacheKey(upstreamURL, base)
+
+	// Source and bytes are recorded by the deferred metric call.
+	source := "miss"
+	var bytes int64
+	defer func() {
+		span.SetAttributes(attribute.String("cachew.source", source), attribute.Int64("cachew.bytes", bytes))
+		s.metrics.recordBundleServe(ctx, source, repoName, bytes, time.Since(start))
+	}()
 
 	// Try serving from cache first — works on any pod.
 	if reader, _, err := s.cache.Open(ctx, bKey); err == nil && reader != nil {
 		defer reader.Close()
 		w.Header().Set("Content-Type", "application/x-git-bundle")
-		if _, err := io.Copy(w, reader); err != nil {
+		n, err := io.Copy(w, reader)
+		bytes = n
+		source = "cache"
+		if err != nil {
 			logger.WarnContext(ctx, "Failed to stream cached bundle", "upstream", upstreamURL, "error", err)
+			span.RecordError(err)
 		}
 		return
 	}
@@ -344,11 +417,15 @@ func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, h
 	if repoErr != nil {
 		logger.ErrorContext(ctx, "Failed to get or create clone", "upstream", upstreamURL, "error", repoErr)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		span.RecordError(repoErr)
+		span.SetStatus(codes.Error, repoErr.Error())
 		return
 	}
 	if cloneErr := s.ensureCloneReady(ctx, repo); cloneErr != nil {
 		logger.ErrorContext(ctx, "Clone unavailable for bundle", "upstream", upstreamURL, "error", cloneErr)
 		http.Error(w, "Repository unavailable", http.StatusServiceUnavailable)
+		span.RecordError(cloneErr)
+		span.SetStatus(codes.Error, cloneErr.Error())
 		return
 	}
 
@@ -356,6 +433,7 @@ func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, h
 	if err != nil {
 		logger.WarnContext(ctx, "Failed to create bundle", "upstream", upstreamURL, "base", base, "error", err)
 		http.Error(w, "Bundle not available", http.StatusNotFound)
+		span.RecordError(err)
 		return
 	}
 	defer bundleFile.Close()
@@ -368,14 +446,22 @@ func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, h
 	wc, cacheErr := s.cache.Create(ctx, bKey, http.Header{"Content-Type": {"application/x-git-bundle"}}, s.config.BundleCacheTTL)
 	if cacheErr != nil {
 		logger.WarnContext(ctx, "Failed to create bundle cache writer", "upstream", upstreamURL, "error", cacheErr)
-		if _, err := io.Copy(w, bundleFile); err != nil {
+		n, err := io.Copy(w, bundleFile)
+		bytes = n
+		source = "generated"
+		if err != nil {
 			logger.WarnContext(ctx, "Failed to stream bundle", "upstream", upstreamURL, "error", err)
+			span.RecordError(err)
 		}
 		return
 	}
-	if _, err := io.Copy(io.MultiWriter(w, wc), bundleFile); err != nil {
-		logger.WarnContext(ctx, "Failed to stream bundle", "upstream", upstreamURL, "error", err)
-		if abortErr := wc.Abort(err); abortErr != nil {
+	n, copyErr := io.Copy(io.MultiWriter(w, wc), bundleFile)
+	bytes = n
+	source = "generated"
+	if copyErr != nil {
+		logger.WarnContext(ctx, "Failed to stream bundle", "upstream", upstreamURL, "error", copyErr)
+		span.RecordError(copyErr)
+		if abortErr := wc.Abort(copyErr); abortErr != nil {
 			logger.WarnContext(ctx, "Failed to abort bundle cache writer", "upstream", upstreamURL, "error", abortErr)
 		}
 		return
@@ -385,7 +471,7 @@ func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, h
 	}
 }
 
-func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseWriter, r *http.Request, reader io.ReadCloser, headers http.Header, repo *gitclone.Repository, upstreamURL, repoName string) error {
+func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseWriter, r *http.Request, reader io.ReadCloser, headers http.Header, repo *gitclone.Repository, upstreamURL, repoName string, start time.Time) error {
 	snapshotCommit := headers.Get("X-Cachew-Snapshot-Commit")
 	mirrorHead := s.getMirrorHead(ctx, repo)
 
@@ -420,7 +506,10 @@ func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseW
 
 	w.Header().Set("Content-Type", "application/zstd")
 	n, err := serveReaderFast(w, r, reader)
-	s.metrics.recordSnapshotServe(ctx, "cache", repoName, n)
+	s.metrics.recordSnapshotServe(ctx, "cache", repoName, n, time.Since(start))
+	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		span.SetAttributes(attribute.String("cachew.source", "cache"), attribute.Int64("cachew.bytes", n))
+	}
 	return errors.Wrap(err, "stream snapshot")
 }
 
@@ -500,7 +589,7 @@ func (s *Strategy) createBundle(ctx context.Context, repo *gitclone.Repository, 
 // mirror, streams tar+zstd to both the HTTP client and a spool file, then
 // triggers a background cache backfill. Concurrent requests for the same URL
 // become readers that follow the spool, avoiding redundant clone+tar work.
-func (s *Strategy) serveSnapshotWithSpool(w http.ResponseWriter, r *http.Request, repo *gitclone.Repository, upstreamURL, repoName string) error {
+func (s *Strategy) serveSnapshotWithSpool(w http.ResponseWriter, r *http.Request, repo *gitclone.Repository, upstreamURL, repoName string, start time.Time) error {
 	ctx := r.Context()
 	logger := logging.FromContext(ctx)
 
@@ -511,26 +600,39 @@ func (s *Strategy) serveSnapshotWithSpool(w http.ResponseWriter, r *http.Request
 	entry := &snapshotSpoolEntry{ready: make(chan struct{})}
 	if existing, loaded := s.snapshotSpools.LoadOrStore(upstreamURL, entry); loaded {
 		winner := existing.(*snapshotSpoolEntry)
+		waitStart := time.Now()
 		<-winner.ready
+		wait := time.Since(waitStart)
 		if spool := winner.spool; spool != nil && !spool.Failed() {
-			logger.DebugContext(ctx, "Serving snapshot from spool", "upstream", upstreamURL)
+			logger.DebugContext(ctx, "Serving snapshot from spool", "upstream", upstreamURL, "wait", wait)
 			if err := spool.ServeTo(w); err != nil {
 				if errors.Is(err, ErrSpoolFailed) {
 					logger.DebugContext(ctx, "Snapshot spool failed before headers, falling back to direct stream", "upstream", upstreamURL)
+					s.metrics.recordSpoolFollowerWait(ctx, repoName, "writer_failed", wait)
 					return s.streamSnapshotDirect(w, r, repo)
 				}
+				s.metrics.recordSpoolFollowerWait(ctx, repoName, "read_error", wait)
 				return errors.Wrap(err, "snapshot spool read")
 			}
-			s.metrics.recordSnapshotServe(ctx, "spool", repoName, spool.Written())
+			s.metrics.recordSpoolFollowerWait(ctx, repoName, "served", wait)
+			s.metrics.recordSnapshotServe(ctx, "spool", repoName, spool.Written(), time.Since(start))
+			if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+				span.SetAttributes(attribute.String("cachew.source", "spool"), attribute.Int64("cachew.bytes", spool.Written()),
+					attribute.Float64("cachew.spool_wait_seconds", wait.Seconds()))
+			}
 			return nil
 		}
 		// Writer failed; fall through to generate independently.
+		s.metrics.recordSpoolFollowerWait(ctx, repoName, "writer_failed", wait)
 		return s.streamSnapshotDirect(w, r, repo)
 	}
 
-	err := s.writeSnapshotSpool(w, r, repo, upstreamURL, entry)
+	err := s.writeSnapshotSpool(w, r, repo, upstreamURL, repoName, entry)
 	if err == nil {
-		s.metrics.recordSnapshotServe(ctx, "generated", repoName, entry.spool.Written())
+		s.metrics.recordSnapshotServe(ctx, "generated", repoName, entry.spool.Written(), time.Since(start))
+		if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+			span.SetAttributes(attribute.String("cachew.source", "generated"), attribute.Int64("cachew.bytes", entry.spool.Written()))
+		}
 	}
 	return err
 }
@@ -602,12 +704,14 @@ func (s *Strategy) prepareSnapshotSpool(ctx context.Context, repo *gitclone.Repo
 // writeSnapshotSpool is the writer path for snapshot spooling. It creates a
 // spool, clones the mirror, streams the tar+zstd output through a SpoolTeeWriter,
 // and triggers a background cache backfill.
-func (s *Strategy) writeSnapshotSpool(w http.ResponseWriter, r *http.Request, repo *gitclone.Repository, upstreamURL string, entry *snapshotSpoolEntry) error {
+func (s *Strategy) writeSnapshotSpool(w http.ResponseWriter, r *http.Request, repo *gitclone.Repository, upstreamURL, repoName string, entry *snapshotSpoolEntry) error {
 	ctx := r.Context()
 	logger := logging.FromContext(ctx)
 
+	writerStart := time.Now()
 	spool, spoolDir, repoDir, err := s.prepareSnapshotSpool(ctx, repo, upstreamURL, entry)
 	if err != nil {
+		s.metrics.recordSpoolWriter(ctx, repoName, "prepare_error", time.Since(writerStart))
 		return errors.Wrap(err, "prepare snapshot spool")
 	}
 	snapshotDir := filepath.Dir(repoDir)
@@ -619,8 +723,10 @@ func (s *Strategy) writeSnapshotSpool(w http.ResponseWriter, r *http.Request, re
 	streamErr := snapshot.StreamTo(ctx, tw, repoDir, nil, s.config.ZstdThreads)
 	if streamErr != nil {
 		spool.MarkError(streamErr)
+		s.metrics.recordSpoolWriter(ctx, repoName, "error", time.Since(writerStart))
 	} else {
 		spool.MarkComplete()
+		s.metrics.recordSpoolWriter(ctx, repoName, "success", time.Since(writerStart))
 	}
 
 	go func() {
@@ -744,9 +850,23 @@ func snapshotSpoolDirForURL(mirrorRoot, upstreamURL string) (string, error) {
 //
 // The archive stores paths relative to .git/ (e.g. ./lfs/objects/xx/yy/sha256) so that
 // the client can extract it directly into the repo's .git/ directory.
-func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitclone.Repository) error {
-	logger := logging.FromContext(ctx)
+func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitclone.Repository) (returnErr error) {
 	upstream := repo.UpstreamURL()
+	ctx, span := tracer.Start(ctx, "git.snapshot.generate_lfs",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "lfs_snapshot_generate"),
+			attribute.String("cachew.upstream", upstream),
+		),
+	)
+	defer func() {
+		if returnErr != nil {
+			span.RecordError(returnErr)
+			span.SetStatus(codes.Error, returnErr.Error())
+		}
+		span.End()
+	}()
+
+	logger := logging.FromContext(ctx)
 
 	// Check if any .gitattributes file at HEAD declares filter=lfs. This searches
 	// the root and all nested .gitattributes, avoiding false negatives for repos


### PR DESCRIPTION
Adds the metrics and spans we need to actually measure cachew's git fast-path through blox (snapshot serve, bundle serve, ensure-refs, repack, spool fan-out) and to follow a single `cachew git restore` end-to-end from the workstation into cachewd.

### Server metrics (`cachew.git.*`)
- `snapshot_serve_duration_seconds` (added to existing `snapshot_serves_total` / `snapshot_serve_bytes`)
- `bundle_serves_total`, `bundle_serve_bytes`, `bundle_serve_duration_seconds` (source=`cache|generated|miss`)
- `ensure_refs_total`, `ensure_refs_duration_seconds` (fetched=true|false, status)
- `spool_writer_duration_seconds`, `spool_follower_waits_total`, `spool_follower_wait_seconds`
- `repack_pack_count` (stage=`before|after`)

### Server spans
- `git.snapshot.serve`, `git.bundle.serve`, `git.ensure_refs`
- `git.snapshot.generate`, `git.snapshot.generate_mirror`, `git.snapshot.generate_lfs`
- `git.repack`

### Client (`cachew git restore`) spans
- `cachew.git_restore` (root), `cachew.download_snapshot`, `cachew.extract`, `cachew.apply_bundle`, `cachew.satisfy_refs`, `cachew.ensure_refs`, `cachew.pull_origin`
- The CLI now also prints per-phase elapsed times to stderr for quick interactive timing.

### Trace propagation
- Initializes `tracing.New` in `cmd/cachew` so the short-lived CLI participates in tracing when `OTEL_EXPORTER_OTLP_ENDPOINT` is set (no-op otherwise).
- Wraps the cache client HTTP transport in `otelhttp` so outgoing requests inject `traceparent` and link to the cachewd handler span (which already runs under `otelhttp.NewMiddleware`).

### Validation
- `go build ./...` clean.
- `golangci-lint run` clean.
- `go test ./...` passes for non-docker packages (`client`, `cmd/cachew`, `internal/strategy/git`, `internal/tracing`, and the rest); `internal/cache` and `internal/metadatadb` need docker locally and are unchanged by this PR.