### PR TITLE
feat(cache): support byte ranges on Cache.Open

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -34,6 +34,8 @@ func (e *HTTPStatusError) Is(target error) bool {
 		return e.StatusCode == http.StatusNotModified
 	case ErrPreconditionFailed:
 		return e.StatusCode == http.StatusPreconditionFailed
+	case ErrRangeNotSatisfiable:
+		return e.StatusCode == http.StatusRequestedRangeNotSatisfiable
 	default:
 		return false
 	}
@@ -174,7 +176,7 @@ func (c *Client) Open(ctx context.Context, key Key, opts ...RequestOption) (io.R
 	}
 
 	switch resp.StatusCode {
-	case http.StatusOK:
+	case http.StatusOK, http.StatusPartialContent:
 		return resp.Body, filterHeaders(resp.Header, transportHeaders...), nil
 
 	case http.StatusNotFound:
@@ -184,6 +186,10 @@ func (c *Client) Open(ctx context.Context, key Key, opts ...RequestOption) (io.R
 	case http.StatusNotModified:
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
 		return nil, filterHeaders(resp.Header, transportHeaders...), errors.Join(ErrNotModified, resp.Body.Close())
+
+	case http.StatusRequestedRangeNotSatisfiable:
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
+		return nil, filterHeaders(resp.Header, transportHeaders...), errors.Join(ErrRangeNotSatisfiable, resp.Body.Close())
 
 	case http.StatusPreconditionFailed:
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -425,6 +425,43 @@ func TestOpenIfMatch(t *testing.T) {
 	assert.IsError(t, err, client.ErrPreconditionFailed)
 }
 
+func TestOpenRange(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/object/{namespace}/{key}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("Range") {
+		case "bytes=0-3":
+			w.Header().Set("Content-Range", "bytes 0-3/10")
+			w.Header().Set("Content-Length", "4")
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write([]byte("0123")) //nolint:errcheck
+		case "bytes=50-60":
+			w.Header().Set("Content-Range", "bytes */10")
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		default:
+			http.Error(w, "unexpected range", http.StatusBadRequest)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := client.New(srv.URL, nil).Namespace("test")
+	defer c.Close()
+	ctx := t.Context()
+	key := client.NewKey("range-test")
+
+	rc, headers, err := c.Open(ctx, key, client.Range("bytes=0-3"))
+	assert.NoError(t, err)
+	data, readErr := io.ReadAll(rc)
+	assert.NoError(t, readErr)
+	assert.NoError(t, rc.Close())
+	assert.Equal(t, "0123", string(data))
+	assert.Equal(t, "bytes 0-3/10", headers.Get("Content-Range"))
+
+	_, headers, err = c.Open(ctx, key, client.Range("bytes=50-60"))
+	assert.IsError(t, err, client.ErrRangeNotSatisfiable)
+	assert.Equal(t, "bytes */10", headers.Get("Content-Range"))
+}
+
 func TestParseKey(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -449,7 +449,7 @@ func TestOpenRange(t *testing.T) {
 	ctx := t.Context()
 	key := client.NewKey("range-test")
 
-	rc, headers, err := c.Open(ctx, key, client.Range("bytes=0-3"))
+	rc, headers, err := c.Open(ctx, key, client.Range(0, 4))
 	assert.NoError(t, err)
 	data, readErr := io.ReadAll(rc)
 	assert.NoError(t, readErr)
@@ -457,7 +457,7 @@ func TestOpenRange(t *testing.T) {
 	assert.Equal(t, "0123", string(data))
 	assert.Equal(t, "bytes 0-3/10", headers.Get("Content-Range"))
 
-	_, headers, err = c.Open(ctx, key, client.Range("bytes=50-60"))
+	_, headers, err = c.Open(ctx, key, client.Range(50, 61))
 	assert.IsError(t, err, client.ErrRangeNotSatisfiable)
 	assert.Equal(t, "bytes */10", headers.Get("Content-Range"))
 }

--- a/client/preconditions.go
+++ b/client/preconditions.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/alecthomas/errors"
@@ -16,6 +17,11 @@ var ErrNotModified = errors.New("not modified")
 // Over HTTP this corresponds to 412 Precondition Failed.
 var ErrPreconditionFailed = errors.New("precondition failed")
 
+// ErrRangeNotSatisfiable is returned when a Range precondition cannot be
+// satisfied against the stored object. Over HTTP this corresponds to 416 Range
+// Not Satisfiable.
+var ErrRangeNotSatisfiable = errors.New("range not satisfiable")
+
 // RequestOptions holds conditional-request parameters. It is the single
 // representation shared by the client wire protocol, the cache backends, and
 // the server handlers.
@@ -26,6 +32,14 @@ type RequestOptions struct {
 	// IfNoneMatch is the If-None-Match precondition. Evaluation reports
 	// ErrNotModified when the stored ETag matches.
 	IfNoneMatch string
+	// Range is a raw HTTP Range header value (e.g. "bytes=0-499"). Only a
+	// single byte range is supported; multi-range or invalid specifiers are
+	// ignored and the full representation is served.
+	Range string
+	// IfRange gates Range on the stored ETag: the range is only applied when
+	// IfRange matches the stored ETag, otherwise the full representation is
+	// served. Only the entity-tag form is supported.
+	IfRange string
 }
 
 // RequestOption configures conditional request parameters.
@@ -39,6 +53,19 @@ func IfMatch(etag string) RequestOption {
 // IfNoneMatch sets the If-None-Match precondition.
 func IfNoneMatch(etag string) RequestOption {
 	return func(o *RequestOptions) { o.IfNoneMatch = etag }
+}
+
+// Range requests a single byte range (e.g. "bytes=0-499"). Open returns the
+// matching bytes with a 206-style Content-Range header, or
+// ErrRangeNotSatisfiable if the range lies outside the object.
+func Range(spec string) RequestOption {
+	return func(o *RequestOptions) { o.Range = spec }
+}
+
+// IfRange sets the If-Range precondition: the Range is only honoured when etag
+// matches the stored ETag, otherwise the full representation is served.
+func IfRange(etag string) RequestOption {
+	return func(o *RequestOptions) { o.IfRange = etag }
 }
 
 // NewRequestOptions applies opts and returns the resulting RequestOptions.
@@ -71,6 +98,95 @@ func (o RequestOptions) applyToRequest(req *http.Request) {
 	if o.IfNoneMatch != "" {
 		req.Header.Set("If-None-Match", o.IfNoneMatch)
 	}
+	if o.Range != "" {
+		req.Header.Set("Range", o.Range)
+	}
+	if o.IfRange != "" {
+		req.Header.Set("If-Range", o.IfRange)
+	}
+}
+
+// RangeOutcome classifies how a Range request should be answered.
+type RangeOutcome int
+
+const (
+	// RangeFull indicates the full representation should be served (no Range,
+	// an unmatched If-Range, or an unsupported/invalid specifier).
+	RangeFull RangeOutcome = iota
+	// RangePartial indicates a single satisfiable byte range.
+	RangePartial
+	// RangeNotSatisfiable indicates the range lies outside the object.
+	RangeNotSatisfiable
+)
+
+// ResolveRange evaluates the Range/If-Range options against an object of the
+// given size and ETag. On RangePartial it returns the [start, start+length)
+// window to serve.
+func (o RequestOptions) ResolveRange(size int64, etag string) (start, length int64, outcome RangeOutcome) {
+	if o.Range == "" {
+		return 0, size, RangeFull
+	}
+	// If-Range only applies the range when its validator matches the stored
+	// ETag; otherwise the client is told to serve the full representation.
+	if o.IfRange != "" && o.IfRange != etag {
+		return 0, size, RangeFull
+	}
+	return resolveByteRange(o.Range, size)
+}
+
+// resolveByteRange parses a single HTTP byte-range specifier against size.
+// Multi-range and syntactically invalid specifiers yield RangeFull so the
+// caller serves the full representation.
+func resolveByteRange(spec string, size int64) (start, length int64, outcome RangeOutcome) {
+	const prefix = "bytes="
+	if !strings.HasPrefix(spec, prefix) {
+		return 0, size, RangeFull
+	}
+	spec = strings.TrimSpace(spec[len(prefix):])
+	if spec == "" || strings.ContainsRune(spec, ',') {
+		return 0, size, RangeFull
+	}
+	startStr, endStr, ok := strings.Cut(spec, "-")
+	if !ok {
+		return 0, size, RangeFull
+	}
+	startStr = strings.TrimSpace(startStr)
+	endStr = strings.TrimSpace(endStr)
+
+	if startStr == "" {
+		// Suffix range "-N": the final N bytes.
+		n, err := strconv.ParseInt(endStr, 10, 64)
+		if err != nil {
+			return 0, size, RangeFull
+		}
+		if n <= 0 || size == 0 {
+			return 0, size, RangeNotSatisfiable
+		}
+		if n > size {
+			n = size
+		}
+		return size - n, n, RangePartial
+	}
+
+	start, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil || start < 0 {
+		return 0, size, RangeFull
+	}
+	if start >= size {
+		return 0, size, RangeNotSatisfiable
+	}
+	if endStr == "" {
+		// Open range "START-": to the end of the object.
+		return start, size - start, RangePartial
+	}
+	end, err := strconv.ParseInt(endStr, 10, 64)
+	if err != nil || end < start {
+		return 0, size, RangeFull
+	}
+	if end >= size {
+		end = size - 1
+	}
+	return start, end - start + 1, RangePartial
 }
 
 // etagListMatches reports whether etag matches an If-Match / If-None-Match

--- a/client/preconditions.go
+++ b/client/preconditions.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -55,11 +56,28 @@ func IfNoneMatch(etag string) RequestOption {
 	return func(o *RequestOptions) { o.IfNoneMatch = etag }
 }
 
-// Range requests a single byte range (e.g. "bytes=0-499"). Open returns the
-// matching bytes with a 206-style Content-Range header, or
+// Range requests a single half-open byte range [start, end) from Open. A
+// negative end means "to the end of the object" (its Content-Length). For
+// example Range(0, 500) requests the first 500 bytes and Range(0, -1) the whole
+// object. Open returns the matching bytes with a Content-Range header, or
 // ErrRangeNotSatisfiable if the range lies outside the object.
-func Range(spec string) RequestOption {
+func Range(start, end int64) RequestOption {
+	return RangeHeader(formatByteRange(start, end))
+}
+
+// RangeHeader sets a raw HTTP Range header value (e.g. "bytes=0-499"). It is for
+// forwarding a client's Range header verbatim; prefer Range for programmatic use.
+func RangeHeader(spec string) RequestOption {
 	return func(o *RequestOptions) { o.Range = spec }
+}
+
+// formatByteRange renders a half-open [start, end) range as an HTTP byte-range
+// specifier. A negative end yields an open-ended range to the end of the object.
+func formatByteRange(start, end int64) string {
+	if end < 0 {
+		return fmt.Sprintf("bytes=%d-", start)
+	}
+	return fmt.Sprintf("bytes=%d-%d", start, end-1)
 }
 
 // IfRange sets the If-Range precondition: the Range is only honoured when etag

--- a/client/preconditions.go
+++ b/client/preconditions.go
@@ -62,12 +62,7 @@ func IfNoneMatch(etag string) RequestOption {
 // object. Open returns the matching bytes with a Content-Range header, or
 // ErrRangeNotSatisfiable if the range lies outside the object.
 func Range(start, end int64) RequestOption {
-	return RangeHeader(formatByteRange(start, end))
-}
-
-// RangeHeader sets a raw HTTP Range header value (e.g. "bytes=0-499"). It is for
-// forwarding a client's Range header verbatim; prefer Range for programmatic use.
-func RangeHeader(spec string) RequestOption {
+	spec := formatByteRange(start, end)
 	return func(o *RequestOptions) { o.Range = spec }
 }
 

--- a/client/preconditions_test.go
+++ b/client/preconditions_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/block/cachew/client"
 )
 
-func TestRangeHeaderFormat(t *testing.T) {
+func TestRangeFormat(t *testing.T) {
 	tests := []struct {
 		name       string
 		start, end int64
@@ -60,7 +60,7 @@ func TestResolveRange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := client.NewRequestOptions(client.RangeHeader(tt.spec), client.IfRange(tt.ifRange))
+			o := client.RequestOptions{Range: tt.spec, IfRange: tt.ifRange}
 			start, length, outcome := o.ResolveRange(tt.size, etag)
 			assert.Equal(t, tt.wantOutcome, outcome)
 			if outcome == client.RangeNotSatisfiable {

--- a/client/preconditions_test.go
+++ b/client/preconditions_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/block/cachew/client"
 )
 
+func TestRangeHeaderFormat(t *testing.T) {
+	tests := []struct {
+		name       string
+		start, end int64
+		want       string
+	}{
+		{name: "FirstN", start: 0, end: 500, want: "bytes=0-499"},
+		{name: "Middle", start: 100, end: 200, want: "bytes=100-199"},
+		{name: "ToEnd", start: 0, end: -1, want: "bytes=0-"},
+		{name: "FromOffsetToEnd", start: 100, end: -1, want: "bytes=100-"},
+		{name: "Single", start: 5, end: 6, want: "bytes=5-5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := client.NewRequestOptions(client.Range(tt.start, tt.end))
+			assert.Equal(t, tt.want, o.Range)
+		})
+	}
+}
+
 func TestResolveRange(t *testing.T) {
 	const etag = `"e"`
 	tests := []struct {
@@ -40,7 +60,7 @@ func TestResolveRange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := client.NewRequestOptions(client.Range(tt.spec), client.IfRange(tt.ifRange))
+			o := client.NewRequestOptions(client.RangeHeader(tt.spec), client.IfRange(tt.ifRange))
 			start, length, outcome := o.ResolveRange(tt.size, etag)
 			assert.Equal(t, tt.wantOutcome, outcome)
 			if outcome == client.RangeNotSatisfiable {

--- a/client/preconditions_test.go
+++ b/client/preconditions_test.go
@@ -1,0 +1,53 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/client"
+)
+
+func TestResolveRange(t *testing.T) {
+	const etag = `"e"`
+	tests := []struct {
+		name        string
+		spec        string
+		ifRange     string
+		size        int64
+		wantStart   int64
+		wantLength  int64
+		wantOutcome client.RangeOutcome
+	}{
+		{name: "NoRange", spec: "", size: 10, wantStart: 0, wantLength: 10, wantOutcome: client.RangeFull},
+		{name: "FirstBytes", spec: "bytes=0-4", size: 10, wantStart: 0, wantLength: 5, wantOutcome: client.RangePartial},
+		{name: "Middle", spec: "bytes=2-5", size: 10, wantStart: 2, wantLength: 4, wantOutcome: client.RangePartial},
+		{name: "OpenEnded", spec: "bytes=3-", size: 10, wantStart: 3, wantLength: 7, wantOutcome: client.RangePartial},
+		{name: "Suffix", spec: "bytes=-3", size: 10, wantStart: 7, wantLength: 3, wantOutcome: client.RangePartial},
+		{name: "SuffixLargerThanSize", spec: "bytes=-20", size: 10, wantStart: 0, wantLength: 10, wantOutcome: client.RangePartial},
+		{name: "EndBeyondSize", spec: "bytes=5-100", size: 10, wantStart: 5, wantLength: 5, wantOutcome: client.RangePartial},
+		{name: "StartAtSize", spec: "bytes=10-20", size: 10, wantOutcome: client.RangeNotSatisfiable},
+		{name: "StartBeyondSize", spec: "bytes=20-", size: 10, wantOutcome: client.RangeNotSatisfiable},
+		{name: "SuffixZero", spec: "bytes=-0", size: 10, wantOutcome: client.RangeNotSatisfiable},
+		{name: "ZeroSizeSuffix", spec: "bytes=-1", size: 0, wantOutcome: client.RangeNotSatisfiable},
+		{name: "ZeroSizeRange", spec: "bytes=0-0", size: 0, wantOutcome: client.RangeNotSatisfiable},
+		{name: "Multi", spec: "bytes=0-1,3-4", size: 10, wantLength: 10, wantOutcome: client.RangeFull},
+		{name: "MissingPrefix", spec: "0-4", size: 10, wantLength: 10, wantOutcome: client.RangeFull},
+		{name: "StartGreaterThanEnd", spec: "bytes=5-2", size: 10, wantLength: 10, wantOutcome: client.RangeFull},
+		{name: "NonNumeric", spec: "bytes=a-b", size: 10, wantLength: 10, wantOutcome: client.RangeFull},
+		{name: "IfRangeMatch", spec: "bytes=0-4", ifRange: etag, size: 10, wantStart: 0, wantLength: 5, wantOutcome: client.RangePartial},
+		{name: "IfRangeMismatch", spec: "bytes=0-4", ifRange: `"other"`, size: 10, wantLength: 10, wantOutcome: client.RangeFull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := client.NewRequestOptions(client.Range(tt.spec), client.IfRange(tt.ifRange))
+			start, length, outcome := o.ResolveRange(tt.size, etag)
+			assert.Equal(t, tt.wantOutcome, outcome)
+			if outcome == client.RangeNotSatisfiable {
+				return
+			}
+			assert.Equal(t, tt.wantStart, start)
+			assert.Equal(t, tt.wantLength, length)
+		})
+	}
+}

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -42,10 +42,15 @@ func IfMatch(etag string) Option { return client.IfMatch(etag) }
 // ErrNotModified when the stored ETag matches.
 func IfNoneMatch(etag string) Option { return client.IfNoneMatch(etag) }
 
-// Range requests a single byte range from Open. The returned headers carry a
+// Range requests a single half-open byte range [start, end) from Open. A
+// negative end means "to the end of the object". The returned headers carry a
 // Content-Range; Open returns ErrRangeNotSatisfiable if the range lies outside
 // the object. Stat ignores Range.
-func Range(spec string) Option { return client.Range(spec) }
+func Range(start, end int64) Option { return client.Range(start, end) }
+
+// RangeHeader sets a raw HTTP Range header value (e.g. "bytes=0-499"), for
+// forwarding a client's Range verbatim; prefer Range for programmatic use.
+func RangeHeader(spec string) Option { return client.RangeHeader(spec) }
 
 // IfRange gates Range on the stored ETag: the range is only applied when etag
 // matches, otherwise the full object is returned.

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -42,6 +42,15 @@ func IfMatch(etag string) Option { return client.IfMatch(etag) }
 // ErrNotModified when the stored ETag matches.
 func IfNoneMatch(etag string) Option { return client.IfNoneMatch(etag) }
 
+// Range requests a single byte range from Open. The returned headers carry a
+// Content-Range; Open returns ErrRangeNotSatisfiable if the range lies outside
+// the object. Stat ignores Range.
+func Range(spec string) Option { return client.Range(spec) }
+
+// IfRange gates Range on the stored ETag: the range is only applied when etag
+// matches, otherwise the full object is returned.
+func IfRange(etag string) Option { return client.IfRange(etag) }
+
 // ErrNotModified is returned by Open/Stat when an If-None-Match precondition is
 // satisfied.
 var ErrNotModified = client.ErrNotModified
@@ -49,6 +58,10 @@ var ErrNotModified = client.ErrNotModified
 // ErrPreconditionFailed is returned by Open/Stat when an If-Match precondition
 // is not met.
 var ErrPreconditionFailed = client.ErrPreconditionFailed
+
+// ErrRangeNotSatisfiable is returned by Open when a requested Range lies outside
+// the object.
+var ErrRangeNotSatisfiable = client.ErrRangeNotSatisfiable
 
 // ErrStatsUnavailable is returned when a cache backend cannot provide statistics.
 var ErrStatsUnavailable = client.ErrStatsUnavailable
@@ -166,6 +179,11 @@ type Cache interface {
 	// Conditional opts are evaluated against the stored ETag: a satisfied
 	// If-None-Match returns ErrNotModified (with headers, no body); a failed
 	// If-Match returns ErrPreconditionFailed.
+	//
+	// A Range opt requests a single byte range: on success the returned
+	// headers carry Content-Range and a Content-Length of the range, and the
+	// reader yields only those bytes. A range outside the object returns
+	// ErrRangeNotSatisfiable (with headers carrying Content-Range: bytes */N).
 	Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser, http.Header, error)
 	// Create a new file in the cache.
 	//

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -48,10 +48,6 @@ func IfNoneMatch(etag string) Option { return client.IfNoneMatch(etag) }
 // the object. Stat ignores Range.
 func Range(start, end int64) Option { return client.Range(start, end) }
 
-// RangeHeader sets a raw HTTP Range header value (e.g. "bytes=0-499"), for
-// forwarding a client's Range verbatim; prefer Range for programmatic use.
-func RangeHeader(spec string) Option { return client.RangeHeader(spec) }
-
 // IfRange gates Range on the stored ETag: the range is only applied when etag
 // matches, otherwise the full object is returned.
 func IfRange(etag string) Option { return client.IfRange(etag) }

--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -583,6 +583,18 @@ func testRange(t *testing.T, c cache.Cache) {
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("789"), data)
 		assert.Equal(t, "bytes 7-9/10", headers.Get("Content-Range"))
+		assert.Equal(t, "3", headers.Get("Content-Length"))
+	})
+
+	t.Run("FullSize", func(t *testing.T) {
+		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=0-9"))
+		assert.NoError(t, err)
+		defer reader.Close()
+		data, err := io.ReadAll(reader)
+		assert.NoError(t, err)
+		assert.Equal(t, content, data)
+		assert.Equal(t, "bytes 0-9/10", headers.Get("Content-Range"))
+		assert.Equal(t, "10", headers.Get("Content-Length"))
 	})
 
 	t.Run("NotSatisfiable", func(t *testing.T) {

--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -575,17 +575,6 @@ func testRange(t *testing.T, c cache.Cache) {
 		assert.Equal(t, "4", headers.Get("Content-Length"))
 	})
 
-	t.Run("Suffix", func(t *testing.T) {
-		reader, headers, err := c.Open(ctx, key, cache.RangeHeader("bytes=-3"))
-		assert.NoError(t, err)
-		defer reader.Close()
-		data, err := io.ReadAll(reader)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("789"), data)
-		assert.Equal(t, "bytes 7-9/10", headers.Get("Content-Range"))
-		assert.Equal(t, "3", headers.Get("Content-Length"))
-	})
-
 	t.Run("FullSize", func(t *testing.T) {
 		reader, headers, err := c.Open(ctx, key, cache.Range(0, 10))
 		assert.NoError(t, err)

--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -83,6 +83,10 @@ func Suite(t *testing.T, newCache func(t *testing.T) cache.Cache) {
 	t.Run("Conditional", func(t *testing.T) {
 		testConditional(t, newCache(t))
 	})
+
+	t.Run("Range", func(t *testing.T) {
+		testRange(t, newCache(t))
+	})
 }
 
 func testCreateAndOpen(t *testing.T, c cache.Cache) {
@@ -541,6 +545,67 @@ func testConditional(t *testing.T, c cache.Cache) {
 
 		_, err = c.Stat(ctx, key, cache.IfMatch(`"other"`))
 		assert.IsError(t, err, cache.ErrPreconditionFailed)
+	})
+}
+
+// testRange verifies that Open honours a single byte range, sets Content-Range
+// and a range-sized Content-Length, returns ErrRangeNotSatisfiable for an
+// out-of-bounds range, and that Stat ignores Range.
+func testRange(t *testing.T, c cache.Cache) {
+	defer c.Close()
+	ctx := t.Context()
+
+	content := []byte("0123456789")
+	key := cache.NewKey("test-range")
+
+	w, err := c.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w.Write(content)
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	t.Run("PartialContent", func(t *testing.T) {
+		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=2-5"))
+		assert.NoError(t, err)
+		defer reader.Close()
+		data, err := io.ReadAll(reader)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("2345"), data)
+		assert.Equal(t, "bytes 2-5/10", headers.Get("Content-Range"))
+		assert.Equal(t, "4", headers.Get("Content-Length"))
+	})
+
+	t.Run("Suffix", func(t *testing.T) {
+		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=-3"))
+		assert.NoError(t, err)
+		defer reader.Close()
+		data, err := io.ReadAll(reader)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("789"), data)
+		assert.Equal(t, "bytes 7-9/10", headers.Get("Content-Range"))
+	})
+
+	t.Run("NotSatisfiable", func(t *testing.T) {
+		_, headers, err := c.Open(ctx, key, cache.Range("bytes=20-30"))
+		assert.IsError(t, err, cache.ErrRangeNotSatisfiable)
+		assert.Equal(t, "bytes */10", headers.Get("Content-Range"))
+	})
+
+	t.Run("IfRangeMismatchServesFull", func(t *testing.T) {
+		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=2-5"), cache.IfRange(`"stale"`))
+		assert.NoError(t, err)
+		defer reader.Close()
+		data, err := io.ReadAll(reader)
+		assert.NoError(t, err)
+		assert.Equal(t, content, data)
+		assert.Equal(t, "", headers.Get("Content-Range"))
+	})
+
+	t.Run("StatIgnoresRange", func(t *testing.T) {
+		headers, err := c.Stat(ctx, key, cache.Range("bytes=2-5"))
+		assert.NoError(t, err)
+		assert.Equal(t, "", headers.Get("Content-Range"))
+		assert.Equal(t, "10", headers.Get("Content-Length"))
 	})
 }
 

--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -565,7 +565,7 @@ func testRange(t *testing.T, c cache.Cache) {
 	assert.NoError(t, w.Close())
 
 	t.Run("PartialContent", func(t *testing.T) {
-		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=2-5"))
+		reader, headers, err := c.Open(ctx, key, cache.Range(2, 6))
 		assert.NoError(t, err)
 		defer reader.Close()
 		data, err := io.ReadAll(reader)
@@ -576,7 +576,7 @@ func testRange(t *testing.T, c cache.Cache) {
 	})
 
 	t.Run("Suffix", func(t *testing.T) {
-		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=-3"))
+		reader, headers, err := c.Open(ctx, key, cache.RangeHeader("bytes=-3"))
 		assert.NoError(t, err)
 		defer reader.Close()
 		data, err := io.ReadAll(reader)
@@ -587,7 +587,7 @@ func testRange(t *testing.T, c cache.Cache) {
 	})
 
 	t.Run("FullSize", func(t *testing.T) {
-		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=0-9"))
+		reader, headers, err := c.Open(ctx, key, cache.Range(0, 10))
 		assert.NoError(t, err)
 		defer reader.Close()
 		data, err := io.ReadAll(reader)
@@ -598,13 +598,13 @@ func testRange(t *testing.T, c cache.Cache) {
 	})
 
 	t.Run("NotSatisfiable", func(t *testing.T) {
-		_, headers, err := c.Open(ctx, key, cache.Range("bytes=20-30"))
+		_, headers, err := c.Open(ctx, key, cache.Range(20, 31))
 		assert.IsError(t, err, cache.ErrRangeNotSatisfiable)
 		assert.Equal(t, "bytes */10", headers.Get("Content-Range"))
 	})
 
 	t.Run("IfRangeMismatchServesFull", func(t *testing.T) {
-		reader, headers, err := c.Open(ctx, key, cache.Range("bytes=2-5"), cache.IfRange(`"stale"`))
+		reader, headers, err := c.Open(ctx, key, cache.Range(2, 6), cache.IfRange(`"stale"`))
 		assert.NoError(t, err)
 		defer reader.Close()
 		data, err := io.ReadAll(reader)
@@ -614,7 +614,7 @@ func testRange(t *testing.T, c cache.Cache) {
 	})
 
 	t.Run("StatIgnoresRange", func(t *testing.T) {
-		headers, err := c.Stat(ctx, key, cache.Range("bytes=2-5"))
+		headers, err := c.Stat(ctx, key, cache.Range(2, 6))
 		assert.NoError(t, err)
 		assert.Equal(t, "", headers.Get("Content-Range"))
 		assert.Equal(t, "10", headers.Get("Content-Length"))

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -304,6 +304,17 @@ func (d *Disk) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser
 		return nil, h, errors.Join(condErr, f.Close())
 	}
 
+	start, length, partial, rangeErr := rangeShortCircuit(headers, finfo.Size(), opts)
+	if rangeErr != nil {
+		return nil, headers, errors.Join(rangeErr, f.Close())
+	}
+	if partial {
+		if _, err := f.Seek(start, io.SeekStart); err != nil {
+			return nil, nil, errors.Join(errors.Errorf("failed to seek for range: %w", err), f.Close())
+		}
+		return newLimitedReadCloser(f, length), headers, nil
+	}
+
 	return f, headers, nil
 }
 

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -310,7 +310,7 @@ func (d *Disk) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser
 	}
 	if partial {
 		if _, err := f.Seek(start, io.SeekStart); err != nil {
-			return nil, nil, errors.Join(errors.Errorf("failed to seek for range: %w", err), f.Close())
+			return nil, headers, errors.Join(errors.Errorf("failed to seek for range: %w", err), f.Close())
 		}
 		return newLimitedReadCloser(f, length), headers, nil
 	}

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -107,7 +107,16 @@ func (m *Memory) Open(_ context.Context, key Key, opts ...Option) (io.ReadCloser
 	if h, err := conditionalShortCircuit(headers, opts); err != nil {
 		return nil, h, err
 	}
-	return io.NopCloser(bytes.NewReader(entry.data)), headers, nil
+
+	start, length, partial, rangeErr := rangeShortCircuit(headers, int64(len(entry.data)), opts)
+	if rangeErr != nil {
+		return nil, headers, rangeErr
+	}
+	data := entry.data
+	if partial {
+		data = data[start : start+length]
+	}
+	return io.NopCloser(bytes.NewReader(data)), headers, nil
 }
 
 func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {

--- a/internal/cache/range.go
+++ b/internal/cache/range.go
@@ -1,0 +1,48 @@
+package cache
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/alecthomas/errors"
+
+	"github.com/block/cachew/client"
+)
+
+// rangeShortCircuit resolves Range/If-Range opts against an object of the given
+// size and the stored ETag in headers. On a satisfiable single range it sets
+// Content-Range, rewrites Content-Length to the range length, and returns the
+// [start, start+length) window with ok=true. When no range applies it returns
+// ok=false (serve the full object). An unsatisfiable range sets
+// Content-Range: bytes */size and returns ErrRangeNotSatisfiable.
+func rangeShortCircuit(headers http.Header, size int64, opts []Option) (start, length int64, ok bool, err error) {
+	s, l, outcome := client.NewRequestOptions(opts...).ResolveRange(size, headers.Get(ETagKey))
+	switch outcome {
+	case client.RangePartial:
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", s, s+l-1, size))
+		headers.Set("Content-Length", strconv.FormatInt(l, 10))
+		return s, l, true, nil
+
+	case client.RangeNotSatisfiable:
+		headers.Set("Content-Range", fmt.Sprintf("bytes */%d", size))
+		return 0, 0, false, ErrRangeNotSatisfiable
+
+	case client.RangeFull:
+	}
+	return 0, size, false, nil
+}
+
+// limitedReadCloser serves the first length bytes of a reader while delegating
+// Close to the underlying closer.
+type limitedReadCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func newLimitedReadCloser(rc io.ReadCloser, length int64) io.ReadCloser {
+	return limitedReadCloser{Reader: io.LimitReader(rc, length), closer: rc}
+}
+
+func (l limitedReadCloser) Close() error { return errors.Wrap(l.closer.Close(), "close range reader") }

--- a/internal/cache/range_test.go
+++ b/internal/cache/range_test.go
@@ -1,0 +1,32 @@
+package cache_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/logging"
+)
+
+// TestRangeEmptyObject verifies range handling for a zero-length object, which
+// the in-memory backend (unlike S3) can store. Any range is unsatisfiable and
+// the Content-Range reports the total size.
+func TestRangeEmptyObject(t *testing.T) {
+	_, ctx := logging.Configure(context.Background(), logging.Config{Level: slog.LevelError})
+	c, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	defer c.Close()
+
+	key := cache.NewKey("range-empty")
+	w, err := c.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	_, headers, err := c.Open(ctx, key, cache.Range("bytes=0-0"))
+	assert.IsError(t, err, cache.ErrRangeNotSatisfiable)
+	assert.Equal(t, "bytes */0", headers.Get("Content-Range"))
+}

--- a/internal/cache/range_test.go
+++ b/internal/cache/range_test.go
@@ -26,7 +26,7 @@ func TestRangeEmptyObject(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, w.Close())
 
-	_, headers, err := c.Open(ctx, key, cache.Range("bytes=0-0"))
+	_, headers, err := c.Open(ctx, key, cache.Range(0, 1))
 	assert.IsError(t, err, cache.ErrRangeNotSatisfiable)
 	assert.Equal(t, "bytes */0", headers.Get("Content-Range"))
 }

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -230,6 +230,18 @@ func (s *S3) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser, 
 		return nil, h, err
 	}
 
+	start, length, partial, rangeErr := rangeShortCircuit(headers, objInfo.Size, opts)
+	if rangeErr != nil {
+		return nil, headers, rangeErr
+	}
+	if partial {
+		reader, err := s.rangeGetReader(ctx, s.config.Bucket, objectName, start, length, objInfo.ETag)
+		if err != nil {
+			return nil, nil, err
+		}
+		return reader, headers, nil
+	}
+
 	reader, err := s.parallelGetReader(ctx, s.config.Bucket, objectName, objInfo.Size, objInfo.ETag)
 	if err != nil {
 		return nil, nil, err

--- a/internal/cache/s3_parallel_get.go
+++ b/internal/cache/s3_parallel_get.go
@@ -38,6 +38,23 @@ func (s *S3) parallelGetReader(ctx context.Context, bucket, objectName string, s
 	return &cancelReadCloser{ReadCloser: pr, cancel: cancel}, nil
 }
 
+// rangeGetReader returns an io.ReadCloser for a single byte range of an S3
+// object, pinned to etag so the read sees a consistent object revision.
+func (s *S3) rangeGetReader(ctx context.Context, bucket, objectName string, start, length int64, etag string) (io.ReadCloser, error) {
+	opts := minio.GetObjectOptions{}
+	if err := opts.SetRange(start, start+length-1); err != nil {
+		return nil, errors.Errorf("set range %d-%d: %w", start, start+length-1, err)
+	}
+	if err := opts.SetMatchETag(etag); err != nil {
+		return nil, errors.Errorf("set etag %s: %w", etag, err)
+	}
+	obj, err := s.client.GetObject(ctx, bucket, objectName, opts)
+	if err != nil {
+		return nil, errors.Errorf("failed to get object range: %w", err)
+	}
+	return &s3Reader{obj: obj}, nil
+}
+
 // cancelReadCloser wraps an io.ReadCloser and cancels a context on Close,
 // ensuring background goroutines are cleaned up when the consumer is done.
 type cancelReadCloser struct {

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alecthomas/errors"
 
+	"github.com/block/cachew/client"
 	"github.com/block/cachew/internal/logging"
 )
 
@@ -114,6 +115,9 @@ func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header,
 //
 // If all caches fail, all errors are returned.
 func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser, http.Header, error) {
+	// A Range request yields a partial body, which must never be backfilled
+	// into a lower tier as if it were the whole object.
+	partial := client.NewRequestOptions(opts...).Range != ""
 	errs := make([]error, len(t.caches))
 	for i, c := range t.caches {
 		r, headers, err := c.Open(ctx, key, opts...)
@@ -122,11 +126,12 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 			continue
 		}
 		if err != nil {
-			// Definitive non-miss error (incl. ErrNotModified/ErrPreconditionFailed):
-			// surface headers so callers can build a 304 response. No body to backfill.
+			// Definitive non-miss error (incl. ErrNotModified/ErrPreconditionFailed/
+			// ErrRangeNotSatisfiable): surface headers so callers can build the
+			// conditional response. No body to backfill.
 			return nil, headers, errors.WithStack(err)
 		}
-		if i > 0 {
+		if i > 0 && !partial {
 			r = t.backfillReader(ctx, key, r, headers, t.caches[0])
 		}
 		return r, headers, nil

--- a/internal/httputil/conditional.go
+++ b/internal/httputil/conditional.go
@@ -21,8 +21,10 @@ func ConditionalOptions(r *http.Request) []client.RequestOption {
 	if v := r.Header.Get("If-None-Match"); v != "" {
 		opts = append(opts, client.IfNoneMatch(v))
 	}
+	// Forward the client's Range header verbatim so the cache can honour forms
+	// the typed client.Range API doesn't model (e.g. suffix "bytes=-N").
 	if v := r.Header.Get("Range"); v != "" {
-		opts = append(opts, client.RangeHeader(v))
+		opts = append(opts, func(o *client.RequestOptions) { o.Range = v })
 	}
 	if v := r.Header.Get("If-Range"); v != "" {
 		opts = append(opts, client.IfRange(v))

--- a/internal/httputil/conditional.go
+++ b/internal/httputil/conditional.go
@@ -10,8 +10,9 @@ import (
 	"github.com/block/cachew/client"
 )
 
-// ConditionalOptions extracts conditional-request options from an incoming
-// request, for forwarding to a cache Open or Stat.
+// ConditionalOptions extracts conditional-request and range options from an
+// incoming request, for forwarding to a cache Open or Stat. Range/If-Range are
+// honoured by Open and ignored by Stat.
 func ConditionalOptions(r *http.Request) []client.RequestOption {
 	var opts []client.RequestOption
 	if v := r.Header.Get("If-Match"); v != "" {
@@ -19,6 +20,12 @@ func ConditionalOptions(r *http.Request) []client.RequestOption {
 	}
 	if v := r.Header.Get("If-None-Match"); v != "" {
 		opts = append(opts, client.IfNoneMatch(v))
+	}
+	if v := r.Header.Get("Range"); v != "" {
+		opts = append(opts, client.Range(v))
+	}
+	if v := r.Header.Get("If-Range"); v != "" {
+		opts = append(opts, client.IfRange(v))
 	}
 	return opts
 }
@@ -51,6 +58,11 @@ func ServeCacheHit(w http.ResponseWriter, headers http.Header, body io.ReadClose
 	switch {
 	case openErr == nil:
 		maps.Copy(w.Header(), headers)
+		w.Header().Set("Accept-Ranges", "bytes")
+		// A Content-Range set by the cache signals a satisfied byte range.
+		if headers.Get("Content-Range") != "" {
+			w.WriteHeader(http.StatusPartialContent)
+		}
 		_, copyErr := io.Copy(w, body)
 		return true, errors.Wrap(errors.Join(copyErr, body.Close()), "serve cache hit")
 
@@ -61,6 +73,12 @@ func ServeCacheHit(w http.ResponseWriter, headers http.Header, body io.ReadClose
 
 	case errors.Is(openErr, client.ErrPreconditionFailed):
 		w.WriteHeader(http.StatusPreconditionFailed)
+		return true, nil
+
+	case errors.Is(openErr, client.ErrRangeNotSatisfiable):
+		maps.Copy(w.Header(), headers)
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
 		return true, nil
 
 	default:
@@ -77,6 +95,7 @@ func ServeCacheStat(w http.ResponseWriter, headers http.Header, statErr error) (
 	switch {
 	case statErr == nil:
 		maps.Copy(w.Header(), headers)
+		w.Header().Set("Accept-Ranges", "bytes")
 		w.WriteHeader(http.StatusOK)
 		return true
 

--- a/internal/httputil/conditional.go
+++ b/internal/httputil/conditional.go
@@ -22,7 +22,7 @@ func ConditionalOptions(r *http.Request) []client.RequestOption {
 		opts = append(opts, client.IfNoneMatch(v))
 	}
 	if v := r.Header.Get("Range"); v != "" {
-		opts = append(opts, client.Range(v))
+		opts = append(opts, client.RangeHeader(v))
 	}
 	if v := r.Header.Get("If-Range"); v != "" {
 		opts = append(opts, client.IfRange(v))

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -12,6 +12,9 @@ var TransportHeaders = []string{ //nolint:gochecknoglobals
 	"Time-To-Live",
 	"If-Match",
 	"If-None-Match",
+	"Range",
+	"If-Range",
+	"Content-Range",
 }
 
 // HopByHopHeaders are hop-by-hop headers that should not be forwarded by proxies (RFC 7230).

--- a/internal/strategy/apiv1_test.go
+++ b/internal/strategy/apiv1_test.go
@@ -151,6 +151,109 @@ func TestConditionalGetIfMatch(t *testing.T) {
 	}
 }
 
+func apiPutBody(ctx context.Context, t *testing.T, handler http.Handler, key cache.Key, body string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/test/"+key.String(), strings.NewReader(body))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	req = httptest.NewRequest(http.MethodHead, "/api/v1/object/test/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"))
+	return w.Header().Get("ETag")
+}
+
+func TestRangeGet(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("range-get")
+	apiPutBody(ctx, t, handler, key, "0123456789")
+
+	tests := []struct {
+		name         string
+		rangeHeader  string
+		ifRange      string
+		wantStatus   int
+		wantBody     string
+		wantCotRange string
+	}{
+		{name: "FirstBytes", rangeHeader: "bytes=0-3", wantStatus: http.StatusPartialContent, wantBody: "0123", wantCotRange: "bytes 0-3/10"},
+		{name: "Middle", rangeHeader: "bytes=2-5", wantStatus: http.StatusPartialContent, wantBody: "2345", wantCotRange: "bytes 2-5/10"},
+		{name: "OpenEnded", rangeHeader: "bytes=7-", wantStatus: http.StatusPartialContent, wantBody: "789", wantCotRange: "bytes 7-9/10"},
+		{name: "Suffix", rangeHeader: "bytes=-3", wantStatus: http.StatusPartialContent, wantBody: "789", wantCotRange: "bytes 7-9/10"},
+		{name: "NotSatisfiable", rangeHeader: "bytes=20-30", wantStatus: http.StatusRequestedRangeNotSatisfiable, wantCotRange: "bytes */10"},
+		{name: "MultiRangeFallsBackToFull", rangeHeader: "bytes=0-1,4-5", wantStatus: http.StatusOK, wantBody: "0123456789"},
+		{name: "NoRange", wantStatus: http.StatusOK, wantBody: "0123456789"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/object/test/"+key.String(), nil)
+			req = req.WithContext(ctx)
+			if tt.rangeHeader != "" {
+				req.Header.Set("Range", tt.rangeHeader)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"))
+			assert.Equal(t, tt.wantCotRange, w.Header().Get("Content-Range"))
+			if tt.wantStatus != http.StatusRequestedRangeNotSatisfiable {
+				assert.Equal(t, tt.wantBody, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestRangeGetIfRange(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("range-ifrange")
+	etag := apiPutBody(ctx, t, handler, key, "0123456789")
+
+	tests := []struct {
+		name       string
+		ifRange    string
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "Match", ifRange: etag, wantStatus: http.StatusPartialContent, wantBody: "0123"},
+		{name: "Mismatch", ifRange: `"stale"`, wantStatus: http.StatusOK, wantBody: "0123456789"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/object/test/"+key.String(), nil)
+			req = req.WithContext(ctx)
+			req.Header.Set("Range", "bytes=0-3")
+			req.Header.Set("If-Range", tt.ifRange)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			assert.Equal(t, tt.wantBody, w.Body.String())
+		})
+	}
+}
+
+func TestRangeHeadIgnoresRange(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("range-head")
+	apiPutBody(ctx, t, handler, key, "0123456789")
+
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/object/test/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Range", "bytes=0-3")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"))
+	assert.Equal(t, "", w.Header().Get("Content-Range"))
+}
+
 // failingReader returns data up to failAfter bytes, then returns an error.
 type failingReader struct {
 	data      []byte

--- a/internal/strategy/apiv1_test.go
+++ b/internal/strategy/apiv1_test.go
@@ -238,6 +238,29 @@ func TestRangeGetIfRange(t *testing.T) {
 	}
 }
 
+// TestRangeStoredContentRangeIgnored guards against a client-supplied
+// Content-Range request header being stored and later replayed, which would
+// make a plain GET spuriously answer 206.
+func TestRangeStoredContentRangeIgnored(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("range-stored-cr")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/test/"+key.String(), strings.NewReader("0123456789"))
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Range", "bytes 0-4/10")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/object/test/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "", w.Header().Get("Content-Range"))
+	assert.Equal(t, "0123456789", w.Body.String())
+}
+
 func TestRangeHeadIgnoresRange(t *testing.T) {
 	handler, ctx := testAPISetup(t)
 	key := cache.NewKey("range-head")


### PR DESCRIPTION
## Summary

Adds single byte-range support to `Cache.Open`, mirroring the existing ETag conditional-request pattern end to end (client SDK → cache backends → server serving → remote wire).

- **`client.Range(start, end int64)`** — a typed, half-open `[start, end)` byte range; a negative `end` means "to the end of the object". e.g. `Range(0, 500)` is the first 500 bytes, `Range(0, -1)` the whole object. Out-of-bounds ranges return `ErrRangeNotSatisfiable`.
- **All backends** slice the body efficiently: disk seeks + `io.LimitReader`, memory slices, S3 issues a single ranged GET (pinned to the object ETag), Remote forwards over the wire. `Tiered` skips backfill on partial reads so a truncated object is never cached.
- **Serving** (`httputil`) emits `206 Partial Content` / `416 Range Not Satisfiable`, advertises `Accept-Ranges: bytes`, and forwards an external client's verbatim `Range` header (incl. suffix `bytes=-N`) on the proxy handlers. `Stat`/HEAD ignores Range.
- Request-only headers (`Range`, `If-Range`, `Content-Range`) are stripped on PUT so they can't be stored and replayed.

### Deliberate scope
- Single byte range only; multi-range and syntactically-invalid `Range` headers fall back to a full `200`.
- `If-Range` supports the entity-tag form only (compared against the stored ETag).

## Test plan
- `client`: `Range` formatting, `ResolveRange` parser edge cases, 206/416 wire mapping.
- `cachetest` conformance suite: partial/full/416/If-Range-mismatch/Stat-ignores-Range across **all** backends (disk, memory, S3, tiered, remote).
- `strategy/apiv1`: end-to-end 206/416, suffix range, multi-range fallback, If-Range, HEAD-ignores-Range, and a stored-`Content-Range` regression test.
- Full `go test`, `go vet`, and `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)