### PR TITLE
feat(observability): extend bandwidth buckets past 10 GbE saturation

### DIFF
--- a/internal/metrics/helper.go
+++ b/internal/metrics/helper.go
@@ -58,10 +58,12 @@ func SmallCountBuckets() []float64 {
 
 // BandwidthMbpsBuckets is for per-request throughput in MiB/s, covering
 // everything from slow long-tail clients (a few MiB/s) up through saturated
-// 10 GbE links (~1.2 GiB/s) and the parallel-stream-on-localhost ceiling.
+// 10 GbE workstations (~1.2 GiB/s) and into the ~12 GiB/s range of 100 Gbps
+// server NICs. Top bucket leaves headroom past the theoretical max so we
+// can spot misattribution.
 func BandwidthMbpsBuckets() []float64 {
 	return []float64{
-		1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000,
+		1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 15000,
 	}
 }
 


### PR DESCRIPTION
The bandwidth histogram added in #318 topped out at 5000 MiB/s (~5.2 GB/s), so any serve from ~5 GiB/s through the cachew server NIC ceiling (~12 GiB/s for 100 Gbps NICs) collapses into the `+Inf` bucket and we lose the signal where we most need it.

Adds 10000 and 15000 MiB/s buckets so `cachew.git.snapshot_serve_bandwidth_mbps` can distinguish 'saturating a 10 GbE workstation' from 'approaching the server NIC limit', with some headroom past the theoretical max to spot misattribution.

For context, the raw curl baseline we measured from a workstation was ~588 MiB/s — a small fraction of available server bandwidth, which is why visibility past the current top bucket matters for the next round of benchmarking.