### PR TITLE
ci: trigger homebrew-tap formula bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - run: goreleaser release --clean --fail-fast
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: homebrew-tap-token
         with:
@@ -21,7 +24,13 @@ jobs:
           private-key: ${{ secrets.BLOCK_HOMEBREW_TAP_PRIVATE_KEY }}
           owner: block
           repositories: homebrew-tap
-      - run: goreleaser release --clean --fail-fast
+      - name: Trigger Homebrew formula bump
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh workflow run bump-formula.yaml \
+            --repo block/homebrew-tap \
+            -f repo=block/cachew \
+            -f formula=cachew \
+            -f "tag=$TAG"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,24 +56,5 @@ changelog:
       - "^docs:"
       - "^test:"
 
-brews:
-  - repository:
-      owner: block
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-      # Push the formula to a per-release branch and open a PR; the tap's
-      # default branch is protected and rejects direct writes.
-      branch: "cachew-{{ .Version }}"
-      pull_request:
-        enabled: true
-        base:
-          branch: main
-    homepage: "https://github.com/block/cachew"
-    description: "Tiered, protocol-aware, caching HTTP proxy for software engineering infrastructure"
-    license: "Apache-2.0"
-    install: |
-      bin.install "cachew"
-      bin.install "cachewd"
-
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
Drop goreleaser's direct Homebrew publishing, which required Contents
and Pull request write access that the tap's GitHub App token does not
grant. Instead, dispatch the tap's bump-formula workflow with the App
token (needs only Actions: write), matching the pattern used by other
block repositories.
