### PR TITLE
ci: open PR for homebrew formula updates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,6 +61,10 @@ brews:
       owner: block
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
     homepage: "https://github.com/block/cachew"
     description: "Tiered, protocol-aware, caching HTTP proxy for software engineering infrastructure"
     license: "Apache-2.0"


### PR DESCRIPTION
Direct writes to block/homebrew-tap are blocked by branch protection,
so push the formula to a branch and open a PR instead.
