### PR TITLE
tracing: log whether OTLP span export is active at startup

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -15,6 +15,8 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/block/cachew/internal/logging"
 )
 
 // Config holds tracing configuration.
@@ -28,9 +30,14 @@ type Config struct {
 // New is a no-op when cfg.Enabled is false or when no exporter
 // destination is configured.
 func New(ctx context.Context, cfg Config) (stop func(), err error) {
+	logger := logging.FromContext(ctx)
+
 	// The OTel SDK reads endpoint/protocol/TLS from OTEL_EXPORTER_OTLP_*
 	// env vars; if no endpoint is set there is nowhere to ship spans.
-	if !cfg.Enabled || os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if !cfg.Enabled || endpoint == "" {
+		logger.InfoContext(ctx, "Tracing disabled: no spans will be exported",
+			"enabled", cfg.Enabled, "otlp_endpoint", endpoint)
 		return func() {}, nil
 	}
 
@@ -49,6 +56,8 @@ func New(ctx context.Context, cfg Config) (stop func(), err error) {
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
+
+	logger.InfoContext(ctx, "Tracing enabled, exporting spans via OTLP", "otlp_endpoint", endpoint)
 
 	return func() {
 		_ = provider.Shutdown(context.Background()) //nolint:errcheck // shutdown errors are not actionable

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -2,14 +2,18 @@ package tracing_test
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 
+	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/tracing"
 )
 
 // New is a no-op when disabled and must return a non-nil stop function.
 func TestNewDisabled(t *testing.T) {
-	stop, err := tracing.New(context.Background(), tracing.Config{Enabled: false})
+	ctx := logging.ContextWithLogger(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	stop, err := tracing.New(ctx, tracing.Config{Enabled: false})
 	if err != nil {
 		t.Fatalf("New(disabled) returned error: %v", err)
 	}


### PR DESCRIPTION
`tracing.New` silently no-ops when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, so a misconfigured or black-holed OTLP endpoint is invisible until you notice the absence of spans in APM. This logs the active endpoint when tracing is enabled, and the reason (enabled flag + endpoint) when it is disabled, so the export state is obvious from cachew's own startup logs.