### PR TITLE
feat(snapshot): ETag-pinned range serving across disk and S3 tiers

### DIFF
--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -44,6 +45,10 @@ type Disk struct {
 	runEviction  chan struct{}
 	stop         context.CancelFunc
 	evictionDone chan struct{}
+	// replaceMu serializes a writer's rename→metadata commit against a pinned
+	// reader's metadata→open, so the reader never observes a new file under old
+	// metadata. A pointer so namespaced shallow copies share one lock.
+	replaceMu *sync.RWMutex
 }
 
 var _ Cache = (*Disk)(nil)
@@ -118,6 +123,7 @@ func NewDisk(ctx context.Context, config DiskConfig) (*Disk, error) {
 		runEviction:  make(chan struct{}),
 		stop:         stop,
 		evictionDone: make(chan struct{}),
+		replaceMu:    &sync.RWMutex{},
 	}
 	disk.size.Store(size)
 
@@ -467,6 +473,11 @@ func (w *diskWriter) Close() error {
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return errors.Errorf("failed to create directory: %w", err)
 	}
+
+	// Hold replaceMu so the rename and metadata commit are atomic to pinned
+	// readers: they never see the new file paired with the old metadata.
+	w.disk.replaceMu.Lock()
+	defer w.disk.replaceMu.Unlock()
 
 	// Check if we're overwriting an existing file and subtract its size
 	if info, err := os.Stat(w.path); err == nil {

--- a/internal/cache/disk_pinned.go
+++ b/internal/cache/disk_pinned.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/errors"
+)
+
+var _ PinnedRangeCache = (*Disk)(nil)
+
+// Pin returns a pin token for a disk entry, but only when it carries a content
+// ETag (set by S3 and persisted via tiered backfill). Locally generated entries
+// never round-tripped through S3 have no content ETag and are reported absent so
+// callers fall back to the authoritative shared tier.
+func (d *Disk) Pin(_ context.Context, key Key) (PinnedObject, error) {
+	d.replaceMu.RLock()
+	defer d.replaceMu.RUnlock()
+	headers, err := d.db.getHeaders(d.namespace, key)
+	if err != nil {
+		return PinnedObject{}, os.ErrNotExist
+	}
+	etag := headers.Get(ContentETagHeader)
+	if etag == "" {
+		return PinnedObject{}, os.ErrNotExist
+	}
+	expiresAt, err := d.db.getTTL(d.namespace, key)
+	if err != nil || time.Now().After(expiresAt) {
+		return PinnedObject{}, os.ErrNotExist
+	}
+	info, err := os.Stat(filepath.Join(d.config.Root, d.keyToPath(d.namespace, key)))
+	if err != nil {
+		return PinnedObject{}, os.ErrNotExist
+	}
+	headers.Set("Content-Length", strconv.FormatInt(info.Size(), 10))
+	return PinnedObject{Pin: pinETagPrefix + etag, Size: info.Size(), Headers: headers}, nil
+}
+
+// OpenPinnedRange serves bytes from start of the local copy, with the file's
+// total size, but only when its stored content ETag matches the pin. Any
+// mismatch, missing ETag, expiry, or absent file returns os.ErrNotExist so the
+// tiered cache falls through to S3; a start at or past EOF returns
+// ErrRangeNotSatisfiable.
+//
+// The returned *os.File is seeked to start; the caller bounds reads to the range
+// length (io.CopyN), which keeps the sendfile zero-copy path.
+func (d *Disk) OpenPinnedRange(ctx context.Context, key Key, pin string, start, _ int64) (io.ReadCloser, int64, error) {
+	etag, ok := strings.CutPrefix(pin, pinETagPrefix)
+	if !ok {
+		return nil, 0, errors.Errorf("unsupported pin token %q", pin)
+	}
+	// Hold replaceMu across the metadata read and file open so the opened fd
+	// matches the validated ETag; the fd then survives any later rename-over.
+	d.replaceMu.RLock()
+	defer d.replaceMu.RUnlock()
+	headers, err := d.db.getHeaders(d.namespace, key)
+	if err != nil || headers.Get(ContentETagHeader) != etag {
+		return nil, 0, os.ErrNotExist
+	}
+	expiresAt, err := d.db.getTTL(d.namespace, key)
+	if err != nil {
+		return nil, 0, os.ErrNotExist
+	}
+	if time.Now().After(expiresAt) {
+		return nil, 0, errors.Join(os.ErrNotExist, d.Delete(ctx, key))
+	}
+	f, err := os.Open(filepath.Join(d.config.Root, d.keyToPath(d.namespace, key)))
+	if err != nil {
+		return nil, 0, os.ErrNotExist
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return nil, 0, errors.Join(errors.Errorf("stat %s: %w", key, err), f.Close())
+	}
+	if start >= info.Size() {
+		return nil, info.Size(), errors.Join(ErrRangeNotSatisfiable, f.Close())
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil, 0, errors.Join(errors.Errorf("seek to %d: %w", start, err), f.Close())
+	}
+	return f, info.Size(), nil
+}

