### PR TITLE
refactor(httputil): generalise range support via ServeCacheHit hooks

### DIFF
--- a/internal/httputil/conditional.go
+++ b/internal/httputil/conditional.go
@@ -32,23 +32,6 @@ func ConditionalOptions(r *http.Request) []client.RequestOption {
 	return opts
 }
 
-// RangeOptions extracts only the Range/If-Range options from r, for callers
-// that evaluate If-Match/If-None-Match separately (e.g. via CheckConditionals)
-// and so must not double-handle them by forwarding the full set to Open.
-// If-Range is only meaningful alongside Range, so it is dropped when Range is
-// absent.
-func RangeOptions(r *http.Request) []client.RequestOption {
-	v := r.Header.Get("Range")
-	if v == "" {
-		return nil
-	}
-	opts := []client.RequestOption{func(o *client.RequestOptions) { o.Range = v }}
-	if ir := r.Header.Get("If-Range"); ir != "" {
-		opts = append(opts, client.IfRange(ir))
-	}
-	return opts
-}
-
 // CheckConditionals evaluates RFC 7232 If-Match and If-None-Match precondition
 // headers on r against etag. It returns 0 when all preconditions pass,
 // otherwise the HTTP status the caller should send: 412 Precondition Failed for
@@ -66,42 +49,74 @@ func CheckConditionals(r *http.Request, etag string) int {
 	}
 }
 
+// ServeOption configures ServeCacheHit.
+type ServeOption func(*serveConfig)
+
+type serveConfig struct {
+	decorate func(http.ResponseWriter, http.Header)
+}
+
+// WithResponseDecorator registers fn to run after the stored headers have been
+// copied to the response but before the status line is written, on the 200, 206
+// and 416 paths. It lets endpoints that delegate range/conditional resolution to
+// the cache still override or augment the response (e.g. force a Content-Type or
+// advertise endpoint-specific metadata) uniformly across full and partial
+// responses. fn is given the stored headers (so it can branch on, say, a
+// Content-Range) and must not write the body or call WriteHeader.
+func WithResponseDecorator(fn func(w http.ResponseWriter, stored http.Header)) ServeOption {
+	return func(c *serveConfig) { c.decorate = fn }
+}
+
 // ServeCacheHit writes the outcome of a cache Open to w. headers and body are
 // the Open return values and openErr its error. It handles the success and
 // conditional cases: a nil error streams the body (always closing it), a
 // satisfied If-None-Match (ErrNotModified) writes 304 with the stored headers,
 // and a failed If-Match (ErrPreconditionFailed) writes 412. It returns
 // handled=false for any other error (e.g. os.ErrNotExist) so the caller can map
