### PR TITLE
feat: compute SHA256 ETag in cache backend writers

### DIFF
--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -2,6 +2,8 @@ package cachetest
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"os"
@@ -72,6 +74,10 @@ func Suite(t *testing.T, newCache func(t *testing.T) cache.Cache) {
 
 	t.Run("NamespaceDelete", func(t *testing.T) {
 		testNamespaceDelete(t, newCache(t))
+	})
+
+	t.Run("ETag", func(t *testing.T) {
+		testETag(t, newCache(t))
 	})
 }
 
@@ -449,6 +455,34 @@ func testListNamespaces(t *testing.T, c cache.Cache) {
 	assert.True(t, nsMap["git"])
 	assert.True(t, nsMap["gomod"])
 	assert.True(t, nsMap["hermit"])
+}
+
+func testETag(t *testing.T, c cache.Cache) {
+	defer c.Close()
+	ctx := t.Context()
+
+	content := []byte("hello etag world")
+	key := cache.NewKey("test-etag")
+
+	w, err := c.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w.Write(content)
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	sum := sha256.Sum256(content)
+	expectedETag := `"` + hex.EncodeToString(sum[:]) + `"`
+
+	// Verify ETag from Open
+	reader, openHeaders, err := c.Open(ctx, key)
+	assert.NoError(t, err)
+	defer reader.Close()
+	assert.Equal(t, expectedETag, openHeaders.Get("ETag"))
+
+	// Verify ETag from Stat is consistent
+	statHeaders, err := c.Stat(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedETag, statHeaders.Get("ETag"))
 }
 
 func testNamespaceDelete(t *testing.T, c cache.Cache) {

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -193,6 +193,7 @@ func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl tim
 		tempPath:  f.Name(),
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
+		etag:      newETagWriter(),
 		ctx:       ctx,
 		cancel:    cancel,
 	}, nil