--- a/internal/cache/disk_pinned_test.go
+++ b/internal/cache/disk_pinned_test.go
@@ -1,0 +1,94 @@
+package cache_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/logging"
+)
+
+func newPinnableDisk(t *testing.T) *cache.Disk {
+	t.Helper()
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	c, err := cache.NewDisk(ctx, cache.DiskConfig{Root: t.TempDir(), MaxTTL: time.Minute})
+	assert.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func writeDiskEntry(t *testing.T, c cache.Cache, key cache.Key, headers http.Header, data []byte) {
+	t.Helper()
+	w, err := c.Create(t.Context(), key, headers, 0)
+	assert.NoError(t, err)
+	_, err = w.Write(data)
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+}
+
+// TestDiskPinnedRange verifies that a disk entry carrying a content ETag (as set
+// by S3 and persisted via tiered backfill) serves byte ranges that stitch back
+// to the original, and that the wrong token is reported absent so the tiered
+// cache falls through to S3.
+func TestDiskPinnedRange(t *testing.T) {
+	c := newPinnableDisk(t)
+	ctx := t.Context()
+	key := cache.NewKey("disk-pinned")
+
+	data := make([]byte, 4<<20)
+	_, err := rand.Read(data)
+	assert.NoError(t, err)
+
+	writeDiskEntry(t, c, key, http.Header{cache.ContentETagHeader: {"etag-abc"}}, data)
+
+	pin, err := c.Pin(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(data)), pin.Size)
+	assert.Equal(t, cache.ETagPin("etag-abc"), pin.Pin)
+
+	chunk := int64(len(data)) / 2
+	got := make([]byte, len(data))
+	for _, b := range [][2]int64{{chunk, int64(len(data)) - 1}, {0, chunk - 1}} {
+		r, total, err := c.OpenPinnedRange(ctx, key, pin.Pin, b[0], b[1])
+		assert.NoError(t, err)
+		assert.Equal(t, int64(len(data)), total)
+		part, err := io.ReadAll(io.LimitReader(r, b[1]-b[0]+1))
+		assert.NoError(t, err)
+		assert.NoError(t, r.Close())
+		copy(got[b[0]:], part)
+	}
+	assert.True(t, bytes.Equal(data, got), "stitched disk ranges must match original")
+
+	// A start past EOF is reported as not satisfiable.
+	_, _, err = c.OpenPinnedRange(ctx, key, pin.Pin, int64(len(data)), int64(len(data))+10)
+	assert.IsError(t, err, cache.ErrRangeNotSatisfiable)
+
+	// A token for a different revision must not be served from disk.
+	_, _, err = c.OpenPinnedRange(ctx, key, cache.ETagPin("etag-other"), 0, chunk-1)
+	assert.IsError(t, err, os.ErrNotExist)
+}
+
+// TestDiskPinnedRangeNotPinnableWithoutETag verifies that a locally generated
+// disk entry (never round-tripped through S3, so no content ETag) is not
+// pinnable, forcing callers to the authoritative shared tier.
+func TestDiskPinnedRangeNotPinnableWithoutETag(t *testing.T) {
+	c := newPinnableDisk(t)
+	ctx := t.Context()
+	key := cache.NewKey("disk-no-etag")
+
+	writeDiskEntry(t, c, key, nil, []byte("hello world"))
+
+	_, err := c.Pin(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+
+	_, _, err = c.OpenPinnedRange(ctx, key, cache.ETagPin("anything"), 0, 4)
+	assert.IsError(t, err, os.ErrNotExist)
+}

--- a/internal/cache/pinned.go
+++ b/internal/cache/pinned.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/alecthomas/errors"
+)
+
+// ErrPinStale is returned when the pinned object revision no longer exists
+// (e.g. the snapshot was regenerated mid-download). Callers should re-pin and
+// restart the transfer.
+var ErrPinStale = errors.New("pinned object revision is stale")
+
+// ErrRangeNotSatisfiable is returned when the requested range starts at or past
+// the end of the object.
+var ErrRangeNotSatisfiable = errors.New("pinned range not satisfiable")
+
+// ContentETagHeader carries an object's content ETag across cache tiers. S3
+// surfaces its native (content-derived) ETag under this header; tiered backfill
+// then stores it alongside the disk copy, so a disk-served range and an
+// S3-served range of the same revision report the same pin token.
+const ContentETagHeader = "X-Cachew-Content-Etag"
+
+// pinETagPrefix tags ETag-based pin tokens. Keeping the token prefixed lets a
+// "version:" form (S3 VersionId) be added later without changing the wire format.
+const pinETagPrefix = "etag:"
+
+// ETagPin builds a pin token from a content ETag.
+func ETagPin(etag string) string { return pinETagPrefix + etag }
+
+// PinnedObject describes an immutable revision of a cached object. The opaque
+// Pin token lets a client fetch byte ranges that all resolve to the same
+// revision, so parallel ranges stitch correctly even across cachew replicas.
+type PinnedObject struct {
+	// Pin is an opaque token identifying the object revision. It is echoed back
+	// to the client and supplied on subsequent range requests.
+	Pin string
+	// Size is the total object size in bytes.
+	Size int64
+	// Headers are the stored object headers (Content-Type, Last-Modified, etc.).
+	Headers http.Header
+}
+
+// PinnedRangeCache is implemented by caches that can serve a byte range from a
+// specific immutable object revision. It backs parallel snapshot downloads:
+// the client pins once, then fetches ranges concurrently against that revision.
+type PinnedRangeCache interface {
+	// Pin stats the object and returns an opaque revision token plus size and
+	// headers. Returns os.ErrNotExist if the object is absent.
+	Pin(ctx context.Context, key Key) (PinnedObject, error)
+	// OpenPinnedRange returns a reader positioned at start for the revision
+	// identified by pin, along with the object's total size. The caller must
+	// read at most min(end, total-1)-start+1 bytes; a backend that can bound
+	// cheaply (S3 via Range) does so, while a disk backend returns the seeked
+	// file so the caller's io.CopyN keeps the sendfile path. Returns
+	// ErrPinStale if the revision changed, ErrRangeNotSatisfiable if start is at
+	// or past total, or os.ErrNotExist if absent.
+	OpenPinnedRange(ctx context.Context, key Key, pin string, start, end int64) (r io.ReadCloser, total int64, err error)
+}

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -158,6 +158,13 @@ func (s *S3) statAndHeaders(ctx context.Context, key Key) (minio.ObjectInfo, htt
 		headers.Set("Last-Modified", objInfo.LastModified.UTC().Format(http.TimeFormat))
 	}
 