-// it to its own status.
-func ServeCacheHit(w http.ResponseWriter, headers http.Header, body io.ReadCloser, openErr error) (handled bool, err error) {
+// it to its own status, and n is the number of body bytes written (0 for
+// bodiless responses).
+func ServeCacheHit(w http.ResponseWriter, headers http.Header, body io.ReadCloser, openErr error, opts ...ServeOption) (handled bool, n int64, err error) {
+	var cfg serveConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	decorate := func() {
+		if cfg.decorate != nil {
+			cfg.decorate(w, headers)
+		}
+	}
+
 	switch {
 	case openErr == nil:
 		maps.Copy(w.Header(), headers)
 		w.Header().Set("Accept-Ranges", "bytes")
+		decorate()
 		// A Content-Range set by the cache signals a satisfied byte range.
 		if headers.Get("Content-Range") != "" {
 			w.WriteHeader(http.StatusPartialContent)
 		}
-		_, copyErr := io.Copy(w, body)
-		return true, errors.Wrap(errors.Join(copyErr, body.Close()), "serve cache hit")
+		var copyErr error
+		n, copyErr = io.Copy(w, body)
+		return true, n, errors.Wrap(errors.Join(copyErr, body.Close()), "serve cache hit")
 
 	case errors.Is(openErr, client.ErrNotModified):
 		maps.Copy(w.Header(), headers)
 		w.WriteHeader(http.StatusNotModified)
-		return true, nil
+		return true, 0, nil
 
 	case errors.Is(openErr, client.ErrPreconditionFailed):
 		w.WriteHeader(http.StatusPreconditionFailed)
-		return true, nil
+		return true, 0, nil
 
 	case errors.Is(openErr, client.ErrRangeNotSatisfiable):
 		maps.Copy(w.Header(), headers)
 		w.Header().Set("Accept-Ranges", "bytes")
+		decorate()
 		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-		return true, nil
+		return true, 0, nil
 
 	default:
-		return false, nil
+		return false, 0, nil
 	}
 }
 

--- a/internal/httputil/conditional_test.go
+++ b/internal/httputil/conditional_test.go
@@ -83,14 +83,16 @@ func TestServeCacheHit(t *testing.T) {
 		headers := cacheHeaders([2]string{"Content-Type", "text/plain"})
 		w := httptest.NewRecorder()
 
-		handled, err := httputil.ServeCacheHit(w, headers, body, nil)
+		handled, n, err := httputil.ServeCacheHit(w, headers, body, nil)
 		assert.True(t, handled)
+		assert.Equal(t, int64(len("payload")), n)
 		assert.NoError(t, err)
 		assert.True(t, body.closed)
 
 		resp := w.Result()
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "bytes", resp.Header.Get("Accept-Ranges"))
 		assert.Equal(t, testETag, resp.Header.Get("ETag"))
 		assert.Equal(t, "text/plain", resp.Header.Get("Content-Type"))
 		data, _ := io.ReadAll(resp.Body)
@@ -101,8 +103,9 @@ func TestServeCacheHit(t *testing.T) {
 		headers := cacheHeaders()
 		w := httptest.NewRecorder()
 
-		handled, err := httputil.ServeCacheHit(w, headers, nil, client.ErrNotModified)
+		handled, n, err := httputil.ServeCacheHit(w, headers, nil, client.ErrNotModified)
 		assert.True(t, handled)
+		assert.Equal(t, int64(0), n)
 		assert.NoError(t, err)
 
 		resp := w.Result()
@@ -116,8 +119,9 @@ func TestServeCacheHit(t *testing.T) {
 	t.Run("PreconditionFailed", func(t *testing.T) {
 		w := httptest.NewRecorder()
 
-		handled, err := httputil.ServeCacheHit(w, nil, nil, client.ErrPreconditionFailed)
+		handled, n, err := httputil.ServeCacheHit(w, nil, nil, client.ErrPreconditionFailed)
 		assert.True(t, handled)
+		assert.Equal(t, int64(0), n)
 		assert.NoError(t, err)
 
 		resp := w.Result()
@@ -125,11 +129,86 @@ func TestServeCacheHit(t *testing.T) {
 		assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
 	})
 
+	t.Run("PartialContentWhenRanged", func(t *testing.T) {
+		body := &trackingReader{Reader: strings.NewReader("2345")}
+		headers := cacheHeaders([2]string{"Content-Range", "bytes 2-5/10"})
+		w := httptest.NewRecorder()
+
+		handled, n, err := httputil.ServeCacheHit(w, headers, body, nil)
+		assert.True(t, handled)
+		assert.Equal(t, int64(4), n)
+		assert.NoError(t, err)
+		assert.True(t, body.closed)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusPartialContent, resp.StatusCode)
+		assert.Equal(t, "bytes 2-5/10", resp.Header.Get("Content-Range"))
+		assert.Equal(t, "bytes", resp.Header.Get("Accept-Ranges"))
+	})
+
+	t.Run("RangeNotSatisfiable", func(t *testing.T) {
+		headers := cacheHeaders([2]string{"Content-Range", "bytes */10"})
+		w := httptest.NewRecorder()
+
+		handled, n, err := httputil.ServeCacheHit(w, headers, nil, client.ErrRangeNotSatisfiable)
+		assert.True(t, handled)
+		assert.Equal(t, int64(0), n)
+		assert.NoError(t, err)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, resp.StatusCode)
+		assert.Equal(t, "bytes */10", resp.Header.Get("Content-Range"))
+		assert.Equal(t, "bytes", resp.Header.Get("Accept-Ranges"))
+	})
+
+	t.Run("DecoratorRunsOnFullPartialAndUnsatisfiable", func(t *testing.T) {
+		// The decorator must run before the status is written on the 200, 206 and
+		// 416 paths, but not on the bodiless 304/412 paths.
+		cases := []struct {
+			name       string
+			headers    http.Header
+			body       io.ReadCloser
+			openErr    error
+			wantRun    bool
+			wantStatus int
+		}{
+			{name: "Full", headers: cacheHeaders(), body: &trackingReader{Reader: strings.NewReader("x")}, wantRun: true, wantStatus: http.StatusOK},
+			{name: "Partial", headers: cacheHeaders([2]string{"Content-Range", "bytes 0-0/2"}), body: &trackingReader{Reader: strings.NewReader("x")}, wantRun: true, wantStatus: http.StatusPartialContent},
+			{name: "Unsatisfiable", headers: cacheHeaders([2]string{"Content-Range", "bytes */2"}), openErr: client.ErrRangeNotSatisfiable, wantRun: true, wantStatus: http.StatusRequestedRangeNotSatisfiable},
+			{name: "NotModified", headers: cacheHeaders(), openErr: client.ErrNotModified, wantRun: false, wantStatus: http.StatusNotModified},
+			{name: "PreconditionFailed", openErr: client.ErrPreconditionFailed, wantRun: false, wantStatus: http.StatusPreconditionFailed},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				w := httptest.NewRecorder()
+				var ran bool
+				decorate := func(rw http.ResponseWriter, _ http.Header) {
+					ran = true
+					rw.Header().Set("X-Decorated", "yes")
+				}
+				handled, _, err := httputil.ServeCacheHit(w, tc.headers, tc.body, tc.openErr, httputil.WithResponseDecorator(decorate))
+				assert.True(t, handled)
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantRun, ran)
+
+				resp := w.Result()
+				defer resp.Body.Close()
+				assert.Equal(t, tc.wantStatus, resp.StatusCode)
+				if tc.wantRun {
+					assert.Equal(t, "yes", resp.Header.Get("X-Decorated"))
+				}
+			})
+		}
+	})
+
 	t.Run("NotHandledForOtherError", func(t *testing.T) {
 		w := httptest.NewRecorder()
 
-		handled, err := httputil.ServeCacheHit(w, nil, nil, os.ErrNotExist)
+		handled, n, err := httputil.ServeCacheHit(w, nil, nil, os.ErrNotExist)
 		assert.False(t, handled)
+		assert.Equal(t, int64(0), n)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode) // response untouched
 	})

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -82,7 +82,7 @@ func (d *APIV1) getObject(w http.ResponseWriter, r *http.Request) {
 
 	namespacedCache := d.cache.Namespace(namespace)
 	cr, headers, err := namespacedCache.Open(r.Context(), key, httputil.ConditionalOptions(r)...)
-	if handled, serveErr := httputil.ServeCacheHit(w, headers, cr, err); handled {
+	if handled, _, serveErr := httputil.ServeCacheHit(w, headers, cr, err); handled {
 		if serveErr != nil {
 			d.logger.Error("Failed to serve cache object", "error", serveErr, "key", key)
 		}

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -320,44 +320,30 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 	}
 	s.maybeBackgroundFetch(repo)
 
-	// Forward only Range/If-Range here; If-Match/If-None-Match are evaluated
-	// against the served body below via CheckConditionals.
-	reader, headers, err := s.cache.Open(ctx, cacheKey, httputil.RangeOptions(r)...)
-	if errors.Is(err, cache.ErrRangeNotSatisfiable) {
-		// A failed If-Match (412) or satisfied If-None-Match (304) takes
-		// precedence over an unsatisfiable range (RFC 7232 §3, RFC 7233 §3.1).
-		if status := httputil.CheckConditionals(r, headers.Get(cache.ETagKey)); status != 0 {
-			w.WriteHeader(status)
-			return
+	// Forward the full conditional/range set: the cache resolves If-Match /
+	// If-None-Match before Range, so 304/412 already take precedence over a
+	// satisfied range or a 416 (RFC 7232 §3, RFC 7233 §3.1), and ServeCacheHit
+	// maps each outcome to its status.
+	reader, headers, err := s.cache.Open(ctx, cacheKey, httputil.ConditionalOptions(r)...)
+	switch {
+	case err == nil,
+		errors.Is(err, cache.ErrNotModified),
+		errors.Is(err, cache.ErrPreconditionFailed),
+		errors.Is(err, cache.ErrRangeNotSatisfiable):
+		if serveErr := s.serveSnapshotWithBundle(ctx, w, r, reader, headers, err, repo, upstreamURL, repoName, start); serveErr != nil {
+			logger.ErrorContext(ctx, "Failed to serve snapshot", "upstream", upstreamURL, "error", serveErr)
+			span.RecordError(serveErr)
+			span.SetStatus(codes.Error, serveErr.Error())
 		}
-		w.Header().Set("Content-Type", "application/zstd")
-		w.Header().Set("Accept-Ranges", "bytes")
-		if cr := headers.Get("Content-Range"); cr != "" {
-			w.Header().Set("Content-Range", cr)
+	case errors.Is(err, os.ErrNotExist):
+		if spoolErr := s.serveSnapshotWithSpool(w, r, repo, upstreamURL, repoName, start); spoolErr != nil {
+			logger.ErrorContext(ctx, "Failed to serve snapshot via spool", "upstream", upstreamURL, "error", spoolErr)
+			span.RecordError(spoolErr)
+			span.SetStatus(codes.Error, spoolErr.Error())
 		}
-		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-		return
-	}
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	default:
 		logger.ErrorContext(ctx, "Failed to open snapshot from cache", "upstream", upstreamURL, "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	if reader == nil {
-		if err := s.serveSnapshotWithSpool(w, r, repo, upstreamURL, repoName, start); err != nil {
-			logger.ErrorContext(ctx, "Failed to serve snapshot via spool", "upstream", upstreamURL, "error", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		}
-		return
-	}
-	defer reader.Close()
-
-	if err := s.serveSnapshotWithBundle(ctx, w, r, reader, headers, repo, upstreamURL, repoName, start); err != nil {
-		logger.ErrorContext(ctx, "Failed to serve snapshot", "upstream", upstreamURL, "error", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 	}
 }
 
@@ -460,16 +446,24 @@ func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, h
 		s.metrics.recordBundleServe(ctx, source, repoName, bytes, time.Since(start))
 	}()
 
-	// Try serving from cache first — works on any pod.
-	if reader, _, err := s.cache.Open(ctx, bKey); err == nil && reader != nil {
-		defer reader.Close()
-		w.Header().Set("Content-Type", "application/x-git-bundle")
-		n, err := io.Copy(w, reader)
+	// Try serving from cache first — works on any pod. Forwarding the
+	// conditional/range set lets clients revalidate and fetch large bundles with
+	// bounded parallel range requests, just like snapshots.
+	reader, headers, openErr := s.cache.Open(ctx, bKey, httputil.ConditionalOptions(r)...)
+	switch {
+	case openErr == nil,
+		errors.Is(openErr, cache.ErrNotModified),
+		errors.Is(openErr, cache.ErrPreconditionFailed),
+		errors.Is(openErr, cache.ErrRangeNotSatisfiable):
+		decorate := func(rw http.ResponseWriter, _ http.Header) {
+			rw.Header().Set("Content-Type", "application/x-git-bundle")
+		}
+		_, n, serveErr := httputil.ServeCacheHit(w, headers, reader, openErr, httputil.WithResponseDecorator(decorate))
 		bytes = n
 		source = "cache"
-		if err != nil {
-			logger.WarnContext(ctx, "Failed to stream cached bundle", "upstream", upstreamURL, "error", err)
-			span.RecordError(err)
+		if serveErr != nil {
+			logger.WarnContext(ctx, "Failed to stream cached bundle", "upstream", upstreamURL, "error", serveErr)
+			span.RecordError(serveErr)
 		}
 		return
 	}
@@ -533,83 +527,74 @@ func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, h
 	}
 }
 
-func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseWriter, r *http.Request, reader io.ReadCloser, headers http.Header, repo *gitclone.Repository, upstreamURL, repoName string, start time.Time) error {
-	// If-Match/If-None-Match are evaluated before serving any body: a satisfied
-	// If-None-Match (304) or a failed If-Match (412) takes precedence over a
-	// range response, so revalidating clients are not handed a 206 they would
-	// have to discard (RFC 7232 §3, RFC 7233 §3.1).
-	if status := httputil.CheckConditionals(r, headers.Get(cache.ETagKey)); status != 0 {
-		w.WriteHeader(status)
-		s.metrics.recordSnapshotServe(ctx, "cache", repoName, 0, time.Since(start))
-		if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
-			span.SetAttributes(attribute.String("cachew.source", "cache"), attribute.Int64("cachew.bytes", 0))
+func (s *Strategy) serveSnapshotWithBundle(ctx context.Context, w http.ResponseWriter, _ *http.Request, reader io.ReadCloser, headers http.Header, openErr error, repo *gitclone.Repository, upstreamURL, repoName string, start time.Time) error {
+	// The snapshot commit is stored alongside the object and surfaces via the
+	// copied headers; only the delta-bundle URL is computed per request. Both are
+	// advertised on full (200) and ranged (206) responses so a client.ParallelGet
+	// learns from its discovery chunk whether to apply a bundle after downloading.
+	var snapshotCommit, bundleURL string
+	if openErr == nil {
+		snapshotCommit, bundleURL = s.snapshotMetadata(ctx, headers, repo, upstreamURL)
+	}
+
+	decorate := func(rw http.ResponseWriter, _ http.Header) {
+		// Content-Type is fixed for snapshots regardless of what the backend recorded.
+		rw.Header().Set("Content-Type", "application/zstd")
+		if bundleURL != "" {
+			rw.Header().Set("X-Cachew-Bundle-Url", bundleURL)
 		}
-		return nil
 	}
 
-	// A satisfied byte range is served as-is. Bundle negotiation applies only to
-	// whole-snapshot downloads, so a partial read (e.g. a client.ParallelGet
-	// chunk) skips it and returns 206 directly.
-	if cr := headers.Get("Content-Range"); cr != "" {
-		applySnapshotCacheHeaders(w, headers)
-		w.Header().Set("Accept-Ranges", "bytes")
-		w.Header().Set("Content-Range", cr)
-		// Ranged clients (client.ParallelGet) read the freshen metadata from the
-		// discovery chunk, so it must be present on partial responses too.
-		s.setSnapshotMetadataHeaders(ctx, w, headers, repo, upstreamURL)
-		w.WriteHeader(http.StatusPartialContent)
-		n, err := io.Copy(w, reader)
-		s.metrics.recordSnapshotServe(ctx, "cache_range", repoName, n, time.Since(start))
-		if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
-			span.SetAttributes(attribute.String("cachew.source", "cache_range"), attribute.Int64("cachew.bytes", n))
-		}
-		return errors.Wrap(err, "stream snapshot range")
+	// Bundle negotiation applies only to whole-snapshot downloads: a ranged chunk
+	// (Content-Range present) skips it and is served as-is.
+	if openErr == nil && bundleURL != "" && headers.Get("Content-Range") == "" {
+		s.pregenerateBundle(ctx, repo, upstreamURL, snapshotCommit)
 	}
 
-	snapshotCommit, bundleURL := s.setSnapshotMetadataHeaders(ctx, w, headers, repo, upstreamURL)
-
-	// Proactively generate and cache the advertised bundle so any pod can serve it.
-	if bundleURL != "" {
-		go func() {
-			bgCtx := context.WithoutCancel(ctx)
-			logger := logging.FromContext(bgCtx)
-			bundleFile, err := s.createBundle(bgCtx, repo, snapshotCommit)
-			if err != nil {
-				logger.WarnContext(bgCtx, "Failed to pre-generate bundle", "upstream", upstreamURL, "error", err)
-				return
-			}
-			defer bundleFile.Close()
-			if err := s.cacheBundle(bgCtx, bundleCacheKey(upstreamURL, snapshotCommit), bundleFile); err != nil {
-				logger.WarnContext(bgCtx, "Failed to cache bundle", "upstream", upstreamURL, "error", err)
-			}
-		}()
+	handled, n, err := httputil.ServeCacheHit(w, headers, reader, openErr, httputil.WithResponseDecorator(decorate))
+	if !handled {
+		return errors.Wrap(openErr, "serve snapshot")
 	}
 
-	applySnapshotCacheHeaders(w, headers)
-	w.Header().Set("Accept-Ranges", "bytes")
-
-	n, err := serveReaderFast(w, r, reader)
-	s.metrics.recordSnapshotServe(ctx, "cache", repoName, n, time.Since(start))
+	source := "cache"
+	if headers.Get("Content-Range") != "" {
+		source = "cache_range"
+	}
+	s.metrics.recordSnapshotServe(ctx, source, repoName, n, time.Since(start))
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
-		span.SetAttributes(attribute.String("cachew.source", "cache"), attribute.Int64("cachew.bytes", n))
+		span.SetAttributes(attribute.String("cachew.source", source), attribute.Int64("cachew.bytes", n))
 	}
-	return errors.Wrap(err, "stream snapshot")
+	return errors.Wrap(err, "serve snapshot")
 }
 
-// setSnapshotMetadataHeaders advertises the snapshot's commit and, when the
-// snapshot trails the mirror's HEAD, the delta-bundle URL clients use to
-// fast-forward. Shared by the full and ranged serve paths so ranged clients
-// (client.ParallelGet) receive the same freshen metadata on the discovery
-// chunk. It returns the snapshot commit and the bundle URL it set (empty when
-// the snapshot is already at HEAD), so callers can decide whether to
-// pre-generate the bundle.
-func (s *Strategy) setSnapshotMetadataHeaders(ctx context.Context, w http.ResponseWriter, headers http.Header, repo *gitclone.Repository, upstreamURL string) (snapshotCommit, bundleURL string) {
+// pregenerateBundle builds and caches the delta bundle for snapshotCommit in the
+// background so any pod can later serve it without regenerating.
+func (s *Strategy) pregenerateBundle(ctx context.Context, repo *gitclone.Repository, upstreamURL, snapshotCommit string) {
+	go func() {
+		bgCtx := context.WithoutCancel(ctx)
+		logger := logging.FromContext(bgCtx)
+		bundleFile, err := s.createBundle(bgCtx, repo, snapshotCommit)
+		if err != nil {
+			logger.WarnContext(bgCtx, "Failed to pre-generate bundle", "upstream", upstreamURL, "error", err)
+			return
+		}
+		defer bundleFile.Close()
+		if err := s.cacheBundle(bgCtx, bundleCacheKey(upstreamURL, snapshotCommit), bundleFile); err != nil {
+			logger.WarnContext(bgCtx, "Failed to cache bundle", "upstream", upstreamURL, "error", err)
+		}
+	}()
+}
+
+// snapshotMetadata reports the snapshot's commit and, when the snapshot trails
+// the mirror's HEAD, the delta-bundle URL clients use to fast-forward (empty
+// when the snapshot is already at HEAD). It performs no response mutation so the
+// full and ranged serve paths can advertise the same freshen metadata via a
+// shared response decorator.
+func (s *Strategy) snapshotMetadata(ctx context.Context, headers http.Header, repo *gitclone.Repository, upstreamURL string) (snapshotCommit, bundleURL string) {
 	snapshotCommit = headers.Get("X-Cachew-Snapshot-Commit")
 	if snapshotCommit == "" {
 		return "", ""
 	}
-	w.Header().Set("X-Cachew-Snapshot-Commit", snapshotCommit)
-
 	mirrorHead := s.getMirrorHead(ctx, repo)
 	if mirrorHead == "" || snapshotCommit == mirrorHead {
 		return snapshotCommit, ""
@@ -618,9 +603,7 @@ func (s *Strategy) setSnapshotMetadataHeaders(ctx context.Context, w http.Respon
 	if err != nil {
 		return snapshotCommit, ""
 	}
-	bundleURL = fmt.Sprintf("/git/%s/snapshot.bundle?base=%s", repoPath, snapshotCommit)
-	w.Header().Set("X-Cachew-Bundle-Url", bundleURL)
-	return snapshotCommit, bundleURL
+	return snapshotCommit, fmt.Sprintf("/git/%s/snapshot.bundle?base=%s", repoPath, snapshotCommit)
 }
 
 // applySnapshotCacheHeaders forwards the cached snapshot's validators so clients

--- a/internal/strategy/handler/handler.go
+++ b/internal/strategy/handler/handler.go
@@ -162,7 +162,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) serveCached(w http.ResponseWriter, r *http.Request, key cache.Key) (bool, error) {
 	cr, headers, err := h.cache.Open(r.Context(), key, httputil.ConditionalOptions(r)...)
-	if handled, serveErr := httputil.ServeCacheHit(w, headers, cr, err); handled {
+	if handled, _, serveErr := httputil.ServeCacheHit(w, headers, cr, err); handled {
 		logging.FromContext(r.Context()).DebugContext(r.Context(), "Cache hit")
 		return true, errors.WithStack(serveErr)
 	}


### PR DESCRIPTION
Add a WithResponseDecorator option and a bytes-served return to
ServeCacheHit so endpoints needing custom headers or negotiation can
reuse the shared range/conditional machinery instead of reimplementing
206/416/304/412 handling.

Refactor the git snapshot and bundle serve paths onto it: both now
forward ConditionalOptions to Open and serve via ServeCacheHit,
deleting the bespoke range/conditional code and giving bundles range
support. Snapshot freshen metadata is injected through the decorator on
both full and ranged responses.

Drop the now-unused RangeOptions helper.
