### PR TITLE
feat: add If-Match/If-None-Match support to API and client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,18 @@ func (e *HTTPStatusError) Error() string {
 	return fmt.Sprintf("unexpected status code: %d", e.StatusCode)
 }
 
+// Is allows errors.Is to match HTTPStatusError against sentinel errors.
+func (e *HTTPStatusError) Is(target error) bool {
+	switch target { //nolint:errorlint // comparing sentinel values, not wrapped errors
+	case ErrNotModified:
+		return e.StatusCode == http.StatusNotModified
+	case ErrPreconditionFailed:
+		return e.StatusCode == http.StatusPreconditionFailed
+	default:
+		return false
+	}
+}
+
 // transportHeaders are headers added by the HTTP transport layer that should
 // not be surfaced as cached-object metadata on responses.
 var transportHeaders = []string{ //nolint:gochecknoglobals
@@ -147,11 +159,15 @@ func (c *Client) objectURL(key Key) string {
 	return fmt.Sprintf("%s/api/v1/object/%s/%s", c.baseURL, c.resolvedNamespace(), key.String())
 }
 
-// Open retrieves an object from the cache server.
-func (c *Client) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header, error) {
+// Open retrieves an object from the cache server. Accepts optional
+// [RequestOption]s such as [IfNoneMatch] for conditional requests.
+func (c *Client) Open(ctx context.Context, key Key, opts ...RequestOption) (io.ReadCloser, http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.objectURL(key), nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create request")
+	}
+	for _, opt := range opts {
+		opt(req)
 	}
 
 	resp, err := c.http.Do(req)
@@ -159,24 +175,37 @@ func (c *Client) Open(ctx context.Context, key Key) (io.ReadCloser, http.Header,
 		return nil, nil, errors.Wrap(err, "failed to execute request")
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return resp.Body, filterHeaders(resp.Header, transportHeaders...), nil
+
+	case http.StatusNotFound:
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
 		return nil, nil, errors.Join(os.ErrNotExist, resp.Body.Close())
-	}
 
-	if resp.StatusCode != http.StatusOK {
+	case http.StatusNotModified:
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		return nil, filterHeaders(resp.Header, transportHeaders...), errors.Join(ErrNotModified, resp.Body.Close())
+
+	case http.StatusPreconditionFailed:
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		return nil, nil, errors.Join(ErrPreconditionFailed, resp.Body.Close())
+
+	default:
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
 		return nil, nil, errors.Join(errors.WithStack(&HTTPStatusError{StatusCode: resp.StatusCode}), resp.Body.Close())
 	}
-
-	return resp.Body, filterHeaders(resp.Header, transportHeaders...), nil
 }
 
-// Stat retrieves headers for an object from the cache server.
-func (c *Client) Stat(ctx context.Context, key Key) (http.Header, error) {
+// Stat retrieves headers for an object from the cache server. Accepts optional
+// [RequestOption]s such as [IfNoneMatch] for conditional requests.
+func (c *Client) Stat(ctx context.Context, key Key, opts ...RequestOption) (http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.objectURL(key), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")
+	}
+	for _, opt := range opts {
+		opt(req)
 	}
 
 	resp, err := c.http.Do(req)
@@ -185,15 +214,18 @@ func (c *Client) Stat(ctx context.Context, key Key) (http.Header, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return filterHeaders(resp.Header, transportHeaders...), nil
+	case http.StatusNotFound:
 		return nil, os.ErrNotExist
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	case http.StatusNotModified:
+		return filterHeaders(resp.Header, transportHeaders...), ErrNotModified
+	case http.StatusPreconditionFailed:
+		return nil, ErrPreconditionFailed
+	default:
 		return nil, errors.WithStack(&HTTPStatusError{StatusCode: resp.StatusCode})
 	}
-
-	return filterHeaders(resp.Header, transportHeaders...), nil
 }
 
 // Create stores a new object in the cache server. The returned CacheWriter

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,6 +3,8 @@ package client_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"maps"
@@ -51,6 +53,28 @@ func (fs *fakeServer) key(r *http.Request) string {
 	return r.PathValue("namespace") + "/" + r.PathValue("key")
 }
 