+	// Surface S3's content-derived ETag so it flows through Open into the
+	// tiered backfill and is persisted on the disk copy. This lets a disk and
+	// an S3 serve of the same revision report the same pin token.
+	if objInfo.ETag != "" {
+		headers.Set(ContentETagHeader, objInfo.ETag)
+	}
+
 	return objInfo, headers, nil
 }
 
@@ -243,10 +250,14 @@ func (r *s3Reader) Read(p []byte) (int, error) {
 	if err == nil || errors.Is(err, io.EOF) {
 		return n, err //nolint:wrapcheck
 	}
-	// Convert NoSuchKey to os.ErrNotExist for consistency
 	errResponse := minio.ToErrorResponse(err)
-	if errResponse.Code == s3ErrNoSuchKey {
+	switch {
+	case errResponse.Code == s3ErrNoSuchKey:
+		// Convert NoSuchKey to os.ErrNotExist for consistency.
 		return n, os.ErrNotExist
+	case errResponse.StatusCode == http.StatusPreconditionFailed || errResponse.Code == "PreconditionFailed":
+		// A pinned (If-Match ETag) range whose object was overwritten.
+		return n, ErrPinStale
 	}
 	return n, errors.WithStack(err)
 }

--- a/internal/cache/s3_pinned.go
+++ b/internal/cache/s3_pinned.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"context"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/alecthomas/errors"
+	"github.com/minio/minio-go/v7"
+)
+
+var _ PinnedRangeCache = (*S3)(nil)
+
+// Pin returns an opaque revision token (the S3 ETag) for the object, so that
+// subsequent range reads can be pinned to this exact revision.
+func (s *S3) Pin(ctx context.Context, key Key) (PinnedObject, error) {
+	objInfo, headers, err := s.statAndHeaders(ctx, key)
+	if err != nil {
+		return PinnedObject{}, err
+	}
+	headers.Set("Content-Length", strconv.FormatInt(objInfo.Size, 10))
+	return PinnedObject{
+		Pin:     pinETagPrefix + objInfo.ETag,
+		Size:    objInfo.Size,
+		Headers: headers,
+	}, nil
+}
+
+// OpenPinnedRange serves bytes [start, min(end, total-1)] from the revision
+// identified by pin. It stats the object first so a stale pin (the object was
+// overwritten) fails closed with ErrPinStale before any data is written, and an
+// out-of-range start returns ErrRangeNotSatisfiable. A SetMatchETag guard on the
+// GET still covers the narrow stat→get race.
+func (s *S3) OpenPinnedRange(ctx context.Context, key Key, pin string, start, end int64) (io.ReadCloser, int64, error) {
+	etag, ok := strings.CutPrefix(pin, pinETagPrefix)
+	if !ok {
+		return nil, 0, errors.Errorf("unsupported pin token %q", pin)
+	}
+
+	objInfo, _, err := s.statAndHeaders(ctx, key)
+	if err != nil {
+		return nil, 0, err
+	}
+	if objInfo.ETag != etag {
+		return nil, 0, ErrPinStale
+	}
+	if start >= objInfo.Size {
+		return nil, objInfo.Size, ErrRangeNotSatisfiable
+	}
+	if end >= objInfo.Size {
+		end = objInfo.Size - 1
+	}
+
+	objectName := s.keyToPath(s.namespace, key)
+	opts := minio.GetObjectOptions{}
+	if err := opts.SetRange(start, end); err != nil {
+		return nil, 0, errors.Errorf("set range %d-%d: %w", start, end, err)
+	}
+	if err := opts.SetMatchETag(etag); err != nil {
+		return nil, 0, errors.Errorf("set etag %s: %w", etag, err)
+	}
+
+	// GetObject is lazy and must not be Stat()'d here: calling Stat() after
+	// SetRange makes minio re-fetch the whole object. A 412 from the race guard
+	// surfaces on Read and is mapped to ErrPinStale by s3Reader.Read.
+	obj, err := s.client.GetObject(ctx, s.config.Bucket, objectName, opts)
+	if err != nil {
+		return nil, 0, errors.Errorf("get pinned range: %w", err)
+	}
+	return &s3Reader{obj: obj}, objInfo.Size, nil
+}

