### PR TITLE
feat: add ETag support with conditional request handling

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -57,43 +57,44 @@ type CacheWriter interface {
 	Abort(err error) error
 }
 
-// Preconditions holds conditional request parameters (RFC 7232).
-type Preconditions struct {
+// OpenOptions holds optional parameters for Open, including conditional
+// request headers (RFC 7232).
+type OpenOptions struct {
 	IfNoneMatch string
 	IfMatch     string
 }
 
-// Precondition configures a conditional request parameter.
-type Precondition func(*Preconditions)
+// OpenOption configures an optional parameter for Open.
+type OpenOption func(*OpenOptions)
 
 // WithIfNoneMatch sets the If-None-Match precondition.
 // For GET/HEAD, a matching ETag results in ErrNotModified.
 // For POST, a matching ETag results in ErrPreconditionFailed.
-func WithIfNoneMatch(etag string) Precondition {
-	return func(p *Preconditions) {
+func WithIfNoneMatch(etag string) OpenOption {
+	return func(p *OpenOptions) {
 		p.IfNoneMatch = etag
 	}
 }
 
 // WithIfMatch sets the If-Match precondition.
 // If the server's ETag does not match, ErrPreconditionFailed is returned.
-func WithIfMatch(etag string) Precondition {
-	return func(p *Preconditions) {
+func WithIfMatch(etag string) OpenOption {
+	return func(p *OpenOptions) {
 		p.IfMatch = etag
 	}
 }
 
-// ResolvePreconditions collects variadic precondition options into a Preconditions struct.
-func ResolvePreconditions(conds []Precondition) Preconditions {
-	var p Preconditions
+// ResolveOpenOptions collects variadic options into an OpenOptions struct.
+func ResolveOpenOptions(conds []OpenOption) OpenOptions {
+	var p OpenOptions
 	for _, c := range conds {
 		c(&p)
 	}
 	return p
 }
 
-func applyPreconditions(req *http.Request, conds []Precondition) {
-	p := ResolvePreconditions(conds)
+func applyOpenOptions(req *http.Request, conds []OpenOption) {
+	p := ResolveOpenOptions(conds)
 	if p.IfNoneMatch != "" {
 		req.Header.Set("If-None-Match", p.IfNoneMatch)
 	}
@@ -199,13 +200,13 @@ func (c *Client) objectURL(key Key) string {
 }
 
 // Open retrieves an object from the cache server.
-func (c *Client) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
+func (c *Client) Open(ctx context.Context, key Key, conds ...OpenOption) (io.ReadCloser, http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.objectURL(key), nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create request")
 	}
 
-	applyPreconditions(req, conds)
+	applyOpenOptions(req, conds)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -238,13 +239,13 @@ func (c *Client) Open(ctx context.Context, key Key, conds ...Precondition) (io.R
 }
 
 // Stat retrieves headers for an object from the cache server.
-func (c *Client) Stat(ctx context.Context, key Key, conds ...Precondition) (http.Header, error) {
+func (c *Client) Stat(ctx context.Context, key Key, conds ...OpenOption) (http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.objectURL(key), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")
 	}
 
-	applyPreconditions(req, conds)
+	applyOpenOptions(req, conds)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -274,7 +275,7 @@ func (c *Client) Stat(ctx context.Context, key Key, conds ...Precondition) (http
 // Create stores a new object in the cache server. The returned CacheWriter
 // must be closed to commit the upload. Call Abort instead of Close to discard
 // the in-progress write and ensure the object is never made visible.
-func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, conds ...Precondition) (CacheWriter, error) {
+func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, conds ...OpenOption) (CacheWriter, error) {
 	ctx, cancel := context.WithCancelCause(ctx)
 	pr, pw := io.Pipe()
 
@@ -290,7 +291,7 @@ func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl t
 		req.Header.Set("Time-To-Live", ttl.String())
 	}
 
-	applyPreconditions(req, conds)
+	applyOpenOptions(req, conds)
 
 	wc := &writeCloser{
 		pw:     pw,
@@ -325,13 +326,13 @@ func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl t
 }
 
 // Delete removes an object from the cache server.
-func (c *Client) Delete(ctx context.Context, key Key, conds ...Precondition) error {
+func (c *Client) Delete(ctx context.Context, key Key, conds ...OpenOption) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.objectURL(key), nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create request")
 	}
 
-	applyPreconditions(req, conds)
+	applyOpenOptions(req, conds)
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,12 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
+// ErrNotModified is returned when a conditional request results in a 304 Not Modified response.
+var ErrNotModified = errors.New("not modified")
+
+// ErrPreconditionFailed is returned when a conditional request results in a 412 Precondition Failed response.
+var ErrPreconditionFailed = errors.New("precondition failed")
+
 // HTTPStatusError is returned when the server responds with an unexpected
 // HTTP status code. Callers can use errors.As to inspect the status code.
 type HTTPStatusError struct {
@@ -49,6 +55,51 @@ type CacheWriter interface {
 	// The provided error is recorded as the cause of cancellation.
 	// The object MUST NOT be made available in the cache after Abort.
 	Abort(err error) error
+}
+
+// Preconditions holds conditional request parameters (RFC 7232).
+type Preconditions struct {
+	IfNoneMatch string
+	IfMatch     string
+}
+
+// Precondition configures a conditional request parameter.
+type Precondition func(*Preconditions)
+
+// WithIfNoneMatch sets the If-None-Match precondition.
+// For GET/HEAD, a matching ETag results in ErrNotModified.
+// For POST, a matching ETag results in ErrPreconditionFailed.
+func WithIfNoneMatch(etag string) Precondition {
+	return func(p *Preconditions) {
+		p.IfNoneMatch = etag
+	}
+}
+
+// WithIfMatch sets the If-Match precondition.
+// If the server's ETag does not match, ErrPreconditionFailed is returned.
+func WithIfMatch(etag string) Precondition {
+	return func(p *Preconditions) {
+		p.IfMatch = etag
+	}
+}
+
+// ResolvePreconditions collects variadic precondition options into a Preconditions struct.
+func ResolvePreconditions(conds []Precondition) Preconditions {
+	var p Preconditions
+	for _, c := range conds {
+		c(&p)
+	}
+	return p
+}
+
+func applyPreconditions(req *http.Request, conds []Precondition) {
+	p := ResolvePreconditions(conds)
+	if p.IfNoneMatch != "" {
+		req.Header.Set("If-None-Match", p.IfNoneMatch)
+	}
+	if p.IfMatch != "" {
+		req.Header.Set("If-Match", p.IfMatch)
+	}
 }
 
 // HeaderFunc returns headers to attach to each outgoing request.
@@ -148,11 +199,13 @@ func (c *Client) objectURL(key Key) string {
 }
 
 // Open retrieves an object from the cache server.
-func (c *Client) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error) {
+func (c *Client) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.objectURL(key), nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create request")
 	}
+
+	applyPreconditions(req, conds)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -164,6 +217,18 @@ func (c *Client) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header,
 		return nil, nil, errors.Join(os.ErrNotExist, resp.Body.Close())
 	}
 
+	if resp.StatusCode == http.StatusNotModified {
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		headers := filterHeaders(resp.Header, transportHeaders...)
+		return nil, headers, errors.Join(ErrNotModified, resp.Body.Close())
+	}
+
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		headers := filterHeaders(resp.Header, transportHeaders...)
+		return nil, headers, errors.Join(ErrPreconditionFailed, resp.Body.Close())
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
 		return nil, nil, errors.Join(errors.WithStack(&HTTPStatusError{StatusCode: resp.StatusCode}), resp.Body.Close())
@@ -173,11 +238,13 @@ func (c *Client) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header,
 }
 
 // Stat retrieves headers for an object from the cache server.
-func (c *Client) Stat(ctx context.Context, key Key) (http.Header, error) {
+func (c *Client) Stat(ctx context.Context, key Key, conds ...Precondition) (http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.objectURL(key), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")
 	}
+
+	applyPreconditions(req, conds)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -187,6 +254,14 @@ func (c *Client) Stat(ctx context.Context, key Key) (http.Header, error) {
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, os.ErrNotExist
+	}
+
+	if resp.StatusCode == http.StatusNotModified {
+		return filterHeaders(resp.Header, transportHeaders...), ErrNotModified
+	}
+
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return nil, ErrPreconditionFailed
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -199,7 +274,7 @@ func (c *Client) Stat(ctx context.Context, key Key) (http.Header, error) {
 // Create stores a new object in the cache server. The returned CacheWriter
 // must be closed to commit the upload. Call Abort instead of Close to discard
 // the in-progress write and ensure the object is never made visible.
-func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (CacheWriter, error) {
+func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, conds ...Precondition) (CacheWriter, error) {
 	ctx, cancel := context.WithCancelCause(ctx)
 	pr, pw := io.Pipe()
 
@@ -214,6 +289,8 @@ func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl t
 	if ttl > 0 {
 		req.Header.Set("Time-To-Live", ttl.String())
 	}
+
+	applyPreconditions(req, conds)
 
 	wc := &writeCloser{
 		pw:     pw,
@@ -231,6 +308,11 @@ func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl t
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
 		_ = resp.Body.Close()                 //nolint:gosec
 
+		if resp.StatusCode == http.StatusPreconditionFailed {
+			wc.done <- ErrPreconditionFailed
+			return
+		}
+
 		if resp.StatusCode != http.StatusOK {
 			wc.done <- errors.WithStack(&HTTPStatusError{StatusCode: resp.StatusCode})
 			return
@@ -243,11 +325,13 @@ func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl t
 }
 
 // Delete removes an object from the cache server.
-func (c *Client) Delete(ctx context.Context, key Key) error {
+func (c *Client) Delete(ctx context.Context, key Key, conds ...Precondition) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.objectURL(key), nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create request")
 	}
+
+	applyPreconditions(req, conds)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -257,6 +341,10 @@ func (c *Client) Delete(ctx context.Context, key Key) error {
 
 	if resp.StatusCode == http.StatusNotFound {
 		return os.ErrNotExist
+	}
+
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return ErrPreconditionFailed
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -120,6 +120,27 @@ func NewKey(s string) Key { return client.NewKey(s) }
 // Stats contains health and usage statistics for a cache.
 type Stats = client.Stats
 
+// Precondition configures a conditional request parameter for Open.
+type Precondition = client.Precondition
+
+// Preconditions holds resolved conditional request parameters.
+type Preconditions = client.Preconditions
+
+// ResolvePreconditions collects variadic options into a Preconditions struct.
+var ResolvePreconditions = client.ResolvePreconditions //nolint:gochecknoglobals
+
+// WithIfMatch sets the If-Match precondition.
+var WithIfMatch = client.WithIfMatch //nolint:gochecknoglobals
+
+// WithIfNoneMatch sets the If-None-Match precondition.
+var WithIfNoneMatch = client.WithIfNoneMatch //nolint:gochecknoglobals
+
+// ErrNotModified is returned by Open when an If-None-Match precondition matches.
+var ErrNotModified = client.ErrNotModified
+
+// ErrPreconditionFailed is returned by Open when an If-Match precondition fails.
+var ErrPreconditionFailed = client.ErrPreconditionFailed
+
 // A Cache knows how to retrieve, create and delete objects from a cache.
 //
 // Objects in the cache are not guaranteed to persist and implementations may delete them at any time.
@@ -139,7 +160,9 @@ type Cache interface {
 	// Expired files MUST NOT be returned.
 	// The returned headers MUST include a Last-Modified header.
 	// Must return os.ErrNotExist if the file does not exist.
-	Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error)
+	// Must return ErrNotModified if an If-None-Match precondition matches.
+	// Must return ErrPreconditionFailed if an If-Match precondition fails.
+	Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error)
 	// Create a new file in the cache.
 	//
 	// If "ttl" is zero, a maximum TTL MUST be used by the implementation.

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -120,14 +120,14 @@ func NewKey(s string) Key { return client.NewKey(s) }
 // Stats contains health and usage statistics for a cache.
 type Stats = client.Stats
 
-// Precondition configures a conditional request parameter for Open.
-type Precondition = client.Precondition
+// OpenOption configures an optional parameter for Open.
+type OpenOption = client.OpenOption
 
-// Preconditions holds resolved conditional request parameters.
-type Preconditions = client.Preconditions
+// OpenOptions holds resolved optional parameters for Open.
+type OpenOptions = client.OpenOptions
 
-// ResolvePreconditions collects variadic options into a Preconditions struct.
-var ResolvePreconditions = client.ResolvePreconditions //nolint:gochecknoglobals
+// ResolveOpenOptions collects variadic options into an OpenOptions struct.
+var ResolveOpenOptions = client.ResolveOpenOptions //nolint:gochecknoglobals
 
 // WithIfMatch sets the If-Match precondition.
 var WithIfMatch = client.WithIfMatch //nolint:gochecknoglobals
@@ -162,7 +162,7 @@ type Cache interface {
 	// Must return os.ErrNotExist if the file does not exist.
 	// Must return ErrNotModified if an If-None-Match precondition matches.
 	// Must return ErrPreconditionFailed if an If-Match precondition fails.
-	Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error)
+	Open(ctx context.Context, key Key, conds ...OpenOption) (io.ReadCloser, http.Header, error)
 	// Create a new file in the cache.
 	//
 	// If "ttl" is zero, a maximum TTL MUST be used by the implementation.

--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,6 +61,22 @@ func Suite(t *testing.T, newCache func(t *testing.T) cache.Cache) {
 
 	t.Run("ContentLength", func(t *testing.T) {
 		testContentLength(t, newCache(t))
+	})
+
+	t.Run("ETag", func(t *testing.T) {
+		testETag(t, newCache(t))
+	})
+
+	t.Run("ETagConsistency", func(t *testing.T) {
+		testETagConsistency(t, newCache(t))
+	})
+
+	t.Run("OpenIfNoneMatch", func(t *testing.T) {
+		testOpenIfNoneMatch(t, newCache(t))
+	})
+
+	t.Run("OpenIfMatch", func(t *testing.T) {
+		testOpenIfMatch(t, newCache(t))
 	})
 
 	t.Run("NamespaceIsolation", func(t *testing.T) {
@@ -369,6 +386,124 @@ func testContentLength(t *testing.T, c cache.Cache) {
 	statHeaders, err := c.Stat(ctx, key)
 	assert.NoError(t, err)
 	assert.Equal(t, strconv.Itoa(len(content)), statHeaders.Get("Content-Length"))
+}
+
+func testETag(t *testing.T, c cache.Cache) {
+	defer c.Close()
+	ctx := t.Context()
+
+	key := cache.NewKey("test-etag")
+
+	writer, err := c.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = writer.Write([]byte("hello world"))
+	assert.NoError(t, err)
+	assert.NoError(t, writer.Close())
+
+	reader, headers, err := c.Open(ctx, key)
+	assert.NoError(t, err)
+	defer reader.Close()
+
+	etag := headers.Get("ETag")
+	assert.NotZero(t, etag, "ETag header should be set")
+	assert.True(t, strings.HasPrefix(etag, `"sha256:`), "ETag should be a sha256-based strong ETag, got: %s", etag)
+	assert.True(t, strings.HasSuffix(etag, `"`), "ETag should end with a quote")
+
+	statHeaders, err := c.Stat(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, etag, statHeaders.Get("ETag"))
+}
+
+func testETagConsistency(t *testing.T, c cache.Cache) {
+	defer c.Close()
+	ctx := t.Context()
+
+	content := []byte("identical content for etag consistency")
+
+	key1 := cache.NewKey("etag-consistency-1")
+	w1, err := c.Create(ctx, key1, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w1.Write(content)
+	assert.NoError(t, err)
+	assert.NoError(t, w1.Close())
+
+	key2 := cache.NewKey("etag-consistency-2")
+	w2, err := c.Create(ctx, key2, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w2.Write(content)
+	assert.NoError(t, err)
+	assert.NoError(t, w2.Close())
+
+	_, h1, err := c.Open(ctx, key1)
+	assert.NoError(t, err)
+	_, h2, err := c.Open(ctx, key2)
+	assert.NoError(t, err)
+
+	assert.Equal(t, h1.Get("ETag"), h2.Get("ETag"))
+}
+
+func testOpenIfNoneMatch(t *testing.T, c cache.Cache) {
+	defer c.Close()
+	ctx := t.Context()
+
+	key := cache.NewKey("test-if-none-match")
+	w, err := c.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("some content"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	// Get the ETag
+	_, headers, err := c.Open(ctx, key)
+	assert.NoError(t, err)
+	etag := headers.Get("ETag")
+	assert.NotZero(t, etag)
+
+	// If-None-Match with matching ETag → ErrNotModified
+	_, retHeaders, err := c.Open(ctx, key, cache.WithIfNoneMatch(etag))
+	assert.IsError(t, err, cache.ErrNotModified)
+	assert.Equal(t, etag, retHeaders.Get("ETag"))
+
+	// If-None-Match with non-matching ETag → success
+	reader, _, err := c.Open(ctx, key, cache.WithIfNoneMatch(`"wrong"`))
+	assert.NoError(t, err)
+	assert.NoError(t, reader.Close())
+
+	// If-None-Match on non-existent key → ErrNotExist (not ErrNotModified)
+	_, _, err = c.Open(ctx, cache.NewKey("nonexistent"), cache.WithIfNoneMatch(etag))
+	assert.IsError(t, err, os.ErrNotExist)
+}
+
+func testOpenIfMatch(t *testing.T, c cache.Cache) {
+	defer c.Close()
+	ctx := t.Context()
+
+	key := cache.NewKey("test-if-match")
+	w, err := c.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("some content"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	// Get the ETag
+	_, headers, err := c.Open(ctx, key)
+	assert.NoError(t, err)
+	etag := headers.Get("ETag")
+	assert.NotZero(t, etag)
+
+	// If-Match with matching ETag → success
+	reader, _, err := c.Open(ctx, key, cache.WithIfMatch(etag))
+	assert.NoError(t, err)
+	assert.NoError(t, reader.Close())
+
+	// If-Match with non-matching ETag → ErrPreconditionFailed
+	_, retHeaders, err := c.Open(ctx, key, cache.WithIfMatch(`"wrong"`))
+	assert.IsError(t, err, cache.ErrPreconditionFailed)
+	assert.Equal(t, etag, retHeaders.Get("ETag"))
+
+	// If-Match on non-existent key → ErrNotExist (not ErrPreconditionFailed)
+	_, _, err = c.Open(ctx, cache.NewKey("nonexistent"), cache.WithIfMatch(etag))
+	assert.IsError(t, err, os.ErrNotExist)
 }
 
 func testNamespaceIsolation(t *testing.T, c cache.Cache) {

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -259,7 +259,7 @@ func (d *Disk) Stat(ctx context.Context, key Key) (http.Header, error) {
 	return headers, nil
 }
 
-func (d *Disk) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
+func (d *Disk) Open(ctx context.Context, key Key, conds ...OpenOption) (io.ReadCloser, http.Header, error) {
 	path := d.keyToPath(d.namespace, key)
 	fullPath := filepath.Join(d.config.Root, path)
 

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -187,6 +187,7 @@ func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl tim
 	return &diskWriter{
 		disk:      d,
 		file:      f,
+		hasher:    NewHashingWriter(f),
 		key:       key,
 		namespace: d.namespace,
 		path:      fullPath,
@@ -258,7 +259,7 @@ func (d *Disk) Stat(ctx context.Context, key Key) (http.Header, error) {
 	return headers, nil
 }
 
-func (d *Disk) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error) {
+func (d *Disk) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
 	path := d.keyToPath(d.namespace, key)
 	fullPath := filepath.Join(d.config.Root, path)
 
@@ -280,6 +281,10 @@ func (d *Disk) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, e
 	headers, err := d.db.getHeaders(d.namespace, key)
 	if err != nil {
 		return nil, nil, errors.Join(errors.Errorf("failed to get headers: %w", err), f.Close())
+	}
+
+	if err := CheckPreconditions(headers, conds...); err != nil {
+		return nil, headers, errors.Join(err, f.Close())
 	}
 
 	finfo, err := f.Stat()
@@ -432,6 +437,7 @@ func (d *Disk) evictBySize(remainingFiles []evictFileInfo) error {
 type diskWriter struct {
 	disk      *Disk
 	file      *os.File
+	hasher    *HashingWriter
 	key       Key
 	namespace Namespace
 	path      string
@@ -445,7 +451,7 @@ type diskWriter struct {
 }
 
 func (w *diskWriter) Write(p []byte) (int, error) {
-	n, err := w.file.Write(p)
+	n, err := w.hasher.Write(p)
 	w.size += int64(n)
 	return n, errors.WithStack(err)
 }
@@ -470,6 +476,8 @@ func (w *diskWriter) Close() error {
 		// Clean up temp file and abort
 		return errors.Join(errors.Wrap(err, "create operation cancelled"), os.Remove(w.tempPath))
 	}
+
+	SetETag(w.headers, w.hasher.ETag())
 
 	// Ensure directory exists (eviction may have removed it)
 	dir := filepath.Dir(w.path)

--- a/internal/cache/etag.go
+++ b/internal/cache/etag.go
@@ -74,25 +74,32 @@ var RequestHeaders = []string{ //nolint:gochecknoglobals
 
 // CheckIfNoneMatch reports whether the given ETag matches any of the values in
 // the If-None-Match header using weak comparison (RFC 7232 §3.2).
-// Handles the special "*" wildcard.
+// The "*" wildcard matches any existing resource, even one without an ETag.
 func CheckIfNoneMatch(ifNoneMatch string, etag string) bool {
-	if ifNoneMatch == "" || etag == "" {
+	if ifNoneMatch == "" {
 		return false
 	}
 	if ifNoneMatch == "*" {
 		return true
 	}
+	if etag == "" {
+		return false
+	}
 	return parseETagList(ifNoneMatch, etag, true)
 }
 
 // CheckIfMatch reports whether the given ETag satisfies the If-Match
-// precondition. An empty If-Match header is always satisfied.
+// precondition (RFC 7232 §3.1). An empty If-Match header is always satisfied.
+// The "*" wildcard is satisfied by any existing resource, even one without an ETag.
 func CheckIfMatch(ifMatch string, etag string) bool {
 	if ifMatch == "" {
 		return true
 	}
 	if ifMatch == "*" {
-		return etag != ""
+		return true
+	}
+	if etag == "" {
+		return false
 	}
 	return parseETagList(ifMatch, etag, false)
 }

--- a/internal/cache/etag.go
+++ b/internal/cache/etag.go
@@ -47,11 +47,11 @@ func SetETag(headers http.Header, etag string) {
 // CheckPreconditions evaluates If-Match and If-None-Match preconditions against
 // the given headers. Returns ErrPreconditionFailed or ErrNotModified if a
 // precondition is not satisfied, or nil if all preconditions pass.
-func CheckPreconditions(headers http.Header, conds ...Precondition) error {
+func CheckPreconditions(headers http.Header, conds ...OpenOption) error {
 	if len(conds) == 0 {
 		return nil
 	}
-	p := ResolvePreconditions(conds)
+	p := ResolveOpenOptions(conds)
 	etag := headers.Get("ETag")
 	if p.IfMatch != "" && !CheckIfMatch(p.IfMatch, etag) {
 		return ErrPreconditionFailed

--- a/internal/cache/etag.go
+++ b/internal/cache/etag.go
@@ -1,0 +1,187 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+	"net/http"
+
+	"github.com/alecthomas/errors"
+)
+
+// HashingWriter wraps an io.Writer to compute a SHA-256 content hash as data
+// passes through. After all writes complete, call ETag() to retrieve the
+// resulting strong ETag value.
+type HashingWriter struct {
+	w    io.Writer
+	hash hash.Hash
+}
+
+// NewHashingWriter returns a writer that hashes all bytes written through it.
+func NewHashingWriter(w io.Writer) *HashingWriter {
+	h := sha256.New()
+	return &HashingWriter{
+		w:    io.MultiWriter(w, h),
+		hash: h,
+	}
+}
+
+// Write passes p through to the underlying writer and updates the hash.
+func (hw *HashingWriter) Write(p []byte) (int, error) {
+	n, err := hw.w.Write(p)
+	return n, errors.WithStack(err)
+}
+
+// ETag returns the strong ETag derived from the content hash.
+// Must only be called after all writes are complete.
+func (hw *HashingWriter) ETag() string {
+	return `"sha256:` + hex.EncodeToString(hw.hash.Sum(nil)) + `"`
+}
+
+// SetETag injects an ETag header into the given header map.
+func SetETag(headers http.Header, etag string) {
+	headers.Set("ETag", etag)
+}
+
+// CheckPreconditions evaluates If-Match and If-None-Match preconditions against
+// the given headers. Returns ErrPreconditionFailed or ErrNotModified if a
+// precondition is not satisfied, or nil if all preconditions pass.
+func CheckPreconditions(headers http.Header, conds ...Precondition) error {
+	if len(conds) == 0 {
+		return nil
+	}
+	p := ResolvePreconditions(conds)
+	etag := headers.Get("ETag")
+	if p.IfMatch != "" && !CheckIfMatch(p.IfMatch, etag) {
+		return ErrPreconditionFailed
+	}
+	if p.IfNoneMatch != "" && CheckIfNoneMatch(p.IfNoneMatch, etag) {
+		return ErrNotModified
+	}
+	return nil
+}
+
+// RequestHeaders that should be stripped when storing object metadata.
+// These are per-request conditional headers that should not be persisted.
+var RequestHeaders = []string{ //nolint:gochecknoglobals
+	"If-Match",
+	"If-None-Match",
+	"If-Modified-Since",
+	"If-Unmodified-Since",
+	"If-Range",
+}
+
+// CheckIfNoneMatch reports whether the given ETag matches any of the values in
+// the If-None-Match header using weak comparison (RFC 7232 §3.2).
+// Handles the special "*" wildcard.
+func CheckIfNoneMatch(ifNoneMatch string, etag string) bool {
+	if ifNoneMatch == "" || etag == "" {
+		return false
+	}
+	if ifNoneMatch == "*" {
+		return true
+	}
+	return parseETagList(ifNoneMatch, etag, true)
+}
+
+// CheckIfMatch reports whether the given ETag satisfies the If-Match
+// precondition. An empty If-Match header is always satisfied.
+func CheckIfMatch(ifMatch string, etag string) bool {
+	if ifMatch == "" {
+		return true
+	}
+	if ifMatch == "*" {
+		return etag != ""
+	}
+	return parseETagList(ifMatch, etag, false)
+}
+
+// parseETagList checks if targetETag appears in a comma-separated ETag list.
+// When weakComparison is true, W/ prefixes are ignored (RFC 7232 §2.3.2).
+// When false, strong comparison is used (RFC 7232 §2.3.1).
+func parseETagList(list, targetETag string, weakComparison bool) bool {
+	for list != "" {
+		// Skip leading whitespace and commas
+		for len(list) > 0 && (list[0] == ' ' || list[0] == '\t' || list[0] == ',') {
+			list = list[1:]
+		}
+		if list == "" {
+			break
+		}
+
+		// Handle weak ETags by skipping the W/ prefix for comparison
+		candidate := list
+		weak := false
+		if len(candidate) >= 2 && candidate[0] == 'W' && candidate[1] == '/' {
+			candidate = candidate[2:]
+			weak = true
+		}
+
+		if len(candidate) == 0 || candidate[0] != '"' {
+			// Malformed — skip to next comma
+			if idx := indexOf(list, ','); idx >= 0 {
+				list = list[idx+1:]
+			} else {
+				break
+			}
+			continue
+		}
+
+		// Find closing quote
+		end := 1
+		for end < len(candidate) && candidate[end] != '"' {
+			end++
+		}
+		if end >= len(candidate) {
+			break
+		}
+		end++ // include closing quote
+
+		etag := candidate[:end]
+		if weak {
+			etag = "W/" + etag
+		}
+
+		var match bool
+		if weakComparison {
+			match = weakEqual(etag, targetETag)
+		} else {
+			match = strongEqual(etag, targetETag)
+		}
+		if match {
+			return true
+		}
+
+		list = candidate[end:]
+	}
+	return false
+}
+
+func strongEqual(a, b string) bool {
+	return a == b && !isWeakETag(a) && !isWeakETag(b)
+}
+
+func isWeakETag(etag string) bool {
+	return len(etag) >= 2 && etag[0] == 'W' && etag[1] == '/'
+}
+
+func weakEqual(a, b string) bool {
+	return stripWeakPrefix(a) == stripWeakPrefix(b)
+}
+
+func stripWeakPrefix(etag string) string {
+	if len(etag) >= 2 && etag[0] == 'W' && etag[1] == '/' {
+		return etag[2:]
+	}
+	return etag
+}
+
+func indexOf(s string, c byte) int {
+	for i := range len(s) {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/cache/etag_test.go
+++ b/internal/cache/etag_test.go
@@ -19,7 +19,7 @@ func TestCheckIfNoneMatch(t *testing.T) {
 		{"EmptyIfNoneMatch", "", `"abc"`, false},
 		{"EmptyETag", `"abc"`, "", false},
 		{"WildcardMatchesAny", "*", `"abc"`, true},
-		{"WildcardEmptyETag", "*", "", false},
+		{"WildcardMatchesEmptyETag", "*", "", true},
 		{"ExactMatchStrong", `"abc"`, `"abc"`, true},
 		{"NoMatch", `"abc"`, `"xyz"`, false},
 		{"MultipleOneMatches", `"aaa", "bbb", "ccc"`, `"bbb"`, true},
@@ -43,7 +43,7 @@ func TestCheckIfMatch(t *testing.T) {
 	}{
 		{"EmptyIfMatch", "", `"abc"`, true},
 		{"WildcardNonEmpty", "*", `"abc"`, true},
-		{"WildcardEmptyETag", "*", "", false},
+		{"WildcardMatchesEmptyETag", "*", "", true},
 		{"ExactMatch", `"abc"`, `"abc"`, true},
 		{"NoMatch", `"abc"`, `"xyz"`, false},
 		{"MultipleOneMatches", `"aaa", "bbb", "ccc"`, `"bbb"`, true},

--- a/internal/cache/etag_test.go
+++ b/internal/cache/etag_test.go
@@ -1,0 +1,98 @@
+package cache_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/cache"
+)
+
+func TestCheckIfNoneMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		ifNoneMatch string
+		etag        string
+		expected    bool
+	}{
+		{"EmptyIfNoneMatch", "", `"abc"`, false},
+		{"EmptyETag", `"abc"`, "", false},
+		{"WildcardMatchesAny", "*", `"abc"`, true},
+		{"WildcardEmptyETag", "*", "", false},
+		{"ExactMatchStrong", `"abc"`, `"abc"`, true},
+		{"NoMatch", `"abc"`, `"xyz"`, false},
+		{"MultipleOneMatches", `"aaa", "bbb", "ccc"`, `"bbb"`, true},
+		{"MultipleNoneMatch", `"aaa", "bbb", "ccc"`, `"zzz"`, false},
+		{"WeakMatchesStrong", `W/"abc"`, `"abc"`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cache.CheckIfNoneMatch(tt.ifNoneMatch, tt.etag)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestCheckIfMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		ifMatch  string
+		etag     string
+		expected bool
+	}{
+		{"EmptyIfMatch", "", `"abc"`, true},
+		{"WildcardNonEmpty", "*", `"abc"`, true},
+		{"WildcardEmptyETag", "*", "", false},
+		{"ExactMatch", `"abc"`, `"abc"`, true},
+		{"NoMatch", `"abc"`, `"xyz"`, false},
+		{"MultipleOneMatches", `"aaa", "bbb", "ccc"`, `"bbb"`, true},
+		{"WeakDoesNotMatchStrong", `W/"abc"`, `"abc"`, false},
+		{"WeakDoesNotMatchWeak", `W/"abc"`, `W/"abc"`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cache.CheckIfMatch(tt.ifMatch, tt.etag)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestHashingWriter(t *testing.T) {
+	t.Run("Format", func(t *testing.T) {
+		hw := cache.NewHashingWriter(io.Discard)
+		_, err := hw.Write([]byte("hello world"))
+		assert.NoError(t, err)
+
+		etag := hw.ETag()
+		assert.True(t, len(etag) > len(`"sha256:"`), "ETag too short: %s", etag)
+		assert.Equal(t, `"sha256:`, etag[:8])
+		assert.Equal(t, `"`, etag[len(etag)-1:])
+	})
+
+	t.Run("Deterministic", func(t *testing.T) {
+		data := []byte("deterministic content")
+
+		hw1 := cache.NewHashingWriter(io.Discard)
+		_, err := hw1.Write(data)
+		assert.NoError(t, err)
+
+		hw2 := cache.NewHashingWriter(io.Discard)
+		_, err = hw2.Write(data)
+		assert.NoError(t, err)
+
+		assert.Equal(t, hw1.ETag(), hw2.ETag())
+	})
+
+	t.Run("DifferentData", func(t *testing.T) {
+		hw1 := cache.NewHashingWriter(io.Discard)
+		_, err := hw1.Write([]byte("data one"))
+		assert.NoError(t, err)
+
+		hw2 := cache.NewHashingWriter(io.Discard)
+		_, err = hw2.Write([]byte("data two"))
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, hw1.ETag(), hw2.ETag())
+	})
+}

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -81,7 +81,7 @@ func (m *Memory) Stat(_ context.Context, key Key) (http.Header, error) {
 	return headers, nil
 }
 
-func (m *Memory) Open(_ context.Context, key Key) (io.ReadCloser, http.Header, error) {
+func (m *Memory) Open(_ context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -100,7 +100,11 @@ func (m *Memory) Open(_ context.Context, key Key) (io.ReadCloser, http.Header, e
 	}
 
 	headers := maps.Clone(entry.headers)
-	headers.Set("Content-Length", strconv.Itoa(len(entry.data)))
+
+	if err := CheckPreconditions(headers, conds...); err != nil {
+		return nil, headers, err
+	}
+
 	return io.NopCloser(bytes.NewReader(entry.data)), headers, nil
 }
 
@@ -119,11 +123,15 @@ func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl t
 
 	ctx, cancel := context.WithCancelCause(ctx)
 
+	buf := &bytes.Buffer{}
+	hasher := NewHashingWriter(buf)
+
 	writer := &memoryWriter{
 		cache:     m,
 		namespace: m.namespace,
 		key:       key,
-		buf:       &bytes.Buffer{},
+		buf:       buf,
+		hasher:    hasher,
 		expiresAt: now.Add(ttl),
 		headers:   clonedHeaders,
 		ctx:       ctx,
@@ -220,6 +228,7 @@ type memoryWriter struct {
 	namespace Namespace
 	key       Key
 	buf       *bytes.Buffer
+	hasher    *HashingWriter
 	expiresAt time.Time
 	headers   http.Header
 	closed    bool
@@ -231,7 +240,7 @@ func (w *memoryWriter) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, errors.New("writer closed")
 	}
-	return errors.WithStack2(w.buf.Write(p))
+	return errors.WithStack2(w.hasher.Write(p))
 }
 
 func (w *memoryWriter) Abort(err error) error {
@@ -249,6 +258,8 @@ func (w *memoryWriter) Close() error {
 	if err := w.ctx.Err(); err != nil {
 		return errors.Wrap(err, "create operation cancelled")
 	}
+
+	SetETag(w.headers, w.hasher.ETag())
 
 	w.cache.mu.Lock()
 	defer w.cache.mu.Unlock()

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -104,7 +104,7 @@ func (m *Memory) Open(_ context.Context, key Key, conds ...Precondition) (io.Rea
 	if err := CheckPreconditions(headers, conds...); err != nil {
 		return nil, headers, err
 	}
-
+	headers.Set("Content-Length", strconv.Itoa(len(entry.data)))
 	return io.NopCloser(bytes.NewReader(entry.data)), headers, nil
 }
 

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -81,7 +81,7 @@ func (m *Memory) Stat(_ context.Context, key Key) (http.Header, error) {
 	return headers, nil
 }
 
-func (m *Memory) Open(_ context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
+func (m *Memory) Open(_ context.Context, key Key, conds ...OpenOption) (io.ReadCloser, http.Header, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 

--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -26,7 +26,7 @@ func (n *noOpCache) Stat(_ context.Context, _ Key) (http.Header, error) {
 	return nil, os.ErrNotExist
 }
 
-func (n *noOpCache) Open(_ context.Context, _ Key) (io.ReadCloser, http.Header, error) {
+func (n *noOpCache) Open(_ context.Context, _ Key, _ ...Precondition) (io.ReadCloser, http.Header, error) {
 	return nil, nil, os.ErrNotExist
 }
 

--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -26,7 +26,7 @@ func (n *noOpCache) Stat(_ context.Context, _ Key) (http.Header, error) {
 	return nil, os.ErrNotExist
 }
 
-func (n *noOpCache) Open(_ context.Context, _ Key, _ ...Precondition) (io.ReadCloser, http.Header, error) {
+func (n *noOpCache) Open(_ context.Context, _ Key, _ ...OpenOption) (io.ReadCloser, http.Header, error) {
 	return nil, nil, os.ErrNotExist
 }
 

--- a/internal/cache/remote.go
+++ b/internal/cache/remote.go
@@ -38,7 +38,7 @@ func (r *Remote) Namespace(namespace Namespace) Cache {
 	return &Remote{c: r.c.Namespace(namespace)}
 }
 
-func (r *Remote) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
+func (r *Remote) Open(ctx context.Context, key Key, conds ...OpenOption) (io.ReadCloser, http.Header, error) {
 	rc, h, err := r.c.Open(ctx, key, conds...)
 	return rc, h, errors.WithStack(err)
 }

--- a/internal/cache/remote.go
+++ b/internal/cache/remote.go
@@ -38,8 +38,8 @@ func (r *Remote) Namespace(namespace Namespace) Cache {
 	return &Remote{c: r.c.Namespace(namespace)}
 }
 
-func (r *Remote) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error) {
-	rc, h, err := r.c.Open(ctx, key)
+func (r *Remote) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
+	rc, h, err := r.c.Open(ctx, key, conds...)
 	return rc, h, errors.WithStack(err)
 }
 

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -170,7 +170,7 @@ func (s *S3) Stat(ctx context.Context, key Key) (http.Header, error) {
 	return headers, nil
 }
 
-func (s *S3) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
+func (s *S3) Open(ctx context.Context, key Key, conds ...OpenOption) (io.ReadCloser, http.Header, error) {
 	objInfo, headers, err := s.statAndHeaders(ctx, key)
 	if err != nil {
 		return nil, nil, err

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -170,13 +170,17 @@ func (s *S3) Stat(ctx context.Context, key Key) (http.Header, error) {
 	return headers, nil
 }
 
-func (s *S3) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error) {
+func (s *S3) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
 	objInfo, headers, err := s.statAndHeaders(ctx, key)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	headers.Set("Content-Length", strconv.FormatInt(objInfo.Size, 10))
+
+	if err := CheckPreconditions(headers, conds...); err != nil {
+		return nil, headers, err
+	}
 
 	objectName := s.keyToPath(s.namespace, key)
 
@@ -273,12 +277,14 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 	ctx, cancel := context.WithCancelCause(ctx)
 
 	pr, pw := io.Pipe()
+	hasher := NewHashingWriter(pw)
 
 	writer := &s3Writer{
 		s3:        s,
 		key:       key,
 		namespace: s.namespace,
 		pipe:      pw,
+		hasher:    hasher,
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
 		ctx:       ctx,
@@ -320,6 +326,7 @@ type s3Writer struct {
 	key       Key
 	namespace Namespace
 	pipe      *io.PipeWriter
+	hasher    *HashingWriter
 	expiresAt time.Time
 	headers   http.Header
 	ctx       context.Context
@@ -330,7 +337,7 @@ type s3Writer struct {
 }
 
 func (w *s3Writer) Write(p []byte) (int, error) {
-	n, err := w.pipe.Write(p)
+	n, err := w.hasher.Write(p)
 	if err != nil {
 		// Check if upload failed - if so, return that error instead
 		select {
@@ -371,6 +378,33 @@ func (w *s3Writer) Close() error {
 	err := <-w.errCh
 	if err != nil {
 		return err
+	}
+
+	// Update stored headers with the content-hash ETag via a server-side
+	// copy-to-self. There is a brief window between PutObject completing
+	// and this metadata update where the object is visible without an ETag.
+	SetETag(w.headers, w.hasher.ETag())
+
+	objectName := w.s3.keyToPath(w.namespace, w.key)
+	headersJSON, err := json.Marshal(w.headers)
+	if err != nil {
+		return errors.Errorf("failed to marshal headers with etag: %w", err)
+	}
+
+	src := minio.CopySrcOptions{
+		Bucket: w.s3.config.Bucket,
+		Object: objectName,
+	}
+	dst := minio.CopyDestOptions{
+		Bucket:          w.s3.config.Bucket,
+		Object:          objectName,
+		UserMetadata:    map[string]string{"Headers": string(headersJSON)},
+		ReplaceMetadata: true,
+		Expires:         w.expiresAt,
+	}
+	if _, err := w.s3.client.CopyObject(w.ctx, dst, src); err != nil {
+		_ = w.s3.client.RemoveObject(context.WithoutCancel(w.ctx), w.s3.config.Bucket, objectName, minio.RemoveObjectOptions{}) //nolint:errcheck,gosec
+		return errors.Wrap(err, "failed to update S3 metadata with ETag")
 	}
 
 	return nil

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -113,15 +113,15 @@ func (t Tiered) Stat(ctx context.Context, key Key) (http.Header, error) {
 // subsequent Opens are served locally.
 //
 // If all caches fail, all errors are returned.
-func (t Tiered) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error) {
+func (t Tiered) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
 	errs := make([]error, len(t.caches))
 	for i, c := range t.caches {
-		r, headers, err := c.Open(ctx, key)
+		r, headers, err := c.Open(ctx, key, conds...)
 		errs[i] = err
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
-			return nil, nil, errors.WithStack(err)
+			return nil, headers, errors.WithStack(err)
 		}
 		if i > 0 {
 			r = t.backfillReader(ctx, key, r, headers, t.caches[0])

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -113,7 +113,7 @@ func (t Tiered) Stat(ctx context.Context, key Key) (http.Header, error) {
 // subsequent Opens are served locally.
 //
 // If all caches fail, all errors are returned.
-func (t Tiered) Open(ctx context.Context, key Key, conds ...Precondition) (io.ReadCloser, http.Header, error) {
+func (t Tiered) Open(ctx context.Context, key Key, conds ...OpenOption) (io.ReadCloser, http.Header, error) {
 	errs := make([]error, len(t.caches))
 	for i, c := range t.caches {
 		r, headers, err := c.Open(ctx, key, conds...)

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -68,7 +68,7 @@ func (d *APIV1) statObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var conds []cache.Precondition
+	var conds []cache.OpenOption
 	if v := r.Header.Get("If-None-Match"); v != "" {
 		conds = append(conds, cache.WithIfNoneMatch(v))
 	}
@@ -108,7 +108,7 @@ func (d *APIV1) getObject(w http.ResponseWriter, r *http.Request) {
 
 	namespacedCache := d.cache.Namespace(namespace)
 
-	var conds []cache.Precondition
+	var conds []cache.OpenOption
 	if v := r.Header.Get("If-None-Match"); v != "" {
 		conds = append(conds, cache.WithIfNoneMatch(v))
 	}
@@ -192,7 +192,7 @@ func (d *APIV1) putObject(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			var conds []cache.Precondition
+			var conds []cache.OpenOption
 			if v := r.Header.Get("If-Match"); v != "" {
 				conds = append(conds, cache.WithIfMatch(v))
 			}
@@ -257,7 +257,7 @@ func (d *APIV1) deleteObject(w http.ResponseWriter, r *http.Request) {
 			d.httpError(w, http.StatusInternalServerError, statErr, "Failed to stat cache object", "key", key)
 			return
 		}
-		var conds []cache.Precondition
+		var conds []cache.OpenOption
 		if v := r.Header.Get("If-Match"); v != "" {
 			conds = append(conds, cache.WithIfMatch(v))
 		}

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -64,8 +64,30 @@ func (d *APIV1) statObject(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Cache object not found", http.StatusNotFound)
 			return
 		}
-		d.httpError(w, http.StatusInternalServerError, err, "Failed to open cache object", "key", key)
+		d.httpError(w, http.StatusInternalServerError, err, "Failed to stat cache object", "key", key)
 		return
+	}
+
+	var conds []cache.Precondition
+	if v := r.Header.Get("If-None-Match"); v != "" {
+		conds = append(conds, cache.WithIfNoneMatch(v))
+	}
+	if v := r.Header.Get("If-Match"); v != "" {
+		conds = append(conds, cache.WithIfMatch(v))
+	}
+	if err := cache.CheckPreconditions(headers, conds...); err != nil {
+		if errors.Is(err, cache.ErrNotModified) {
+			maps.Copy(w.Header(), headers)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if errors.Is(err, cache.ErrPreconditionFailed) {
+			if etag := headers.Get("ETag"); etag != "" {
+				w.Header().Set("ETag", etag)
+			}
+			http.Error(w, "Precondition failed", http.StatusPreconditionFailed)
+			return
+		}
 	}
 
 	maps.Copy(w.Header(), headers)
@@ -85,10 +107,31 @@ func (d *APIV1) getObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	namespacedCache := d.cache.Namespace(namespace)
-	cr, headers, err := namespacedCache.Open(r.Context(), key)
+
+	var conds []cache.Precondition
+	if v := r.Header.Get("If-None-Match"); v != "" {
+		conds = append(conds, cache.WithIfNoneMatch(v))
+	}
+	if v := r.Header.Get("If-Match"); v != "" {
+		conds = append(conds, cache.WithIfMatch(v))
+	}
+
+	cr, headers, err := namespacedCache.Open(r.Context(), key, conds...)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			http.Error(w, "Cache object not found", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, cache.ErrNotModified) {
+			maps.Copy(w.Header(), headers)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if errors.Is(err, cache.ErrPreconditionFailed) {
+			if etag := headers.Get("ETag"); etag != "" {
+				w.Header().Set("ETag", etag)
+			}
+			http.Error(w, "Precondition failed", http.StatusPreconditionFailed)
 			return
 		}
 		d.httpError(w, http.StatusInternalServerError, err, "Failed to open cache object", "key", key)
@@ -130,8 +173,35 @@ func (d *APIV1) putObject(w http.ResponseWriter, r *http.Request) {
 
 	// Extract and filter headers from request
 	headers := httputil.FilterHeaders(r.Header, httputil.TransportHeaders...)
+	headers = httputil.FilterHeaders(headers, cache.RequestHeaders...)
 
 	namespacedCache := d.cache.Namespace(namespace)
+
+	if r.Header.Get("If-Match") != "" || r.Header.Get("If-None-Match") != "" {
+		existingHeaders, statErr := namespacedCache.Stat(r.Context(), key)
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			d.httpError(w, http.StatusInternalServerError, statErr, "Failed to stat cache object", "key", key)
+			return
+		}
+		if existingHeaders == nil {
+			existingHeaders = make(http.Header)
+		}
+		var conds []cache.Precondition
+		if v := r.Header.Get("If-Match"); v != "" {
+			conds = append(conds, cache.WithIfMatch(v))
+		}
+		if v := r.Header.Get("If-None-Match"); v != "" {
+			conds = append(conds, cache.WithIfNoneMatch(v))
+		}
+		if err := cache.CheckPreconditions(existingHeaders, conds...); err != nil {
+			if etag := existingHeaders.Get("ETag"); etag != "" {
+				w.Header().Set("ETag", etag)
+			}
+			http.Error(w, "Precondition failed", http.StatusPreconditionFailed)
+			return
+		}
+	}
+
 	cw, err := namespacedCache.Create(r.Context(), key, headers, ttl)
 	if err != nil {
 		d.httpError(w, http.StatusInternalServerError, err, "Failed to create cache writer", "key", key)
@@ -146,6 +216,13 @@ func (d *APIV1) putObject(w http.ResponseWriter, r *http.Request) {
 	if err := cw.Close(); err != nil {
 		d.httpError(w, http.StatusInternalServerError, err, "Failed to close cache writer")
 		return
+	}
+
+	storedHeaders, err := namespacedCache.Stat(r.Context(), key)
+	if err == nil {
+		if etag := storedHeaders.Get("ETag"); etag != "" {
+			w.Header().Set("ETag", etag)
+		}
 	}
 }
 
@@ -162,6 +239,33 @@ func (d *APIV1) deleteObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	namespacedCache := d.cache.Namespace(namespace)
+
+	if r.Header.Get("If-Match") != "" || r.Header.Get("If-None-Match") != "" {
+		existingHeaders, statErr := namespacedCache.Stat(r.Context(), key)
+		if statErr != nil {
+			if errors.Is(statErr, os.ErrNotExist) {
+				http.Error(w, "Cache object not found", http.StatusNotFound)
+				return
+			}
+			d.httpError(w, http.StatusInternalServerError, statErr, "Failed to stat cache object", "key", key)
+			return
+		}
+		var conds []cache.Precondition
+		if v := r.Header.Get("If-Match"); v != "" {
+			conds = append(conds, cache.WithIfMatch(v))
+		}
+		if v := r.Header.Get("If-None-Match"); v != "" {
+			conds = append(conds, cache.WithIfNoneMatch(v))
+		}
+		if err := cache.CheckPreconditions(existingHeaders, conds...); err != nil {
+			if etag := existingHeaders.Get("ETag"); etag != "" {
+				w.Header().Set("ETag", etag)
+			}
+			http.Error(w, "Precondition failed", http.StatusPreconditionFailed)
+			return
+		}
+	}
+
 	err = namespacedCache.Delete(r.Context(), key)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -183,22 +183,29 @@ func (d *APIV1) putObject(w http.ResponseWriter, r *http.Request) {
 			d.httpError(w, http.StatusInternalServerError, statErr, "Failed to stat cache object", "key", key)
 			return
 		}
-		if existingHeaders == nil {
-			existingHeaders = make(http.Header)
-		}
-		var conds []cache.Precondition
-		if v := r.Header.Get("If-Match"); v != "" {
-			conds = append(conds, cache.WithIfMatch(v))
-		}
-		if v := r.Header.Get("If-None-Match"); v != "" {
-			conds = append(conds, cache.WithIfNoneMatch(v))
-		}
-		if err := cache.CheckPreconditions(existingHeaders, conds...); err != nil {
-			if etag := existingHeaders.Get("ETag"); etag != "" {
-				w.Header().Set("ETag", etag)
+		resourceExists := statErr == nil
+		if !resourceExists {
+			// Resource doesn't exist: If-Match always fails (nothing to match),
+			// If-None-Match always passes (nothing to conflict with).
+			if r.Header.Get("If-Match") != "" {
+				http.Error(w, "Precondition failed", http.StatusPreconditionFailed)
+				return
 			}
-			http.Error(w, "Precondition failed", http.StatusPreconditionFailed)
-			return
+		} else {
+			var conds []cache.Precondition
+			if v := r.Header.Get("If-Match"); v != "" {
+				conds = append(conds, cache.WithIfMatch(v))
+			}
+			if v := r.Header.Get("If-None-Match"); v != "" {
+				conds = append(conds, cache.WithIfNoneMatch(v))
+			}
+			if err := cache.CheckPreconditions(existingHeaders, conds...); err != nil {
+				if etag := existingHeaders.Get("ETag"); etag != "" {
+					w.Header().Set("ETag", etag)
+				}
+				http.Error(w, "Precondition failed", http.StatusPreconditionFailed)
+				return
+			}
 		}
 	}
 

--- a/internal/strategy/apiv1_test.go
+++ b/internal/strategy/apiv1_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,4 +63,261 @@ func (r *failingReader) Read(p []byte) (int, error) {
 		return n, io.ErrUnexpectedEOF
 	}
 	return n, nil
+}
+
+// setupAPIV1 creates a memory cache, registers the APIV1 strategy, and stores
+// a test object. Returns the mux, context, key, and stored ETag.
+func setupAPIV1(t *testing.T) (http.Handler, context.Context, cache.Key, string) {
+	t.Helper()
+	_, ctx := logging.Configure(context.Background(), logging.Config{Level: slog.LevelError})
+	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	t.Cleanup(func() { memCache.Close() })
+
+	mux := http.NewServeMux()
+	_, err = strategy.NewAPIV1(ctx, struct{}{}, memCache, mux)
+	assert.NoError(t, err)
+
+	key := cache.NewKey("etag-test")
+
+	// Store an object
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+key.String(),
+		strings.NewReader("hello etag"))
+	req.Header.Set("Content-Type", "text/plain")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GET to retrieve the ETag
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/object/default/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	etag := w.Header().Get("ETag")
+	assert.NotZero(t, etag)
+
+	return mux, ctx, key, etag
+}
+
+func TestGetObjectIfNoneMatchHit(t *testing.T) {
+	mux, ctx, key, etag := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-None-Match", etag)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	assert.Equal(t, etag, w.Header().Get("ETag"))
+	assert.Equal(t, "", w.Body.String()) // no body on 304
+}
+
+func TestGetObjectIfNoneMatchMiss(t *testing.T) {
+	mux, ctx, key, _ := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-None-Match", `"wrong-etag"`)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "hello etag", w.Body.String())
+}
+
+func TestHeadObjectIfNoneMatchHit(t *testing.T) {
+	mux, ctx, key, etag := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-None-Match", etag)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	assert.Equal(t, etag, w.Header().Get("ETag"))
+}
+
+func TestPutObjectIfNoneMatchStar(t *testing.T) {
+	mux, ctx, key, _ := setupAPIV1(t)
+
+	// Try to create-if-absent — should fail because object already exists
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+key.String(),
+		strings.NewReader("new data"))
+	req.Header.Set("If-None-Match", "*")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}
+
+func TestPutObjectIfMatchCorrect(t *testing.T) {
+	mux, ctx, key, etag := setupAPIV1(t)
+
+	// Conditional overwrite with correct ETag — should succeed
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+key.String(),
+		strings.NewReader("updated data"))
+	req.Header.Set("If-Match", etag)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPutObjectIfMatchWrong(t *testing.T) {
+	mux, ctx, key, _ := setupAPIV1(t)
+
+	// Conditional overwrite with wrong ETag — should fail
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+key.String(),
+		strings.NewReader("updated data"))
+	req.Header.Set("If-Match", `"wrong-etag"`)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}
+
+func TestDeleteObjectIfMatchCorrect(t *testing.T) {
+	mux, ctx, key, etag := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-Match", etag)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify object is actually deleted
+	req = httptest.NewRequest(http.MethodHead, "/api/v1/object/default/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDeleteObjectIfMatchWrong(t *testing.T) {
+	mux, ctx, key, _ := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-Match", `"wrong-etag"`)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+
+	// Verify object still exists
+	req = httptest.NewRequest(http.MethodHead, "/api/v1/object/default/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHeadObjectIfMatchCorrect(t *testing.T) {
+	mux, ctx, key, etag := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-Match", etag)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHeadObjectIfMatchWrong(t *testing.T) {
+	mux, ctx, key, _ := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-Match", `"wrong-etag"`)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}
+
+func TestPutObjectIfNoneMatchSpecificETag(t *testing.T) {
+	mux, ctx, key, etag := setupAPIV1(t)
+
+	// If-None-Match with the existing ETag should fail
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+key.String(),
+		strings.NewReader("new data"))
+	req.Header.Set("If-None-Match", etag)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}
+
+func TestPutObjectReturnsNewETag(t *testing.T) {
+	mux, ctx, key, _ := setupAPIV1(t)
+
+	// Overwrite with new content
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+key.String(),
+		strings.NewReader("updated content"))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	newETag := w.Header().Get("ETag")
+	assert.NotZero(t, newETag, "PUT response should include the new ETag")
+	assert.True(t, strings.HasPrefix(newETag, `"sha256:`), "ETag should be sha256-based")
+}
+
+func TestOverwriteChangesETag(t *testing.T) {
+	mux, ctx, key, originalETag := setupAPIV1(t)
+
+	// Overwrite with different content
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+key.String(),
+		strings.NewReader("different content"))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GET and verify ETag changed
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/object/default/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	newETag := w.Header().Get("ETag")
+	assert.NotEqual(t, originalETag, newETag, "ETag should change when content changes")
+}
+
+func TestGetObjectIfMatchCorrect(t *testing.T) {
+	mux, ctx, key, etag := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-Match", etag)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "hello etag", w.Body.String())
+}
+
+func TestGetObjectIfMatchWrong(t *testing.T) {
+	mux, ctx, key, _ := setupAPIV1(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/object/default/"+key.String(), nil)
+	req.Header.Set("If-Match", `"wrong-etag"`)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
 }

--- a/internal/strategy/apiv1_test.go
+++ b/internal/strategy/apiv1_test.go
@@ -155,6 +155,36 @@ func TestPutObjectIfNoneMatchStar(t *testing.T) {
 	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
 }
 
+func TestPutObjectIfNoneMatchStarNewKey(t *testing.T) {
+	mux, ctx, _, _ := setupAPIV1(t)
+
+	// Create-if-absent on a new key — should succeed
+	newKey := cache.NewKey("brand-new-key")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+newKey.String(),
+		strings.NewReader("new data"))
+	req.Header.Set("If-None-Match", "*")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPutObjectIfMatchStarNewKey(t *testing.T) {
+	mux, ctx, _, _ := setupAPIV1(t)
+
+	// If-Match: * on a non-existent key — should fail
+	newKey := cache.NewKey("nonexistent-key")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/default/"+newKey.String(),
+		strings.NewReader("new data"))
+	req.Header.Set("If-Match", "*")
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}
+
 func TestPutObjectIfMatchCorrect(t *testing.T) {
 	mux, ctx, key, etag := setupAPIV1(t)
 


### PR DESCRIPTION
Add content-hash (SHA-256) based ETags to all cache backends, with full
If-Match and If-None-Match support threaded from the HTTP serving layer
through to storage backends.

ETag generation:
- All backends (disk, memory, S3) compute SHA-256 content hashes during
  Create() via a shared HashingWriter, producing consistent ETags across
  tiers (same content = same ETag regardless of backend).
- S3 backend does a server-side copy-to-self after upload to update
  stored metadata with the computed ETag.

Cache interface changes:
- Open() now accepts variadic Precondition options (WithIfMatch,
  WithIfNoneMatch) for atomic precondition checking, eliminating
  TOCTOU races between Stat() and Open() that would cause data
  corruption with future range request support.
- Returns ErrNotModified or ErrPreconditionFailed when preconditions
  are not met, along with stored headers (including ETag).
- CheckPreconditions() helper for use by Stat/PUT/DELETE paths.

APIV1 HTTP handler:
- GET/HEAD: If-None-Match → 304, If-Match → 412
- POST: If-Match/If-None-Match → 412, returns new ETag in response
- DELETE: If-Match/If-None-Match → 412
- 304 responses include full stored headers per RFC 7232 §4.1

Client:
- Precondition type with WithIfMatch/WithIfNoneMatch options
- Open, Stat, Create, Delete all accept preconditions (variadic,
  backward compatible)
- ErrNotModified and ErrPreconditionFailed sentinels
- 304 and 412 responses return headers (including ETag)

RFC compliance:
- If-Match uses strong comparison (W/ prefix ETags don't match)
- If-None-Match uses weak comparison per RFC 7232 §2.3.2
- Conditional request headers stripped from stored object metadata
