### PR TITLE
feat(git): forward snapshot ETag and support HEAD requests

### DIFF
--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -70,7 +70,7 @@ func (d *APIV1) statObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	maps.Copy(w.Header(), headers)
-	if status := checkConditionals(r, headers.Get("ETag")); status != 0 {
+	if status := CheckConditionals(r, headers.Get("ETag")); status != 0 {
 		w.WriteHeader(status)
 		return
 	}
@@ -101,7 +101,7 @@ func (d *APIV1) getObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	maps.Copy(w.Header(), headers)
-	if status := checkConditionals(r, headers.Get("ETag")); status != 0 {
+	if status := CheckConditionals(r, headers.Get("ETag")); status != 0 {
 		_ = cr.Close()
 		w.WriteHeader(status)
 		return
@@ -219,10 +219,10 @@ func (d *APIV1) httpError(w http.ResponseWriter, code int, err error, message st
 	http.Error(w, message, code)
 }
 
-// checkConditionals evaluates If-Match and If-None-Match precondition headers
+// CheckConditionals evaluates If-Match and If-None-Match precondition headers
 // against the stored ETag for GET/HEAD requests. Returns 0 if all
 // preconditions pass, otherwise the HTTP status code to send (304 or 412).
-func checkConditionals(r *http.Request, etag string) int {
+func CheckConditionals(r *http.Request, etag string) int {
 	if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
 		if etag == "" || !etagListMatches(ifMatch, etag) {
 			return http.StatusPreconditionFailed

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -22,6 +22,7 @@ import (
 	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/snapshot"
+	"github.com/block/cachew/internal/strategy"
 )
 
 const lfsFetchTimeout = 25 * time.Minute
@@ -239,14 +240,21 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 	r = r.WithContext(ctx)
 	logger := logging.FromContext(ctx)
 
+	cacheKey := snapshotCacheKey(upstreamURL)
+
+	// HEAD is answered from cache metadata alone so probes never read or
+	// generate the snapshot body, and never warm up a mirror.
+	if r.Method == http.MethodHead {
+		s.serveSnapshotHead(ctx, w, r, cacheKey, repoName, start)
+		return
+	}
+
 	repo, repoErr := s.cloneManager.GetOrCreate(ctx, upstreamURL)
 	if repoErr != nil {
 		logger.ErrorContext(ctx, "Failed to get or create clone", "upstream", upstreamURL, "error", repoErr)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-
-	cacheKey := snapshotCacheKey(upstreamURL)
 
 	// On cold start the local mirror may not be ready yet. Check the S3 cache
 	// first so we can stream a cached snapshot to the client immediately while
@@ -333,6 +341,40 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 		logger.ErrorContext(ctx, "Failed to serve snapshot", "upstream", upstreamURL, "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
+	}
+}
+
+// serveSnapshotHead answers a HEAD request from cache metadata alone via Stat,
+// reporting the snapshot's validators (ETag, Content-Length) and freshness
+// commit without reading or generating the body. An uncached snapshot yields
+// 404 rather than triggering the expensive on-demand generation that GET does.
+// If-None-Match / If-Match preconditions are honoured against the cached ETag.
+func (s *Strategy) serveSnapshotHead(ctx context.Context, w http.ResponseWriter, r *http.Request, cacheKey cache.Key, repoName string, start time.Time) {
+	headers, err := s.cache.Stat(ctx, cacheKey)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.Error(w, "Snapshot not cached", http.StatusNotFound)
+			return
+		}
+		logging.FromContext(ctx).ErrorContext(ctx, "Failed to stat snapshot", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	applySnapshotCacheHeaders(w, headers)
+	if commit := headers.Get("X-Cachew-Snapshot-Commit"); commit != "" {
+		w.Header().Set("X-Cachew-Snapshot-Commit", commit)
+	}
+
+	status := http.StatusOK
+	if conditional := strategy.CheckConditionals(r, headers.Get(cache.ETagKey)); conditional != 0 {
+		status = conditional
+	}
+	w.WriteHeader(status)
+
+	s.metrics.recordSnapshotServe(ctx, "head", repoName, 0, time.Since(start))
+	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		span.SetAttributes(attribute.String("cachew.source", "head"), attribute.Int64("cachew.bytes", 0))
 	}
 }
 
@@ -507,13 +549,26 @@ func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseW
 		}()
 	}
 
-	w.Header().Set("Content-Type", "application/zstd")
+	applySnapshotCacheHeaders(w, headers)
 	n, err := serveReaderFast(w, r, reader)
 	s.metrics.recordSnapshotServe(ctx, "cache", repoName, n, time.Since(start))
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
 		span.SetAttributes(attribute.String("cachew.source", "cache"), attribute.Int64("cachew.bytes", n))
 	}
 	return errors.Wrap(err, "stream snapshot")
+}
+
+// applySnapshotCacheHeaders forwards the cached snapshot's validators so clients
+// can revalidate (ETag) and size the transfer (Content-Length). Content-Type is
+// fixed for snapshots regardless of what the cache backend recorded.
+func applySnapshotCacheHeaders(w http.ResponseWriter, headers http.Header) {
+	w.Header().Set("Content-Type", "application/zstd")
+	if etag := headers.Get(cache.ETagKey); etag != "" {
+		w.Header().Set(cache.ETagKey, etag)
+	}
+	if contentLength := headers.Get("Content-Length"); contentLength != "" {
+		w.Header().Set("Content-Length", contentLength)
+	}
 }
 
 // cacheBundle streams r into the cache under key. Used by the bundle

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -508,6 +508,81 @@ func TestSnapshotServesFreshSnapshotWithCommitHeader(t *testing.T) {
 		"X-Cachew-Snapshot-Commit should be set so client knows snapshot is fresh")
 	assert.Equal(t, "", w.Header().Get("X-Cachew-Bundle-Url"),
 		"no bundle URL when snapshot is already at mirror HEAD")
+	assert.NotEqual(t, "", w.Header().Get(cache.ETagKey),
+		"ETag should be forwarded from the cached snapshot so clients can revalidate")
+	assert.NotEqual(t, "", w.Header().Get("Content-Length"),
+		"Content-Length should be forwarded from the cached snapshot")
+}
+
+func TestSnapshotHeadServesMetadataWithoutBody(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamURL := "https://github.com/org/repo"
+	mirrorPath := filepath.Join(mirrorRoot, "github.com", "org", "repo")
+	createTestMirrorRepo(t, mirrorPath)
+
+	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	mux := newTestMux()
+
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{MirrorRoot: mirrorRoot}, nil)
+	s, err := git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+
+	manager, err := cm()
+	assert.NoError(t, err)
+	repo, err := manager.GetOrCreate(ctx, upstreamURL)
+	assert.NoError(t, err)
+
+	handler := mux.handlers["GET /git/{host}/{path...}"]
+	assert.NotZero(t, handler)
+
+	// Before any snapshot exists, HEAD must report 404 rather than generating one.
+	missReq := httptest.NewRequest(http.MethodHead, "/git/github.com/org/repo/snapshot.tar.zst", nil)
+	missReq = missReq.WithContext(ctx)
+	missReq.SetPathValue("host", "github.com")
+	missReq.SetPathValue("path", "org/repo/snapshot.tar.zst")
+	missResp := httptest.NewRecorder()
+	handler.ServeHTTP(missResp, missReq)
+	assert.Equal(t, 404, missResp.Code, "HEAD on an uncached snapshot must not trigger generation")
+
+	waitForReady(t, s)
+	err = s.GenerateAndUploadSnapshot(ctx, repo)
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodHead, "/git/github.com/org/repo/snapshot.tar.zst", nil)
+	req = req.WithContext(ctx)
+	req.SetPathValue("host", "github.com")
+	req.SetPathValue("path", "org/repo/snapshot.tar.zst")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, 0, w.Body.Len(), "HEAD must not return a body")
+	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
+	assert.NotEqual(t, "", w.Header().Get(cache.ETagKey),
+		"HEAD should report the snapshot ETag from cache metadata")
+	assert.NotEqual(t, "", w.Header().Get("Content-Length"),
+		"HEAD should report the snapshot Content-Length from cache metadata")
+	assert.NotEqual(t, "", w.Header().Get("X-Cachew-Snapshot-Commit"),
+		"HEAD should report the snapshot commit from cache metadata")
+
+	// A HEAD carrying the snapshot's ETag in If-None-Match must revalidate to 304.
+	etag := w.Header().Get(cache.ETagKey)
+	condReq := httptest.NewRequest(http.MethodHead, "/git/github.com/org/repo/snapshot.tar.zst", nil)
+	condReq = condReq.WithContext(ctx)
+	condReq.SetPathValue("host", "github.com")
+	condReq.SetPathValue("path", "org/repo/snapshot.tar.zst")
+	condReq.Header.Set("If-None-Match", etag)
+	condResp := httptest.NewRecorder()
+	handler.ServeHTTP(condResp, condReq)
+	assert.Equal(t, http.StatusNotModified, condResp.Code,
+		"HEAD with a matching If-None-Match should return 304")
 }
 
 func TestSnapshotServesBundleURLWhenStale(t *testing.T) {


### PR DESCRIPTION
The common bundle-serving path (serveSnapshotWithBundle) dropped the cached ETag and Content-Length, so clients could not revalidate snapshots. Forward both validators via a shared applySnapshotCacheHeaders helper.

Add HEAD support backed by the cache's Stat() so probes never read or generate the body, or warm up a mirror. HEAD reports the ETag, Content-Length and snapshot commit, returns 404 when uncached, and honours If-None-Match/If-Match via the now-exported CheckConditionals helper.

Closes #334