--- a/internal/cache/s3_pinned_test.go
+++ b/internal/cache/s3_pinned_test.go
@@ -1,0 +1,75 @@
+package cache_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/s3client/s3clienttest"
+)
+
+// TestS3PinnedRange verifies that an object can be pinned and reassembled
+// byte-for-byte from independent ranged reads, and that overwriting the object
+// invalidates the old pin (fail-closed) rather than mixing revisions.
+func TestS3PinnedRange(t *testing.T) {
+	bucket := s3clienttest.Start(t)
+	c := newS3Cache(t, bucket)
+	defer c.Close()
+
+	pc, ok := c.(cache.PinnedRangeCache)
+	assert.True(t, ok, "S3 cache must implement PinnedRangeCache")
+
+	ctx := t.Context()
+	key := cache.NewKey("pinned-object")
+
+	// 10 MiB of random data so multiple distinct ranges are exercised.
+	data := make([]byte, 10<<20)
+	_, err := rand.Read(data)
+	assert.NoError(t, err)
+
+	w, err := c.Create(ctx, key, nil, 0)
+	assert.NoError(t, err)
+	_, err = w.Write(data)
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	pin, err := pc.Pin(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(data)), pin.Size)
+	assert.NotZero(t, pin.Pin)
+
+	// Reassemble from four ranges in arbitrary order.
+	chunk := int64(len(data)) / 4
+	bounds := [][2]int64{
+		{2 * chunk, 3*chunk - 1},
+		{0, chunk - 1},
+		{3 * chunk, int64(len(data)) - 1},
+		{chunk, 2*chunk - 1},
+	}
+	got := make([]byte, len(data))
+	for _, b := range bounds {
+		r, total, err := pc.OpenPinnedRange(ctx, key, pin.Pin, b[0], b[1])
+		assert.NoError(t, err)
+		assert.Equal(t, int64(len(data)), total)
+		part, err := io.ReadAll(r)
+		assert.NoError(t, err)
+		assert.NoError(t, r.Close())
+		assert.Equal(t, b[1]-b[0]+1, int64(len(part)))
+		copy(got[b[0]:], part)
+	}
+	assert.True(t, bytes.Equal(data, got), "stitched ranges must match original")
+
+	// Overwrite the object: the old pin must now fail closed up front.
+	w2, err := c.Create(ctx, key, nil, 0)
+	assert.NoError(t, err)
+	_, err = w2.Write(make([]byte, len(data)))
+	assert.NoError(t, err)
+	assert.NoError(t, w2.Close())
+
+	_, _, err = pc.OpenPinnedRange(ctx, key, pin.Pin, 0, chunk-1)
+	assert.IsError(t, err, cache.ErrPinStale)
+}

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -340,3 +340,47 @@ func (t Tiered) ListNamespaces(ctx context.Context) ([]string, error) {
 	sort.Strings(namespaces)
 	return namespaces, nil
 }