+func fakeCheckConditionals(r *http.Request, etag string) int {
+	if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
+		if etag == "" || (ifMatch != "*" && ifMatch != etag) {
+			return http.StatusPreconditionFailed
+		}
+	}
+	if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != "" {
+		if (ifNoneMatch == "*" && etag != "") || ifNoneMatch == etag {
+			if r.Method == http.MethodGet || r.Method == http.MethodHead {
+				return http.StatusNotModified
+			}
+			return http.StatusPreconditionFailed
+		}
+	}
+	return 0
+}
+
+func fakeETag(data []byte) string {
+	sum := sha256.Sum256(data)
+	return `"` + hex.EncodeToString(sum[:]) + `"`
+}
+
 func (fs *fakeServer) get(w http.ResponseWriter, r *http.Request) {
 	fs.mu.Lock()
 	obj, ok := fs.objects[fs.key(r)]
@@ -60,6 +84,10 @@ func (fs *fakeServer) get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	maps.Copy(w.Header(), obj.headers)
+	if status := fakeCheckConditionals(r, obj.headers.Get("ETag")); status != 0 {
+		w.WriteHeader(status)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	w.Write(obj.body) //nolint:errcheck
 }
@@ -73,6 +101,10 @@ func (fs *fakeServer) stat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	maps.Copy(w.Header(), obj.headers)
+	if status := fakeCheckConditionals(r, obj.headers.Get("ETag")); status != 0 {
+		w.WriteHeader(status)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -90,6 +122,7 @@ func (fs *fakeServer) put(w http.ResponseWriter, r *http.Request) {
 		}
 		headers[k] = v
 	}
+	headers.Set("ETag", fakeETag(body))
 	fs.mu.Lock()
 	fs.objects[fs.key(r)] = fakeObject{body: body, headers: headers}
 	fs.mu.Unlock()
@@ -286,6 +319,110 @@ func TestArchiveExtract(t *testing.T) {
 	}
 	assert.True(t, slices.Contains(names, "x.txt"))
 	assert.False(t, slices.Contains(names, "y.log"))
+}
+
+func TestOpenIfNoneMatch(t *testing.T) {
+	srv := newFakeServer(nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, nil).Namespace("test")
+	defer c.Close()
+	ctx := t.Context()
+
+	key := client.NewKey("etag-test")
+	payload := []byte("etag content")
+
+	wc, err := c.Create(ctx, key, nil, 0)
+	assert.NoError(t, err)
+	_, err = wc.Write(payload)
+	assert.NoError(t, err)
+	assert.NoError(t, wc.Close())
+
+	etag := fakeETag(payload)
+
+	tests := []struct {
+		name        string
+		ifNoneMatch string
+		wantErr     error
+	}{
+		{name: "Matching", ifNoneMatch: etag, wantErr: client.ErrNotModified},
+		{name: "NonMatching", ifNoneMatch: `"wrong"`, wantErr: nil},
+		{name: "Wildcard", ifNoneMatch: "*", wantErr: client.ErrNotModified},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc, headers, err := c.Open(ctx, key, client.IfNoneMatch(tt.ifNoneMatch))
+			if tt.wantErr != nil {
+				assert.IsError(t, err, tt.wantErr)
+				assert.NotZero(t, headers.Get("ETag"))
+				assert.True(t, rc == nil)
+			} else {
+				assert.NoError(t, err)
+				data, readErr := io.ReadAll(rc)
+				assert.NoError(t, readErr)
+				assert.NoError(t, rc.Close())
+				assert.Equal(t, payload, data)
+				_ = headers
+			}
+		})
+	}
+}
+
+func TestStatIfNoneMatch(t *testing.T) {
+	srv := newFakeServer(nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, nil).Namespace("test")
+	defer c.Close()
+	ctx := t.Context()
+
+	key := client.NewKey("stat-etag")
+	payload := []byte("stat content")
+
+	wc, err := c.Create(ctx, key, nil, 0)
+	assert.NoError(t, err)
+	_, err = wc.Write(payload)
+	assert.NoError(t, err)
+	assert.NoError(t, wc.Close())
+
+	etag := fakeETag(payload)
+
+	headers, err := c.Stat(ctx, key, client.IfNoneMatch(etag))
+	assert.IsError(t, err, client.ErrNotModified)
+	assert.NotZero(t, headers.Get("ETag"))
+
+	headers, err = c.Stat(ctx, key, client.IfNoneMatch(`"wrong"`))
+	assert.NoError(t, err)
+	assert.NotZero(t, headers.Get("ETag"))
+}
+
+func TestOpenIfMatch(t *testing.T) {
+	srv := newFakeServer(nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, nil).Namespace("test")
+	defer c.Close()
+	ctx := t.Context()
+
+	key := client.NewKey("ifmatch-test")
+	payload := []byte("ifmatch content")
+
+	wc, err := c.Create(ctx, key, nil, 0)
+	assert.NoError(t, err)
+	_, err = wc.Write(payload)
+	assert.NoError(t, err)
+	assert.NoError(t, wc.Close())
+
+	etag := fakeETag(payload)
+
+	// Matching ETag should succeed
+	rc, _, err := c.Open(ctx, key, client.IfMatch(etag))
+	assert.NoError(t, err)
+	assert.NoError(t, rc.Close())
+
+	// Non-matching should fail with 412
+	_, _, err = c.Open(ctx, key, client.IfMatch(`"wrong"`))
+	assert.IsError(t, err, client.ErrPreconditionFailed)
 }
 
 func TestParseKey(t *testing.T) {

--- a/client/preconditions.go
+++ b/client/preconditions.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/alecthomas/errors"
+)
+
+// ErrNotModified is returned when the server responds with 304 Not Modified,
+// indicating the resource has not changed since the ETag in If-None-Match.
+var ErrNotModified = errors.New("not modified")
+
+// ErrPreconditionFailed is returned when the server responds with 412
+// Precondition Failed, indicating an If-Match or If-None-Match condition was not met.
+var ErrPreconditionFailed = errors.New("precondition failed")
+
+// RequestOption configures conditional headers on an outgoing cache request.
+type RequestOption func(req *http.Request)
+
+// IfMatch sets the If-Match header. The server will return 412 Precondition
+// Failed if the stored ETag does not match.
+func IfMatch(etag string) RequestOption {
+	return func(req *http.Request) {
+		req.Header.Set("If-Match", etag)
+	}
+}
+
+// IfNoneMatch sets the If-None-Match header. For GET/HEAD the server returns
+// 304 Not Modified when the ETag matches; for other methods it returns 412.
+func IfNoneMatch(etag string) RequestOption {
+	return func(req *http.Request) {
+		req.Header.Set("If-None-Match", etag)
+	}
+}

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -10,6 +10,8 @@ var TransportHeaders = []string{ //nolint:gochecknoglobals
 	"User-Agent",
 	"Transfer-Encoding",
 	"Time-To-Live",
+	"If-Match",
+	"If-None-Match",
 }
 
 // HopByHopHeaders are hop-by-hop headers that should not be forwarded by proxies (RFC 7230).

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -69,6 +69,10 @@ func (d *APIV1) statObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	maps.Copy(w.Header(), headers)
+	if status := checkConditionals(r, headers.Get("ETag")); status != 0 {
+		w.WriteHeader(status)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -96,6 +100,11 @@ func (d *APIV1) getObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	maps.Copy(w.Header(), headers)
+	if status := checkConditionals(r, headers.Get("ETag")); status != 0 {
+		_ = cr.Close()
+		w.WriteHeader(status)
+		return
+	}
 
 	_, err = io.Copy(w, cr)
 	if err != nil {
@@ -207,4 +216,21 @@ func (d *APIV1) httpError(w http.ResponseWriter, code int, err error, message st
 	args = append(args, "error", err)
 	d.logger.Error(message, args...)
 	http.Error(w, message, code)
+}
+
+// checkConditionals evaluates If-Match and If-None-Match precondition headers
+// against the stored ETag for GET/HEAD requests. Returns 0 if all
+// preconditions pass, otherwise the HTTP status code to send (304 or 412).
+func checkConditionals(r *http.Request, etag string) int {
+	if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
+		if etag == "" || (ifMatch != "*" && ifMatch != etag) {
+			return http.StatusPreconditionFailed
+		}
+	}
+	if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != "" {
+		if (ifNoneMatch == "*" && etag != "") || ifNoneMatch == etag {
+			return http.StatusNotModified
+		}
+	}
+	return 0
 }

--- a/internal/strategy/apiv1_test.go
+++ b/internal/strategy/apiv1_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,108 @@ func TestPutObjectAbortsOnReadError(t *testing.T) {
 	nsCache := memCache.Namespace("test")
 	_, _, err = nsCache.Open(ctx, key)
 	assert.IsError(t, err, os.ErrNotExist)
+}
+
+func testAPISetup(t *testing.T) (http.Handler, context.Context) {
+	t.Helper()
+	_, ctx := logging.Configure(context.Background(), logging.Config{Level: slog.LevelError})
+	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	t.Cleanup(func() { memCache.Close() })
+
+	mux := http.NewServeMux()
+	_, err = strategy.NewAPIV1(ctx, struct{}{}, memCache, mux)
+	assert.NoError(t, err)
+	return mux, ctx
+}
+
+func apiPut(ctx context.Context, t *testing.T, handler http.Handler, key cache.Key) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/test/"+key.String(), strings.NewReader("test data"))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Stat to get the ETag
+	req = httptest.NewRequest(http.MethodHead, "/api/v1/object/test/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	etag := w.Header().Get("ETag")
+	assert.NotZero(t, etag)
+	return etag
+}
+
+func TestConditionalGetIfNoneMatch(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("cond-get")
+	etag := apiPut(ctx, t, handler, key)
+
+	tests := []struct {
+		name           string
+		ifNoneMatch    string
+		expectedStatus int
+	}{
+		{name: "Matching", ifNoneMatch: etag, expectedStatus: http.StatusNotModified},
+		{name: "NonMatching", ifNoneMatch: `"wrong"`, expectedStatus: http.StatusOK},
+		{name: "Wildcard", ifNoneMatch: "*", expectedStatus: http.StatusNotModified},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/object/test/"+key.String(), nil)
+			req = req.WithContext(ctx)
+			req.Header.Set("If-None-Match", tt.ifNoneMatch)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedStatus == http.StatusNotModified {
+				assert.Equal(t, etag, w.Header().Get("ETag"))
+				assert.Equal(t, 0, w.Body.Len())
+			}
+		})
+	}
+}
+
+func TestConditionalHeadIfNoneMatch(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("cond-head")
+	etag := apiPut(ctx, t, handler, key)
+
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/object/test/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("If-None-Match", etag)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotModified, w.Code)
+	assert.Equal(t, etag, w.Header().Get("ETag"))
+}
+
+func TestConditionalGetIfMatch(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("cond-ifmatch")
+	etag := apiPut(ctx, t, handler, key)
+
+	tests := []struct {
+		name           string
+		ifMatch        string
+		expectedStatus int
+	}{
+		{name: "Matching", ifMatch: etag, expectedStatus: http.StatusOK},
+		{name: "NonMatching", ifMatch: `"wrong"`, expectedStatus: http.StatusPreconditionFailed},
+		{name: "Wildcard", ifMatch: "*", expectedStatus: http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/object/test/"+key.String(), nil)
+			req = req.WithContext(ctx)
+			req.Header.Set("If-Match", tt.ifMatch)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
 }
 
 // failingReader returns data up to failAfter bytes, then returns an error.


### PR DESCRIPTION
Server: check conditional headers on GET/HEAD object endpoints.
Return 304 when If-None-Match matches the stored ETag; return 412
when If-Match does not match.

Client: add RequestOption functional options (IfMatch, IfNoneMatch)
to Open and Stat. Add ErrNotModified and ErrPreconditionFailed
sentinel errors with HTTPStatusError.Is so errors.Is works across
all error paths.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
