### PR TITLE
fix(lfs): extend GitHub token refresh buffer + add LFS fetch timeout

### DIFF
--- a/internal/githubapp/config.go
+++ b/internal/githubapp/config.go
@@ -18,9 +18,12 @@ type TokenCacheConfig struct {
 }
 
 // DefaultTokenCacheConfig returns default token cache configuration.
+// RefreshBuffer must exceed the longest subprocess that bakes a token into
+// its environment, so a token can't expire mid-call (GitHub App tokens have
+// a fixed 1 h TTL).
 func DefaultTokenCacheConfig() TokenCacheConfig {
 	return TokenCacheConfig{
-		RefreshBuffer: 5 * time.Minute,
+		RefreshBuffer: 30 * time.Minute,
 		JWTExpiration: 10 * time.Minute,
 	}
 }

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -23,6 +23,8 @@ import (
 	"github.com/block/cachew/internal/snapshot"
 )
 
+const lfsFetchTimeout = 25 * time.Minute
+
 func snapshotDirForURL(mirrorRoot, upstreamURL string) (string, error) {
 	repoPath, err := gitclone.RepoPathFromURL(upstreamURL)
 	if err != nil {
@@ -915,15 +917,21 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 		}
 
 		// Fetch only the LFS objects referenced by HEAD (the default branch).
+		// Timeout must stay below githubapp.RefreshBuffer (30m) so the baked-in
+		// token can't expire mid-fetch and trigger a retry storm.
 		fetchStart := time.Now()
-		fetchCmd, err := repo.GitCommand(ctx, "-C", workDir, "lfs", "fetch", "origin", "HEAD")
+		fetchCtx, cancel := context.WithTimeout(ctx, lfsFetchTimeout)
+		fetchCmd, err := repo.GitCommand(fetchCtx, "-C", workDir, "lfs", "fetch", "origin", "HEAD")
 		if err != nil {
+			cancel()
 			s.metrics.recordLFSPhase(ctx, upstream, "fetch", "error", time.Since(fetchStart))
 			return errors.Wrap(err, "create git lfs fetch command")
 		}
-		if output, err := fetchCmd.CombinedOutput(); err != nil {
+		output, fetchErr := fetchCmd.CombinedOutput()
+		cancel()
+		if fetchErr != nil {
 			s.metrics.recordLFSPhase(ctx, upstream, "fetch", "error", time.Since(fetchStart))
-			return errors.Wrapf(err, "git lfs fetch: %s", string(output))
+			return errors.Wrapf(fetchErr, "git lfs fetch: %s", string(output))
 		}
 		s.metrics.recordLFSPhase(ctx, upstream, "fetch", "success", time.Since(fetchStart))
 

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -928,9 +928,9 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 			s.metrics.recordLFSPhase(ctx, upstream, "fetch", "error", time.Since(fetchStart))
 			return errors.Wrap(err, "create git lfs fetch command")
 		}
-		// Run in its own process group so the cancel below kills the whole
-		// tree — git-lfs spawns transfer helpers that inherit our pipes and
-		// can keep CombinedOutput blocked after the parent dies.
+		// git-lfs spawns transfer helpers that inherit our pipes; without
+		// killing the whole group, CombinedOutput stays blocked after the
+		// timeout fires.
 		fetchCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		fetchCmd.Cancel = func() error {
 			return syscall.Kill(-fetchCmd.Process.Pid, syscall.SIGKILL)

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/alecthomas/errors"
@@ -926,6 +927,13 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 			cancel()
 			s.metrics.recordLFSPhase(ctx, upstream, "fetch", "error", time.Since(fetchStart))
 			return errors.Wrap(err, "create git lfs fetch command")
+		}
+		// Run in its own process group so the cancel below kills the whole
+		// tree — git-lfs spawns transfer helpers that inherit our pipes and
+		// can keep CombinedOutput blocked after the parent dies.
+		fetchCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		fetchCmd.Cancel = func() error {
+			return syscall.Kill(-fetchCmd.Process.Pid, syscall.SIGKILL)
 		}
 		output, fetchErr := fetchCmd.CombinedOutput()
 		cancel()


### PR DESCRIPTION
## Problem

LFS snapshot jobs have been failing with repeated `Bad credentials` from the
GitHub LFS batch API. Individual jobs have been observed running for **12–26
hours** before something finally killed them:

```
git lfs fetch: Fetching reference refs/heads/main
batch response: Bad credentials
batch response: Bad credentials
... x6
error: failed to fetch some objects from '.../info/lfs'
: exit status 2, elapsed=25h58m40s
```

## Root cause

GitHub App installation tokens have a fixed **1 h server-side TTL** (not
configurable). The `TokenManager` cache served tokens until they had only
`RefreshBuffer = 5m` of validity remaining. That meant an LFS fetch starting
near a cache boundary could be handed a token with as little as ~5 minutes of
life left. If the fetch ran longer than that, the token expired mid-flight.
git-lfs's batch endpoint then retried with the **same** expired token (it's
baked into `credential.helper` as a literal), turning every retry into a 401,
and there was no per-subprocess timeout to stop the retry storm.

## Fix

Two coordinated changes that make `lfsFetchTimeout < RefreshBuffer` an
airtight invariant:

1. **`internal/githubapp/config.go`** — bump `RefreshBuffer` from `5m` to
   `30m`. Every token handed out now has at least 30 m of validity remaining.

2. **`internal/strategy/git/snapshot.go`** — wrap `git lfs fetch` in
   `context.WithTimeout(ctx, 25*time.Minute)`. Bounds the retry-storm
   runaway and guarantees no subprocess can outlive the token baked into
   its environment.

The 25 m < 30 m invariant is the airtight piece: the longest possible LFS
subprocess is shorter than the minimum remaining validity of any token it
could be handed, so a "Bad credentials" from token expiry should now be
impossible by construction on the LFS path.

## Why not a refresh-mid-subprocess approach?

That alternative (file-backed credential helper + background refresh
goroutine) is much more invasive — new shell-form helper, temp-file
lifecycle, refresh goroutine, symlink-safety, ~150 LOC + tests. It only
buys us coverage of subprocesses that legitimately run longer than 1 h,
which our metrics don't show.