+
+var _ PinnedRangeCache = (*Tiered)(nil)
+
+// Pin returns a pin token from the authoritative shared tier (the last pinnable
+// tier, i.e. S3) so the token is consistent across replicas. A disk tier may
+// hold a stale copy, so it must not mint the cross-replica pin.
+func (t Tiered) Pin(ctx context.Context, key Key) (PinnedObject, error) {
+	for i := len(t.caches) - 1; i >= 0; i-- {
+		pc, ok := t.caches[i].(PinnedRangeCache)
+		if !ok {
+			continue
+		}
+		obj, err := pc.Pin(ctx, key)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return obj, errors.WithStack(err)
+	}
+	return PinnedObject{}, os.ErrNotExist
+}
+
+// OpenPinnedRange serves a range from the first tier that holds the pinned
+// revision, preferring local disk (sendfile zero-copy) over S3. A disk miss or
+// ETag mismatch returns os.ErrNotExist, which falls through to S3; S3's
+// ErrPinStale (the revision was overwritten) propagates to fail the request closed.
+func (t Tiered) OpenPinnedRange(ctx context.Context, key Key, pin string, start, end int64) (io.ReadCloser, int64, error) {
+	var found bool
+	for _, c := range t.caches {
+		pc, ok := c.(PinnedRangeCache)
+		if !ok {
+			continue
+		}
+		found = true
+		rc, total, err := pc.OpenPinnedRange(ctx, key, pin, start, end)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return rc, total, errors.WithStack(err)
+	}
+	if !found {
+		return nil, 0, errors.New("no pinnable cache tier configured")
+	}
+	return nil, 0, os.ErrNotExist
+}

