### PR TITLE
fix(git): honour conditional GETs when serving cached snapshots

### DIFF
--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -550,7 +550,18 @@ func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseW
 	}
 
 	applySnapshotCacheHeaders(w, headers)
-	n, err := serveReaderFast(w, r, reader)
+
+	// Honour conditional GETs against the advertised ETag. ServeContent does this
+	// natively for *os.File readers, but cache backends returning non-file readers
+	// (S3, memory, remote) fall through to io.Copy, so revalidate explicitly to
+	// avoid streaming the full snapshot when the client already has it.
+	var n int64
+	var err error
+	if status := strategy.CheckConditionals(r, headers.Get(cache.ETagKey)); status != 0 {
+		w.WriteHeader(status)
+	} else {
+		n, err = serveReaderFast(w, r, reader)
+	}
 	s.metrics.recordSnapshotServe(ctx, "cache", repoName, n, time.Since(start))
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
 		span.SetAttributes(attribute.String("cachew.source", "cache"), attribute.Int64("cachew.bytes", n))

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -585,6 +585,65 @@ func TestSnapshotHeadServesMetadataWithoutBody(t *testing.T) {
 		"HEAD with a matching If-None-Match should return 304")
 }
 
+func TestSnapshotGetHonorsIfNoneMatch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamURL := "https://github.com/org/repo"
+	mirrorPath := filepath.Join(mirrorRoot, "github.com", "org", "repo")
+	createTestMirrorRepo(t, mirrorPath)
+
+	// The memory cache returns a non-*os.File reader, exercising the io.Copy path
+	// where ServeContent would not otherwise evaluate conditionals.
+	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	mux := newTestMux()
+
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{MirrorRoot: mirrorRoot}, nil)
+	s, err := git.New(ctx, git.Config{}, newTestScheduler(ctx, t), memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+
+	manager, err := cm()
+	assert.NoError(t, err)
+	repo, err := manager.GetOrCreate(ctx, upstreamURL)
+	assert.NoError(t, err)
+
+	waitForReady(t, s)
+	err = s.GenerateAndUploadSnapshot(ctx, repo)
+	assert.NoError(t, err)
+
+	handler := mux.handlers["GET /git/{host}/{path...}"]
+	assert.NotZero(t, handler)
+
+	// First GET captures the advertised ETag and the full body.
+	req := httptest.NewRequest(http.MethodGet, "/git/github.com/org/repo/snapshot.tar.zst", nil)
+	req = req.WithContext(ctx)
+	req.SetPathValue("host", "github.com")
+	req.SetPathValue("path", "org/repo/snapshot.tar.zst")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	etag := w.Header().Get(cache.ETagKey)
+	assert.NotEqual(t, "", etag, "GET should advertise the snapshot ETag")
+	assert.NotEqual(t, 0, w.Body.Len(), "unconditional GET should return the snapshot body")
+
+	// A conditional GET with the matching ETag must return 304 with no body.
+	condReq := httptest.NewRequest(http.MethodGet, "/git/github.com/org/repo/snapshot.tar.zst", nil)
+	condReq = condReq.WithContext(ctx)
+	condReq.SetPathValue("host", "github.com")
+	condReq.SetPathValue("path", "org/repo/snapshot.tar.zst")
+	condReq.Header.Set("If-None-Match", etag)
+	condResp := httptest.NewRecorder()
+	handler.ServeHTTP(condResp, condReq)
+	assert.Equal(t, http.StatusNotModified, condResp.Code,
+		"GET with a matching If-None-Match should return 304")
+	assert.Equal(t, 0, condResp.Body.Len(), "304 must not return a body")
+}
+
 func TestSnapshotServesBundleURLWhenStale(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found in PATH")


### PR DESCRIPTION
serveSnapshotWithBundle advertises the snapshot ETag but, for cache backends that return non-*os.File readers (S3, memory, remote tier), fell through to io.Copy and never evaluated If-None-Match/If-Match. A revalidating client therefore received a full 200 body instead of 304.

Evaluate strategy.CheckConditionals after applying the cached headers and before streaming, short-circuiting to 304/412 for all reader types. File-backed readers already got this via http.ServeContent.

Addresses Codex review feedback on #337.