@@ -439,6 +440,7 @@ type diskWriter struct {
 	expiresAt time.Time
 	headers   http.Header
 	size      int64
+	etag      *etagWriter
 	ctx       context.Context
 	cancel    context.CancelCauseFunc
 	closed    bool
@@ -447,6 +449,7 @@ type diskWriter struct {
 func (w *diskWriter) Write(p []byte) (int, error) {
 	n, err := w.file.Write(p)
 	w.size += int64(n)
+	w.etag.WriteBytes(p[:n])
 	return n, errors.WithStack(err)
 }
 
@@ -485,6 +488,8 @@ func (w *diskWriter) Close() error {
 	if err := os.Rename(w.tempPath, w.path); err != nil {
 		return errors.Errorf("failed to rename temp file: %w", err)
 	}
+
+	w.etag.SetETag(w.headers)
 
 	if err := w.disk.db.set(w.key, w.namespace, w.expiresAt, w.headers); err != nil {
 		return errors.Join(errors.Errorf("failed to set metadata: %w", err), os.Remove(w.path))

--- a/internal/cache/etag.go
+++ b/internal/cache/etag.go
@@ -1,0 +1,31 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"net/http"
+)
+
+// ETagKey is the HTTP header key used to store the ETag.
+const ETagKey = "ETag"
+
+// etagWriter computes a SHA256 hash of all written data. After all data has
+// been written, call SetETag to populate the ETag header.
+type etagWriter struct {
+	hash hash.Hash
+}
+
+func newETagWriter() *etagWriter {
+	return &etagWriter{hash: sha256.New()}
+}
+
+// WriteBytes feeds p into the running hash. sha256 never returns an error.
+func (e *etagWriter) WriteBytes(p []byte) {
+	_, _ = e.hash.Write(p)
+}
+
+// SetETag sets the ETag header on the given headers from the accumulated hash.
+func (e *etagWriter) SetETag(headers http.Header) {
+	headers.Set(ETagKey, `"`+hex.EncodeToString(e.hash.Sum(nil))+`"`)
+}

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -126,6 +126,7 @@ func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl t
 		buf:       &bytes.Buffer{},
 		expiresAt: now.Add(ttl),
 		headers:   clonedHeaders,
+		etag:      newETagWriter(),
 		ctx:       ctx,
 		cancel:    cancel,
 	}
@@ -222,6 +223,7 @@ type memoryWriter struct {
 	buf       *bytes.Buffer
 	expiresAt time.Time
 	headers   http.Header
+	etag      *etagWriter
 	closed    bool
 	ctx       context.Context
 	cancel    context.CancelCauseFunc
@@ -231,7 +233,9 @@ func (w *memoryWriter) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, errors.New("writer closed")
 	}
-	return errors.WithStack2(w.buf.Write(p))
+	n, err := w.buf.Write(p)
+	w.etag.WriteBytes(p[:n])
+	return n, errors.WithStack(err)
 }
 
 func (w *memoryWriter) Abort(err error) error {
@@ -275,6 +279,8 @@ func (w *memoryWriter) Close() error {
 			w.cache.evictOldest(neededSpace)
 		}
 	}
+
+	w.etag.SetETag(w.headers)
 
 	w.cache.currentSize.Add(-oldSize)
 	// Copy the buffer data to avoid holding a reference to the buffer's internal slice

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -225,6 +225,31 @@ func (s *S3) refreshExpiration(ctx context.Context, objectName string, objInfo m
 	return nil
 }
 
+// updateHeaders replaces the stored headers on an S3 object using server-side
+// copy-to-self with metadata replacement.
+func (s *S3) updateHeaders(ctx context.Context, namespace Namespace, key Key, headers http.Header, expiresAt time.Time) error {
+	objectName := s.keyToPath(namespace, key)
+	userMetadata := make(map[string]string)
+	headersJSON, err := json.Marshal(headers)
+	if err != nil {
+		return errors.Errorf("failed to marshal headers: %w", err)
+	}
+	userMetadata["Headers"] = string(headersJSON)
+
+	src := minio.CopySrcOptions{Bucket: s.config.Bucket, Object: objectName}
+	dst := minio.CopyDestOptions{
+		Bucket:          s.config.Bucket,
+		Object:          objectName,
+		UserMetadata:    userMetadata,
+		ReplaceMetadata: true,
+		Expires:         expiresAt,
+	}
+	if _, err := s.client.CopyObject(ctx, dst, src); err != nil {
+		return errors.Wrap(err, "update headers")
+	}
+	return nil
+}
+
 // ceilSecond rounds a time up to the next whole second. S3's Expires header
 // uses HTTP-date format (second precision), so sub-second components would be
 // silently truncated, potentially causing premature expiry.
@@ -281,6 +306,7 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 		pipe:      pw,
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
+		etag:      newETagWriter(),
 		ctx:       ctx,
 		cancel:    cancel,
 		errCh:     make(chan error, 1),
@@ -322,6 +348,7 @@ type s3Writer struct {
 	pipe      *io.PipeWriter
 	expiresAt time.Time
 	headers   http.Header
+	etag      *etagWriter
 	ctx       context.Context
 	cancel    context.CancelCauseFunc
 	errCh     chan error
@@ -331,6 +358,9 @@ type s3Writer struct {
 
 func (w *s3Writer) Write(p []byte) (int, error) {
 	n, err := w.pipe.Write(p)
+	if n > 0 {
+		w.etag.WriteBytes(p[:n])
+	}
 	if err != nil {
 		// Check if upload failed - if so, return that error instead
 		select {
@@ -368,11 +398,16 @@ func (w *s3Writer) Close() error {
 	}
 
 	// Wait for upload to complete and get any error
-	err := <-w.errCh
-	if err != nil {
+	if err := <-w.errCh; err != nil {
 		return err
 	}
 
+	// Update stored headers with the computed ETag via server-side copy.
+	// Skip if the context was cancelled (via Abort).
+	if w.ctx.Err() == nil {
+		w.etag.SetETag(w.headers)
+		return w.s3.updateHeaders(w.ctx, w.namespace, w.key, w.headers, w.expiresAt)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Add a reusable etagWriter that computes a SHA256 hash of written
content and sets a quoted hex-encoded ETag header. Each backend
(disk, memory, S3) hashes data in Write() and sets the ETag on
Close(). S3 uses a post-upload CopyObject metadata-replace since
headers are serialised before content is fully written.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