--- a/internal/cache/tiered_pinned_test.go
+++ b/internal/cache/tiered_pinned_test.go
@@ -1,0 +1,83 @@
+package cache_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/s3client"
+	"github.com/block/cachew/internal/s3client/s3clienttest"
+)
+
+// TestTieredPinnedRangeFallthrough verifies the disk-first/S3-fallback pin path:
+// a range is served from S3 while disk is cold, and after a tiered Open backfills
+// the disk copy (persisting S3's content ETag) the same pin serves identical bytes
+// from disk. The pin token is identical across both, so chunks stitch regardless
+// of which tier answers each range.
+func TestTieredPinnedRangeFallthrough(t *testing.T) {
+	bucket := s3clienttest.Start(t)
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+
+	disk, err := cache.NewDisk(ctx, cache.DiskConfig{Root: t.TempDir(), LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	defer disk.Close()
+
+	clientProvider := s3client.NewClientProvider(ctx, s3client.Config{Endpoint: s3clienttest.Addr, UseSSL: false})
+	s3, err := cache.NewS3(ctx, cache.S3Config{Bucket: bucket, MaxTTL: time.Hour, UploadPartSizeMB: 16}, clientProvider)
+	assert.NoError(t, err)
+	defer s3.Close()
+
+	key := cache.NewKey("tiered-pinned")
+	data := make([]byte, 4<<20)
+	_, err = rand.Read(data)
+	assert.NoError(t, err)
+
+	// Seed S3 only, leaving the disk tier cold.
+	w, err := s3.Create(ctx, key, nil, 0)
+	assert.NoError(t, err)
+	_, err = w.Write(data)
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{disk, s3}).(cache.PinnedRangeCache)
+
+	pin, err := tiered.Pin(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(data)), pin.Size)
+
+	stitch := func() []byte {
+		t.Helper()
+		chunk := int64(len(data)) / 2
+		got := make([]byte, len(data))
+		for _, b := range [][2]int64{{0, chunk - 1}, {chunk, int64(len(data)) - 1}} {
+			r, total, err := tiered.OpenPinnedRange(ctx, key, pin.Pin, b[0], b[1])
+			assert.NoError(t, err)
+			assert.Equal(t, int64(len(data)), total)
+			part, err := io.ReadAll(io.LimitReader(r, b[1]-b[0]+1))
+			assert.NoError(t, err)
+			assert.NoError(t, r.Close())
+			copy(got[b[0]:], part)
+		}
+		return got
+	}
+
+	// Disk cold: served from S3.
+	assert.True(t, bytes.Equal(data, stitch()), "S3-fallback ranges must match")
+
+	// Warm the disk tier; backfill persists S3's content ETag onto the disk copy.
+	r, _, err := tiered.(cache.Cache).Open(ctx, key)
+	assert.NoError(t, err)
+	_, err = io.Copy(io.Discard, r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+
+	// Disk warm: same pin still serves identical bytes (now from disk).
+	assert.True(t, bytes.Equal(data, stitch()), "disk-served ranges must match")
+}

--- a/internal/strategy/git/parse_range_test.go
+++ b/internal/strategy/git/parse_range_test.go
@@ -1,0 +1,91 @@
+package git //nolint:testpackage // white-box test for unexported range helpers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/cache"
+)
+
+func TestParseSingleByteRange(t *testing.T) {
+	tests := []struct {
+		header     string
+		start, end int64
+		ok         bool
+	}{
+		{"bytes=0-99", 0, 99, true},
+		{"bytes=100-199", 100, 199, true},
+		{"bytes=5-5", 5, 5, true},
+		{"", 0, 0, false},
+		{"bytes=0-", 0, 0, false},           // open-ended rejected
+		{"bytes=-100", 0, 0, false},         // suffix rejected
+		{"bytes=0-99,200-299", 0, 0, false}, // multi-range rejected
+		{"bytes=99-0", 0, 0, false},         // end < start rejected
+		{"items=0-99", 0, 0, false},         // wrong unit
+		{"bytes=a-b", 0, 0, false},          // non-numeric
+	}
+	for _, tt := range tests {
+		start, end, ok := parseSingleByteRange(tt.header)
+		assert.Equal(t, tt.ok, ok, "ok for %q", tt.header)
+		if tt.ok {
+			assert.Equal(t, tt.start, start, "start for %q", tt.header)
+			assert.Equal(t, tt.end, end, "end for %q", tt.header)
+		}
+	}
+}
+
+// failPinCache fails the test if the pinned-range handler reaches the cache,
+// proving the oversized-range guard rejects the request before any read.
+type failPinCache struct{ t *testing.T }
+
+func (p failPinCache) Pin(context.Context, cache.Key) (cache.PinnedObject, error) {
+	p.t.Fatal("Pin must not be called")
+	return cache.PinnedObject{}, nil //nolint:nilnil // unreachable; t.Fatal above
+}
+
+func (p failPinCache) OpenPinnedRange(context.Context, cache.Key, string, int64, int64) (io.ReadCloser, int64, error) {
+	p.t.Fatal("OpenPinnedRange must not be called for an oversized range")
+	return nil, 0, nil
+}
+
+func TestServePinnedRangeRejectsOversizedRange(t *testing.T) {
+	s := &Strategy{}
+	req := httptest.NewRequest(http.MethodGet, "/git/x/snapshot.tar.zst", nil)
+	// Length = maxPinRangeBytes + 1, one byte over the cap.
+	req.Header.Set("Range", fmt.Sprintf("bytes=0-%d", int64(maxPinRangeBytes)))
+	w := httptest.NewRecorder()
+
+	s.servePinnedRange(w, req, failPinCache{t}, cache.NewKey("k"), "repo", "x", time.Now())
+
+	assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, w.Code)
+}
+
+func TestStrongIfMatchETag(t *testing.T) {
+	tests := []struct {
+		header string
+		etag   string
+		ok     bool
+	}{
+		{`"abc123"`, "abc123", true},
+		{`  "abc123"  `, "abc123", true},
+		{"", "", false},
+		{"*", "", false},
+		{`W/"abc123"`, "", false},   // weak validator rejected
+		{`"abc", "def"`, "", false}, // multi-value rejected
+		{"abc123", "", false},       // unquoted rejected
+	}
+	for _, tt := range tests {
+		etag, ok := strongIfMatchETag(tt.header)
+		assert.Equal(t, tt.ok, ok, "ok for %q", tt.header)
+		if tt.ok {
+			assert.Equal(t, tt.etag, etag, "etag for %q", tt.header)
+		}
+	}
+}

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -248,6 +250,20 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 
 	cacheKey := snapshotCacheKey(upstreamURL)
 
+	// Parallel download path: a Range request carrying a strong If-Match ETag is
+	// pinned to one content revision, so concurrent chunks stitch correctly
+	// across replicas and a regenerated snapshot fails closed (412) rather than
+	// mixing revisions. Served from the tiered cache (disk first, then S3),
+	// bypassing the cold-start/freshness logic below.
+	if rangeHdr := r.Header.Get("Range"); rangeHdr != "" {
+		if etag, matched := strongIfMatchETag(r.Header.Get("If-Match")); matched {
+			if pc, pinnable := s.cache.(cache.PinnedRangeCache); pinnable {
+				s.servePinnedRange(w, r, pc, cacheKey, repoName, etag, start)
+				return
+			}
+		}
+	}
+
 	// On cold start the local mirror may not be ready yet. Check the S3 cache
 	// first so we can stream a cached snapshot to the client immediately while
 	// the mirror restores in the background. This avoids blocking the client
