### PR TITLE
ci: push homebrew formula to a PR branch

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,6 +61,9 @@ brews:
       owner: block
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      # Push the formula to a per-release branch and open a PR; the tap's
+      # default branch is protected and rejects direct writes.
+      branch: "cachew-{{ .Version }}"
       pull_request:
         enabled: true
         base:


### PR DESCRIPTION
PR mode requires repository.branch to differ from the base branch;
without it goreleaser committed directly to the protected default
branch and was rejected. Push to a per-release branch instead.