@@ -257,7 +273,7 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 		if existing, loaded := s.coldSnapshotMu.LoadOrStore(upstreamURL, entry); loaded {
 			winner := existing.(*coldSnapshotEntry)
 			<-winner.done
-			reader, _, openErr := s.cache.Open(ctx, cacheKey)
+			reader, hdrs, openErr := s.cache.Open(ctx, cacheKey)
 			if openErr == nil && reader != nil {
 				winner.serving.Add(1)
 				defer func() {
@@ -266,6 +282,7 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 				}()
 				logger.InfoContext(ctx, "Serving locally cached snapshot after waiting for in-flight fill", "upstream", upstreamURL)
 				w.Header().Set("Content-Type", "application/zstd")
+				advertiseSnapshotValidators(w, hdrs)
 				n, err := serveReaderFast(w, r, reader)
 				s.metrics.recordSnapshotServe(ctx, "cold_cache", repoName, n, time.Since(start))
 				span.SetAttributes(attribute.String("cachew.source", "cold_cache"), attribute.Int64("cachew.bytes", n))
@@ -281,10 +298,11 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 				close(entry.done)
 				s.coldSnapshotMu.Delete(upstreamURL)
 			}()
-			reader, _, openErr := s.cache.Open(ctx, cacheKey)
+			reader, hdrs, openErr := s.cache.Open(ctx, cacheKey)
 			if openErr == nil && reader != nil {
 				logger.InfoContext(ctx, "Serving cached snapshot while mirror warms up", "upstream", upstreamURL)
 				w.Header().Set("Content-Type", "application/zstd")
+				advertiseSnapshotValidators(w, hdrs)
 				n, err := serveReaderFast(w, r, reader)
 				s.metrics.recordSnapshotServe(ctx, "cold_cache", repoName, n, time.Since(start))
 				span.SetAttributes(attribute.String("cachew.source", "cold_cache"), attribute.Int64("cachew.bytes", n))
@@ -334,6 +352,133 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 	}
+}
+
+// maxPinRangeBytes caps a single pinned range. Ranges are streamed, not
+// buffered, but a cap still bounds the work one request can demand and keeps
+// clients on reasonable chunk sizes.
+const maxPinRangeBytes = 256 << 20 // 256 MiB
+
+// advertiseSnapshotValidators sets the headers a parallel-download client needs
+// to discover the pin: the content ETag (strong validator) and Accept-Ranges.
+// They are set only when the cache surfaced a content ETag; entries without one
+// are served as a normal stream and the client won't attempt ranges.
+func advertiseSnapshotValidators(w http.ResponseWriter, headers http.Header) {
+	if etag := headers.Get(cache.ContentETagHeader); etag != "" {
+		w.Header().Set("ETag", strconv.Quote(etag))
+		w.Header().Set("Accept-Ranges", "bytes")
+	}
+}
+
+// strongIfMatchETag extracts a single strong ETag from an If-Match header,
+// returning false for missing, weak (W/...), "*", or multi-value forms. A
+// content-revision pin must be a single strong validator.
+func strongIfMatchETag(header string) (string, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" || header == "*" || strings.Contains(header, ",") || strings.HasPrefix(header, "W/") {
+		return "", false
+	}
+	etag, err := strconv.Unquote(header)
+	if err != nil {
+		return "", false
+	}
+	return etag, true
+}
+
+// servePinnedRange serves one byte range pinned to the client's If-Match content
+// ETag. Every range across a parallel download resolves to the same revision, so
+// chunks stitch correctly no matter which replica handles each request. The
+// tiered cache serves from local disk when its stored ETag matches (sendfile
+// zero-copy), else from S3. A revision overwritten mid-download fails closed
+// with 412 so the client re-reads the validator and restarts.
+func (s *Strategy) servePinnedRange(w http.ResponseWriter, r *http.Request, pc cache.PinnedRangeCache, cacheKey cache.Key, repoName, etag string, start time.Time) {
+	ctx := r.Context()
+	startByte, endByte, ok := parseSingleByteRange(r.Header.Get("Range"))
+	// endByte-startByte is overflow-safe (both non-negative, end >= start); the
+	// length form endByte-startByte+1 is not.
+	if !ok || endByte-startByte >= maxPinRangeBytes {
+		http.Error(w, "invalid or oversized range", http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+
+	reader, total, err := pc.OpenPinnedRange(ctx, cacheKey, cache.ETagPin(etag), startByte, endByte)
+	switch {
+	case errors.Is(err, cache.ErrRangeNotSatisfiable):
+		http.Error(w, "range not satisfiable", http.StatusRequestedRangeNotSatisfiable)
+		return
+	case errors.Is(err, cache.ErrPinStale), errors.Is(err, os.ErrNotExist):
+		// The revision is gone (overwritten or evicted). Fail closed.
+		http.Error(w, "snapshot revision unavailable", http.StatusPreconditionFailed)
+		return
+	case err != nil:
+		logging.FromContext(ctx).ErrorContext(ctx, "Failed to open pinned range", "repo", repoName, "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	defer reader.Close()
+
+	// A disk *os.File is validated up front, so it can stream directly (and via
+	// sendfile). A lazy S3 reader can still 412 on the stat→get race, so force
+	// its first read with a one-byte peek to surface that before the 206 status.
+	body := io.Reader(reader)
+	if _, isFile := reader.(*os.File); !isFile {
+		br := bufio.NewReader(reader)
+		if _, err := br.Peek(1); err != nil {
+			switch {
+			case errors.Is(err, cache.ErrPinStale), errors.Is(err, os.ErrNotExist):
+				http.Error(w, "snapshot revision unavailable", http.StatusPreconditionFailed)
+			default:
+				logging.FromContext(ctx).ErrorContext(ctx, "Failed to read pinned range", "repo", repoName, "error", err)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			}
+			return
+		}
+		body = br
+	}
+
+	// Clamp the end to the object so the advertised length matches the bytes a
+	// backend actually serves (a client may request a chunk past EOF).
+	if endByte >= total {
+		endByte = total - 1
+	}
+	length := endByte - startByte + 1
+
+	w.Header().Set("Content-Type", "application/zstd")
+	w.Header().Set("ETag", strconv.Quote(etag))
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", startByte, endByte, total))
+	w.WriteHeader(http.StatusPartialContent)
+
+	// io.CopyN bounds a disk *os.File to length while preserving sendfile; an S3
+	// reader is already bounded to the range by SetRange.
+	n, err := io.CopyN(w, body, length)
+	if err != nil && !errors.Is(err, io.EOF) {
+		logging.FromContext(ctx).WarnContext(ctx, "Failed to write pinned range", "repo", repoName, "error", err)
+	}
+	s.metrics.recordSnapshotServe(ctx, "pin_range", repoName, n, time.Since(start))
+}
+
+// parseSingleByteRange parses a closed "bytes=a-b" range header. Open-ended or
+// multi-range forms are rejected; pinned clients always request closed ranges.
+func parseSingleByteRange(header string) (start, end int64, ok bool) {
+	spec, found := strings.CutPrefix(header, "bytes=")
+	if !found || strings.Contains(spec, ",") {
+		return 0, 0, false
+	}
+	lo, hi, found := strings.Cut(spec, "-")
+	if !found || lo == "" || hi == "" {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseInt(lo, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	end, err = strconv.ParseInt(hi, 10, 64)
+	if err != nil || end < start {
+		return 0, 0, false
+	}
+	return start, end, true
 }
 
 func (s *Strategy) streamSnapshotArtifact(_ context.Context, w http.ResponseWriter, r *http.Request, reader io.ReadCloser, headers http.Header) error {
@@ -508,6 +653,7 @@ func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseW
 	}
 
 	w.Header().Set("Content-Type", "application/zstd")
+	advertiseSnapshotValidators(w, headers)
 	n, err := serveReaderFast(w, r, reader)
 	s.metrics.recordSnapshotServe(ctx, "cache", repoName, n, time.Since(start))
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {


### PR DESCRIPTION
Serve snapshot byte ranges pinned to a content ETag using standard HTTP `ETag` / `If-Match` / `Range`. Parallel chunk downloads stitch correctly across replicas, and a snapshot regenerated mid-download fails closed with `412` rather than mixing revisions.

S3 surfaces its content ETag, which flows through the tiered backfill onto the disk copy. The tiered cache serves a pinned range from local disk when its stored ETag matches (sendfile zero-copy) and falls back to S3 otherwise; disk entries that never round-tripped through S3 carry no content ETag and are not pinnable. Normal snapshot responses advertise `ETag` + `Accept-Ranges` so clients can discover the pin.

The `PinnedRangeCache` interface is implemented by disk, S3, and tiered. Tests cover S3 and disk range stitching, disk fail-closed on ETag mismatch, non-pinnable ETag-less disk entries, tiered disk-first/S3-fallback after backfill, and handler `If-Match`/range validation.