### PR TITLE
feat(client): parallel git snapshot download with bounded in-memory streaming

### DIFF
--- a/client/git.go
+++ b/client/git.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -184,42 +185,88 @@ func (c *Client) openGitArtifact(ctx context.Context, repoURL, suffix string) (*
 	}, nil
 }
 
-// GitSnapshotMetadata carries the freshen metadata returned alongside a
-// parallel snapshot download. Commit is the mirror's HEAD SHA at snapshot time
-// (empty for cold serves); BundleURL, when non-empty, points at a delta bundle
-// that brings the snapshot up to the mirror's current HEAD.
-type GitSnapshotMetadata struct {
-	Commit    string
-	BundleURL string
-}
-
-// DownloadGitSnapshot fetches the working-tree snapshot for repoURL into dst,
-// using up to concurrency concurrent range requests of chunkSize bytes each.
-// When concurrency is 1, or the server does not support ranges, it transparently
-// falls back to a single full download. dst is written at non-overlapping
-// offsets via WriteAt (e.g. an *os.File) and the caller owns its lifecycle. It
-// returns the snapshot's freshen metadata, read from the discovery response.
-// Returns os.ErrNotExist when the server has no snapshot available.
-func (c *Client) DownloadGitSnapshot(ctx context.Context, repoURL string, dst io.WriterAt, chunkSize int64, concurrency int) (GitSnapshotMetadata, error) {
+// OpenGitSnapshotParallel downloads the working-tree snapshot for repoURL with
+// up to concurrency concurrent range requests of chunkSize bytes each. It
+// returns as soon as the freshen metadata (Commit, BundleURL) is available,
+// with the download continuing in the background as the caller reads Body, so
+// extraction overlaps the transfer.
+//
+// The caller must Close the returned GitSnapshot, which cancels any in-flight
+// download. A concurrency of 1 streams a single plain request with no
+// buffering; a server without range support falls back to a single full
+// download. Returns os.ErrNotExist when the server has no snapshot.
+func (c *Client) OpenGitSnapshotParallel(ctx context.Context, repoURL string, chunkSize int64, concurrency int) (*GitSnapshot, error) {
+	if concurrency <= 1 {
+		return c.OpenGitSnapshot(ctx, repoURL)
+	}
+	if err := validateParallelParams(chunkSize, concurrency); err != nil {
+		return nil, err
+	}
 	endpoint, err := gitEndpointURL(c.baseURL, repoURL, "snapshot.tar.zst")
 	if err != nil {
-		return GitSnapshotMetadata{}, err
+		return nil, err
 	}
-	reader := &gitArtifactRangeReader{client: c, endpoint: endpoint}
-	if err := ParallelGet(ctx, reader, NewKey(repoURL), dst, chunkSize, concurrency); err != nil {
-		return GitSnapshotMetadata{}, errors.Wrap(err, "download snapshot")
+	reader := &gitArtifactRangeReader{client: c, endpoint: endpoint, discovered: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	buf := newStreamBuffer(chunkSize, concurrency)
+	done := make(chan error, 1)
+	go func() {
+		err := ParallelGet(ctx, reader, NewKey(repoURL), buf, chunkSize, concurrency)
+		buf.closeWrite(err)
+		done <- errors.Wrap(err, "download snapshot")
+	}()
+
+	// A small object can finish before discovered is observed, leaving both
+	// channels ready and select picking at random; treat done as "no snapshot"
+	// only when discovery never happened, otherwise let Body drain the buffered
+	// bytes or surface the download error.
+	select {
+	case <-reader.discovered:
+	case err := <-done:
+		if !reader.didDiscover() {
+			cancel()
+			_ = buf.Close() //nolint:errcheck
+			if err == nil {
+				return nil, errors.WithStack(os.ErrNotExist)
+			}
+			return nil, err
+		}
 	}
-	return reader.metadata(), nil
+	headers := reader.discoveryHeaders()
+	return &GitSnapshot{
+		Body:      &cancelReadCloser{ReadCloser: buf, cancel: cancel},
+		Headers:   headers,
+		Commit:    headers.Get(SnapshotCommitHeader),
+		BundleURL: headers.Get(BundleURLHeader),
+	}, nil
+}
+
+// cancelReadCloser cancels the supplied context when Closed, in addition to
+// closing the wrapped reader, so closing a streaming download stops its
+// background goroutine promptly.
+type cancelReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelReadCloser) Close() error {
+	c.cancel()
+	return errors.WithStack(c.ReadCloser.Close())
 }
 
 // gitArtifactRangeReader adapts a git artifact endpoint to the RangeReader
-// interface so ParallelGet can fetch it with concurrent range requests. The
-// object's identity is the endpoint URL, so the Key argument is ignored. It
-// records the first response's headers, which carry the snapshot's freshen
-// metadata (delivered on the discovery chunk) that ParallelGet does not surface.
+// interface. The object's identity is the endpoint URL, so the Key argument is
+// ignored. ParallelGet reports the accepted discovery response's headers via
+// observeDiscovery, which carry the snapshot's freshen metadata it does not
+// surface itself.
 type gitArtifactRangeReader struct {
 	client   *Client
 	endpoint string
+
+	// discovered is closed once the discovery response's headers are recorded.
+	discovered chan struct{}
 
 	mu        sync.Mutex
 	discovery http.Header
@@ -238,14 +285,12 @@ func (g *gitArtifactRangeReader) Open(ctx context.Context, _ Key, opts ...Reques
 	}
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusPartialContent:
-		g.recordDiscovery(resp.Header)
 		return resp.Body, resp.Header, nil
 	case http.StatusNotFound:
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
 		return nil, nil, errors.Join(os.ErrNotExist, resp.Body.Close())
 	case http.StatusRequestedRangeNotSatisfiable:
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
-		g.recordDiscovery(resp.Header)
 		return nil, resp.Header, errors.Join(ErrRangeNotSatisfiable, resp.Body.Close())
 	default:
 		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
@@ -253,23 +298,39 @@ func (g *gitArtifactRangeReader) Open(ctx context.Context, _ Key, opts ...Reques
 	}
 }
 
-// recordDiscovery stores the first response's headers so the freshen metadata
-// they carry survives after the bodies are consumed.
-func (g *gitArtifactRangeReader) recordDiscovery(h http.Header) {
+// didDiscover reports whether the first response's headers have been recorded.
+func (g *gitArtifactRangeReader) didDiscover() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.discovery != nil
+}
+
+// observeDiscovery stores the accepted discovery response's headers so the
+// freshen metadata they carry survives after the bodies are consumed. Only the
+// first observation is kept: a later etag-less fallback read must not clobber
+// the headers a caller may already hold.
+func (g *gitArtifactRangeReader) observeDiscovery(h http.Header) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.discovery == nil {
 		g.discovery = h.Clone()
+		close(g.discovered)
 	}
 }
 
-func (g *gitArtifactRangeReader) metadata() GitSnapshotMetadata {
+// discoveryHeaders returns the first response's headers with transport-layer
+// headers stripped. The discovery response is a 206 for only the first chunk,
+// so Content-Range/Content-Length are rewritten to describe the full
+// reassembled object streamed on GitSnapshot.Body.
+func (g *gitArtifactRangeReader) discoveryHeaders() http.Header {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return GitSnapshotMetadata{
-		Commit:    g.discovery.Get(SnapshotCommitHeader),
-		BundleURL: g.discovery.Get(BundleURLHeader),
+	headers := filterHeaders(g.discovery, transportHeaders...)
+	if total, ok := parseContentRangeTotal(headers.Get("Content-Range")); ok {
+		headers.Del("Content-Range")
+		headers.Set("Content-Length", strconv.FormatInt(total, 10))
 	}
+	return headers
 }
 
 // gitEndpointURL builds a /git/{host}/{repoPath}/{suffix} URL from a cachew

--- a/client/git_test.go
+++ b/client/git_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -148,7 +149,6 @@ func TestOpenGitBundle(t *testing.T) {
 
 	api := client.NewWithHTTPClient(srv.URL, srv.Client())
 
-	// Root-relative URL (as returned in X-Cachew-Bundle-Url).
 	body, err := api.OpenGitBundle(context.Background(),
 		"/git/github.com/org/repo/snapshot.bundle?base=abc")
 	assert.NoError(t, err)
@@ -157,7 +157,6 @@ func TestOpenGitBundle(t *testing.T) {
 	assert.NoError(t, body.Close())
 	assert.Equal(t, "bundle-bytes", string(data))
 
-	// Absolute URL.
 	body, err = api.OpenGitBundle(context.Background(),
 		srv.URL+"/git/github.com/org/repo/snapshot.bundle?base=abc")
 	assert.NoError(t, err)
@@ -175,7 +174,7 @@ func TestOpenGitBundleNotFound(t *testing.T) {
 	assert.True(t, errors.Is(err, os.ErrNotExist))
 }
 
-func TestDownloadGitSnapshotParallel(t *testing.T) {
+func TestOpenGitSnapshotParallel(t *testing.T) {
 	body := make([]byte, 1000)
 	for i := range body {
 		body[i] = byte(i % 251)
@@ -190,29 +189,53 @@ func TestDownloadGitSnapshotParallel(t *testing.T) {
 		w.Header().Set("ETag", etag)
 		w.Header().Set(client.SnapshotCommitHeader, "deadbeef")
 		w.Header().Set(client.BundleURLHeader, "/git/github.com/org/repo/snapshot.bundle?base=deadbeef")
-		// ServeContent honours Range/If-Range against the ETag set above, so it
-		// returns 206 + Content-Range for the chunked requests ParallelGet makes.
 		http.ServeContent(w, r, "snapshot.tar.zst", time.Time{}, bytes.NewReader(body))
 	}))
 	defer srv.Close()
 
 	api := client.NewWithHTTPClient(srv.URL, srv.Client())
-	var dst bufferAt
-	// A 128-byte chunk over a 1000-byte body forces multiple chunks, exercising
-	// concurrent range reassembly.
-	meta, err := api.DownloadGitSnapshot(context.Background(), "https://github.com/org/repo", &dst, 128, 4)
+	snap, err := api.OpenGitSnapshotParallel(context.Background(), "https://github.com/org/repo", 128, 4)
 	assert.NoError(t, err)
-	assert.Equal(t, body, dst.buf)
-	assert.Equal(t, "deadbeef", meta.Commit)
-	assert.Equal(t, "/git/github.com/org/repo/snapshot.bundle?base=deadbeef", meta.BundleURL)
+	defer snap.Close()
+
+	assert.Equal(t, "deadbeef", snap.Commit)
+	assert.Equal(t, "/git/github.com/org/repo/snapshot.bundle?base=deadbeef", snap.BundleURL)
+
+	assert.Equal(t, "", snap.Headers.Get("Content-Range"))
+	assert.Equal(t, strconv.Itoa(len(body)), snap.Headers.Get("Content-Length"))
+
+	got, err := io.ReadAll(snap.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, body, got)
 	assert.True(t, requests.Load() > 1, "expected multiple range requests, got %d", requests.Load())
 }
 
-func TestDownloadGitSnapshotFallsBackWithoutRange(t *testing.T) {
+func TestOpenGitSnapshotParallelSmallObject(t *testing.T) {
+	body := []byte("a tiny snapshot that fits in the first chunk")
+	const etag = `"snap-small"`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zstd")
+		w.Header().Set("ETag", etag)
+		w.Header().Set(client.SnapshotCommitHeader, "beef")
+		http.ServeContent(w, r, "snapshot.tar.zst", time.Time{}, bytes.NewReader(body))
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	for range 200 {
+		snap, err := api.OpenGitSnapshotParallel(context.Background(), "https://github.com/org/repo", 4096, 4)
+		assert.NoError(t, err)
+		assert.Equal(t, "beef", snap.Commit)
+		got, err := io.ReadAll(snap.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, body, got)
+		assert.NoError(t, snap.Close())
+	}
+}
+
+func TestOpenGitSnapshotParallelFallsBackWithoutRange(t *testing.T) {
 	body := []byte("full body, server ignores ranges")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// No ETag and no range handling: always answer the full object with 200,
-		// mimicking an older server. ParallelGet must fall back to a single read.
 		w.Header().Set("Content-Type", "application/zstd")
 		w.Header().Set(client.SnapshotCommitHeader, "cafe")
 		_, _ = w.Write(body) //nolint:errcheck
@@ -220,21 +243,47 @@ func TestDownloadGitSnapshotFallsBackWithoutRange(t *testing.T) {
 	defer srv.Close()
 
 	api := client.NewWithHTTPClient(srv.URL, srv.Client())
-	var dst bufferAt
-	meta, err := api.DownloadGitSnapshot(context.Background(), "https://github.com/org/repo", &dst, 8, 4)
+	snap, err := api.OpenGitSnapshotParallel(context.Background(), "https://github.com/org/repo", 8, 4)
 	assert.NoError(t, err)
-	assert.Equal(t, body, dst.buf)
-	assert.Equal(t, "cafe", meta.Commit)
+	defer snap.Close()
+
+	assert.Equal(t, "cafe", snap.Commit)
+	got, err := io.ReadAll(snap.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, body, got)
 }
 
-func TestDownloadGitSnapshotNotFound(t *testing.T) {
+func TestOpenGitSnapshotParallelNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
 	defer srv.Close()
 
 	api := client.NewWithHTTPClient(srv.URL, srv.Client())
-	var dst bufferAt
-	_, err := api.DownloadGitSnapshot(context.Background(), "https://github.com/org/repo", &dst, 8, 4)
+	_, err := api.OpenGitSnapshotParallel(context.Background(), "https://github.com/org/repo", 8, 4)
 	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestOpenGitSnapshotParallelCloseStopsDownload(t *testing.T) {
+	body := make([]byte, 1<<20)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	const etag = `"snap-v1"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zstd")
+		w.Header().Set("ETag", etag)
+		http.ServeContent(w, r, "snapshot.tar.zst", time.Time{}, bytes.NewReader(body))
+	}))
+	defer srv.Close()
+
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	snap, err := api.OpenGitSnapshotParallel(context.Background(), "https://github.com/org/repo", 4096, 4)
+	assert.NoError(t, err)
+
+	buf := make([]byte, 16)
+	_, err = io.ReadFull(snap.Body, buf)
+	assert.NoError(t, err)
+	assert.NoError(t, snap.Close())
 }

--- a/client/parallel_get.go
+++ b/client/parallel_get.go
@@ -3,130 +3,324 @@ package client
 import (
 	"context"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/alecthomas/errors"
 	"golang.org/x/sync/errgroup"
 )
 
+// chunkRetryAttempts bounds retries when a chunk response ignores the
+// requested range, e.g. a load-balanced replica that cannot serve the range;
+// discovery already proved range support, so a retry may route to a capable
+// replica.
+const chunkRetryAttempts = 4
+
 // RangeReader is the subset of cache operations ParallelGet needs: a
-// conditional, Range-capable Open. Both *Client and the cache.Cache interface
-// satisfy it, so ParallelGet can drive either a remote cache server or a local
-// backend.
+// conditional, Range-capable Open. Both *Client and cache.Cache satisfy it.
 type RangeReader interface {
 	Open(ctx context.Context, key Key, opts ...RequestOption) (io.ReadCloser, http.Header, error)
 }
 
-// ParallelGet downloads an object from any Range-capable RangeReader into dst,
-// fetching it in chunkSize-byte chunks concurrently (up to concurrency requests
-// in flight) and writing each chunk at its offset via dst.WriteAt. Latency-bound
-// backends such as a remote cache can saturate bandwidth with overlapping reads.
+// ParallelGet downloads an object in chunkSize-byte chunks with up to
+// concurrency requests in flight, writing each chunk at its offset via
+// dst.WriteAt. dst may block writes to apply backpressure (e.g. a bounded
+// reordering buffer feeding a stream): chunk dispatch never runs more than
+// 2*concurrency chunks past the oldest incomplete chunk, so a dst window of
+// 2*concurrency*chunkSize is never exceeded and blocked writes always drain.
 //
-// The first chunk is fetched with a ranged Open, whose response yields both the
-// total size (from Content-Range) and the object's ETag; every remaining chunk
-// is then requested with IfMatch pinned to that ETag. If the object changes
-// mid-download, the chunk is rejected with a bodiless ErrPreconditionFailed
-// (412) and ParallelGet returns an error rather than splicing bytes from two
-// revisions; a server that ignores If-Match is caught by verifying each chunk's
-// response ETag. A missing or truncated chunk is likewise reported as an error,
-// so a partially written dst must be discarded by the caller on failure. An
-// object with no ETag to pin to cannot be kept revision-safe across chunks, so
-// it falls back to a single full read instead of parallelising. A concurrency of
-// 1 likewise reads the whole object in one request, since chunking a single
-// worker would only serialise ranged GETs for no benefit.
-//
-// dst is written via concurrent WriteAt calls at non-overlapping offsets; the
-// caller owns dst's lifecycle (open, close, cleanup) and need not pre-size it,
-// as WriteAt extends the destination.
+// Chunks are pinned to the discovery response's ETag so a mid-download rewrite
+// is rejected rather than spliced. No ETag, a range-ignoring backend, an
+// object that fits in the first chunk, or concurrency 1 all fall back to a
+// single full read. On error dst is left partially written and must be
+// discarded by the caller.
 func ParallelGet(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, chunkSize int64, concurrency int) error {
-	if chunkSize <= 0 {
-		return errors.Errorf("parallel get: chunk size must be positive, got %d", chunkSize)
-	}
-	concurrency = max(concurrency, 1)
-
-	if concurrency == 1 {
+	if max(concurrency, 1) == 1 {
 		return fullRead(ctx, c, key, dst)
 	}
-
-	rc, headers, err := c.Open(ctx, key, Range(0, chunkSize))
-	if errors.Is(err, ErrRangeNotSatisfiable) {
-		return nil
+	if err := validateParallelParams(chunkSize, concurrency); err != nil {
+		return err
 	}
+
+	rc, headers, etag, total, hasRange, err := discoverFirstChunk(ctx, c, key, chunkSize)
 	if err != nil {
-		return errors.Wrap(err, "parallel get: open first chunk")
+		return err
+	}
+	if rc == nil {
+		notifyDiscovery(c, headers)
+		return nil // Empty object: nothing to write.
 	}
 
-	etag := headers.Get(ETagKey)
-	total, hasRange := parseContentRangeTotal(headers.Get("Content-Range"))
-
-	firstLen := min(chunkSize, total)
+	// Range ignored or the object fits in the first chunk: this response
+	// already carries the whole object (negative length = unknown size).
 	if !hasRange {
-		firstLen = -1
+		notifyDiscovery(c, headers)
+		return errors.Wrap(writeChunkAt(dst, 0, -1, rc), "parallel get")
 	}
-	if !hasRange || total <= chunkSize {
-		return errors.Wrap(writeChunkAt(dst, 0, firstLen, rc), "parallel get")
+	if total <= chunkSize {
+		notifyDiscovery(c, headers)
+		return errors.Wrap(writeChunkAt(dst, 0, total, rc), "parallel get")
 	}
 
+	// Without an ETag there is nothing to pin chunks to, so a rewrite could be
+	// spliced undetected; fall back to a single revision-consistent read.
+	// fullRead reports its own response's headers: this response's bytes are
+	// discarded, so its metadata must not be recorded either.
 	if etag == "" {
 		if err := rc.Close(); err != nil {
 			return errors.Wrap(err, "parallel get: close discovery reader")
 		}
 		return fullRead(ctx, c, key, dst)
 	}
+	notifyDiscovery(c, headers)
 
-	numChunks := int((total + chunkSize - 1) / chunkSize)
+	numChunks := 1 + (total-1)/chunkSize // overflow-safe ceil; total > chunkSize here
 	eg, egCtx := errgroup.WithContext(ctx)
-	eg.SetLimit(concurrency)
-	eg.Go(func() error { return writeChunkAt(dst, 0, firstLen, rc) })
-	for seq := 1; seq < numChunks; seq++ {
-		if egCtx.Err() != nil {
-			break
+
+	// Bound dispatch run-ahead: a chunk may start only while it is within
+	// 2*concurrency of the oldest incomplete chunk. A dst whose WriteAt blocks
+	// (bounded window, no ctx) therefore cannot deadlock when a sibling chunk
+	// fails: every dispatched write fits its window once the stream drains to
+	// the gap, so blocked writes complete and eg.Wait returns.
+	gate := newDispatchGate(int64(2 * concurrency))
+
+	var nextSeq atomic.Int64
+	nextSeq.Store(1)
+	worker := func() error {
+		for {
+			seq := nextSeq.Add(1) - 1
+			if seq >= numChunks {
+				return nil
+			}
+			if err := gate.wait(egCtx, seq); err != nil {
+				return err
+			}
+			start := seq * chunkSize
+			end := min(start+chunkSize, total)
+			body, err := openChunk(egCtx, c, key, etag, start, end)
+			if err != nil {
+				return err
+			}
+			if err := writeChunkAt(dst, start, end-start, body); err != nil {
+				return errors.WithStack(err)
+			}
+			gate.complete(seq)
 		}
-		start := int64(seq) * chunkSize
-		end := min(start+chunkSize, total)
-		eg.Go(func() error { return fetchChunk(egCtx, c, key, dst, start, end, etag) })
+	}
+
+	// The first worker writes chunk zero from the already-open discovery body,
+	// keeping in-flight requests at concurrency rather than concurrency+1. rc
+	// was opened with the parent ctx, so close it on egCtx cancellation or a
+	// failed sibling would leave the copy blocked; double Close is harmless.
+	eg.Go(func() error {
+		stop := context.AfterFunc(egCtx, func() { _ = rc.Close() }) //nolint:errcheck
+		err := writeChunkAt(dst, 0, min(chunkSize, total), rc)
+		stop()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		gate.complete(0)
+		return worker()
+	})
+	for range min(int64(concurrency), numChunks) - 1 {
+		eg.Go(worker)
 	}
 	return errors.Wrap(eg.Wait(), "parallel get")
 }
 
-func fullRead(ctx context.Context, c RangeReader, key Key, dst io.WriterAt) error {
-	rc, _, err := c.Open(ctx, key)
-	if err != nil {
-		return errors.Wrap(err, "parallel get: full read")
-	}
-	return errors.Wrap(writeChunkAt(dst, 0, -1, rc), "parallel get")
-}
-
-func fetchChunk(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, start, end int64, etag string) error {
-	rc, headers, err := c.Open(ctx, key, Range(start, end), IfMatch(etag))
-	if errors.Is(err, ErrPreconditionFailed) {
-		return errors.Errorf("open range %d-%d: object changed during read: %w", start, end, err)
+// discoverFirstChunk opens chunk zero with a ranged request, revealing the
+// total size and the ETag that pin the remaining chunks. A response that
+// ignores the range is accepted as the single-stream fallback rather than
+// retried: on a cold miss the server streams a freshly generated object, and
+// closing that body would abort and repeat the expensive generation. A nil rc
+// with nil err means the object is empty.
+func discoverFirstChunk(ctx context.Context, c RangeReader, key Key, chunkSize int64) (rc io.ReadCloser, headers http.Header, etag string, total int64, hasRange bool, err error) {
+	rc, headers, err = c.Open(ctx, key, Range(0, chunkSize))
+	if errors.Is(err, ErrRangeNotSatisfiable) {
+		return nil, headers, "", 0, false, nil
 	}
 	if err != nil {
-		return errors.Errorf("open range %d-%d: %w", start, end, err)
+		return nil, nil, "", 0, false, errors.Wrap(err, "parallel get: open first chunk")
 	}
-	if got := headers.Get(ETagKey); got != etag {
-		return errors.Join(
-			errors.Errorf("object changed during read at offset %d: etag %q != %q", start, got, etag),
-			rc.Close(),
-		)
-	}
-	return writeChunkAt(dst, start, end-start, rc)
+	etag = headers.Get(ETagKey)
+	total, hasRange = parseContentRangeTotal(headers.Get("Content-Range"))
+	return rc, headers, etag, total, hasRange, nil
 }
 
-func writeChunkAt(dst io.WriterAt, off, want int64, src io.ReadCloser) error {
-	n, copyErr := io.Copy(io.NewOffsetWriter(dst, off), src)
-	if err := errors.Join(copyErr, src.Close()); err != nil {
-		return errors.Errorf("write chunk at offset %d: %w", off, err)
+// discoveryObserver is implemented by RangeReaders that need the headers of
+// the response ParallelGet accepts as the object's source of truth, e.g. to
+// surface application metadata carried on the response. Discarded
+// range-ignoring attempts are never observed.
+type discoveryObserver interface {
+	observeDiscovery(http.Header)
+}
+
+func notifyDiscovery(c RangeReader, headers http.Header) {
+	if o, ok := c.(discoveryObserver); ok && headers != nil {
+		o.observeDiscovery(headers)
 	}
-	if want >= 0 && n != want {
-		return errors.Errorf("short chunk at offset %d: wrote %d of %d bytes", off, n, want)
+}
+
+// maxParallelGetConcurrency bounds the buffering window (2*concurrency
+// chunk-sized pages) so a misconfigured concurrency cannot exhaust memory
+// before the download starts.
+const maxParallelGetConcurrency = 1024
+
+// validateParallelParams rejects parameters whose buffering-window arithmetic
+// (2*concurrency pages of chunkSize bytes) would overflow or allocate
+// unboundedly.
+func validateParallelParams(chunkSize int64, concurrency int) error {
+	if chunkSize <= 0 {
+		return errors.Errorf("parallel get: chunk size must be positive, got %d", chunkSize)
+	}
+	if concurrency > maxParallelGetConcurrency {
+		return errors.Errorf("parallel get: concurrency %d exceeds maximum %d", concurrency, maxParallelGetConcurrency)
+	}
+	if window := 2 * int64(concurrency); chunkSize > math.MaxInt64/window {
+		return errors.Errorf("parallel get: chunk size %d with concurrency %d overflows the buffer window", chunkSize, concurrency)
 	}
 	return nil
 }
 
+// dispatchGate bounds chunk dispatch to a window past the oldest incomplete
+// chunk, so every in-flight chunk's write offset stays within window chunks of
+// the stream's contiguous frontier. done is a ring: the gate only ever tracks
+// chunks in [low, low+window), so cells cannot alias.
+type dispatchGate struct {
+	window int64
+
+	mu   sync.Mutex
+	wake chan struct{} // closed and replaced when low advances
+	done []bool        // completion of chunk seq at done[seq%window]
+	low  int64         // oldest incomplete chunk
+}
+
+func newDispatchGate(window int64) *dispatchGate {
+	return &dispatchGate{window: window, wake: make(chan struct{}), done: make([]bool, window)}
+}
+
+// wait blocks until seq is within the dispatch window or ctx is cancelled.
+func (g *dispatchGate) wait(ctx context.Context, seq int64) error {
+	if err := ctx.Err(); err != nil {
+		return errors.WithStack(err)
+	}
+	g.mu.Lock()
+	for seq-g.low >= g.window {
+		ch := g.wake
+		g.mu.Unlock()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		}
+		g.mu.Lock()
+	}
+	g.mu.Unlock()
+	return nil
+}
+
+// complete marks seq fully written, advancing the window over any
+// contiguously completed chunks.
+func (g *dispatchGate) complete(seq int64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.done[seq%g.window] = true
+	if seq != g.low {
+		return
+	}
+	for g.done[g.low%g.window] {
+		g.done[g.low%g.window] = false
+		g.low++
+	}
+	close(g.wake)
+	g.wake = make(chan struct{})
+}
+
+// openChunk fetches one chunk's range pinned to the discovery ETag.
+// Range-ignoring responses are retried, as each attempt may route to a
+// different replica; an ETag mismatch or precondition failure is fatal since
+// the object changed mid-download.
+func openChunk(ctx context.Context, c RangeReader, key Key, etag string, start, end int64) (io.ReadCloser, error) {
+	for attempt := 0; ; attempt++ {
+		body, h, err := c.Open(ctx, key, Range(start, end), IfMatch(etag))
+		if errors.Is(err, ErrPreconditionFailed) {
+			return nil, errors.Errorf("parallel get: open range %d-%d: object changed during read: %w", start, end, err)
+		}
+		if err != nil {
+			return nil, errors.Errorf("parallel get: open range %d-%d: %w", start, end, err)
+		}
+		// Check Content-Range before trusting the ETag: a range-ignoring
+		// response often carries no ETag.
+		if cr := h.Get("Content-Range"); !strings.HasPrefix(cr, "bytes "+strconv.FormatInt(start, 10)+"-") {
+			if attempt < chunkRetryAttempts-1 {
+				if err := body.Close(); err != nil {
+					return nil, errors.Wrap(err, "parallel get: close range-ignoring chunk reader")
+				}
+				continue
+			}
+			return nil, errors.Join(
+				errors.Errorf("parallel get: server ignored range %d-%d (Content-Range %q)", start, end, cr),
+				body.Close(),
+			)
+		}
+		if got := h.Get(ETagKey); got != etag {
+			return nil, errors.Join(
+				errors.Errorf("parallel get: object changed during read at offset %d: etag %q != %q", start, got, etag),
+				body.Close(),
+			)
+		}
+		return body, nil
+	}
+}
+
+// fullRead downloads the object in a single request, writing sequentially from
+// offset zero with an unknown length.
+func fullRead(ctx context.Context, c RangeReader, key Key, dst io.WriterAt) error {
+	rc, headers, err := c.Open(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "parallel get: full read")
+	}
+	notifyDiscovery(c, headers)
+	return errors.Wrap(writeChunkAt(dst, 0, -1, rc), "parallel get")
+}
+
+// writeChunkAt copies src to its offset in dst, closing src. length < 0 means
+// "write the whole body" (unknown size); otherwise the copy is capped at
+// length so an overlong body can never write into another chunk's range, and
+// short or overlong bodies are reported as errors.
+func writeChunkAt(dst io.WriterAt, off, length int64, src io.ReadCloser) error {
+	w := io.NewOffsetWriter(dst, off)
+	if length < 0 {
+		_, err := io.Copy(w, src)
+		return errors.Join(errors.Wrap(err, "write chunk"), src.Close())
+	}
+	n, err := io.Copy(w, io.LimitReader(src, length))
+	if err != nil {
+		return errors.Join(errors.Errorf("write chunk at offset %d: %w", off, err), src.Close())
+	}
+	if n != length {
+		return errors.Join(errors.Errorf("chunk at offset %d: wrote %d of %d bytes", off, n, length), src.Close())
+	}
+	if overlong(src) {
+		return errors.Join(errors.Errorf("chunk at offset %d: read more than the expected %d bytes", off, length), src.Close())
+	}
+	return errors.WithStack(src.Close())
+}
+
+// overlong reports whether r has bytes left, detecting a body longer than the
+// requested chunk without buffering the excess.
+func overlong(r io.Reader) bool {
+	var probe [1]byte
+	n, _ := io.ReadFull(r, probe[:]) //nolint:errcheck // any byte past the chunk is overlong, regardless of the error
+	return n > 0
+}
+
+// parseContentRangeTotal extracts the total from "bytes start-end/total",
+// returning ok=false when the header is absent or unparseable.
 func parseContentRangeTotal(contentRange string) (total int64, ok bool) {
 	_, size, found := strings.Cut(contentRange, "/")
 	if !found {

--- a/client/parallel_get_test.go
+++ b/client/parallel_get_test.go
@@ -11,30 +11,38 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
 
 	"github.com/block/cachew/client"
 )
 
+// Compile-time assertion that the concrete Client satisfies the narrow
+// interface ParallelGet drives.
 var _ client.RangeReader = (*client.Client)(nil)
 
-type bufferAt struct {
-	mu  sync.Mutex
-	buf []byte
-}
-
-func (b *bufferAt) WriteAt(p []byte, off int64) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if end := int(off) + len(p); end > len(b.buf) {
-		b.buf = append(b.buf, make([]byte, end-len(b.buf))...)
+func patternBytes(n int) []byte {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = byte(i % 251)
 	}
-	copy(b.buf[off:], p)
-	return len(p), nil
+	return data
 }
 
+// collect runs ParallelGet into an in-memory WriterAt and returns the
+// reassembled bytes.
+func collect(c client.RangeReader, key client.Key, chunkSize int64, concurrency int) ([]byte, error) {
+	dst := &bufferAt{}
+	err := client.ParallelGet(context.Background(), c, key, dst, chunkSize, concurrency)
+	return dst.buf, err
+}
+
+// rangeFlipReader serves correct byte ranges but reports a different ETag for
+// any chunk past the first, simulating an object rewritten mid-download.
 type rangeFlipReader struct {
 	data      []byte
 	firstETag string
@@ -64,12 +72,14 @@ func (f *rangeFlipReader) Open(_ context.Context, _ client.Key, opts ...client.R
 
 func TestParallelGetETagMismatch(t *testing.T) {
 	c := &rangeFlipReader{data: make([]byte, 1000), firstETag: `"v1"`, restETag: `"v2"`}
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+	_, err := collect(c, client.NewKey("k"), 100, 4)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "object changed during read")
 }
 
+// ifMatchFlipReader honours If-Match against firstETag on the discovery request
+// but reports restETag (and a 412) for any pinned chunk, modelling a server that
+// enforces If-Match on an object rewritten mid-download.
 type ifMatchFlipReader struct {
 	data      []byte
 	firstETag string
@@ -102,12 +112,14 @@ func (f *ifMatchFlipReader) Open(_ context.Context, _ client.Key, opts ...client
 
 func TestParallelGetPreconditionFailedOnRewrite(t *testing.T) {
 	c := &ifMatchFlipReader{data: make([]byte, 1000), firstETag: `"v1"`, restETag: `"v2"`}
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+	dst := &bufferAt{}
+	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), dst, 100, 4)
 	assert.IsError(t, err, client.ErrPreconditionFailed)
 	assert.Contains(t, err.Error(), "object changed during read")
 }
 
+// noETagReader serves byte ranges but never sets an ETag, modelling a legacy
+// entry or a RangeReader implementation that omits it.
 type noETagReader struct {
 	data []byte
 }
@@ -128,26 +140,24 @@ func (n *noETagReader) Open(_ context.Context, _ client.Key, opts ...client.Requ
 }
 
 func TestParallelGetNoETagMultiChunk(t *testing.T) {
-	data := make([]byte, 1000)
-	for i := range data {
-		data[i] = byte(i % 251)
-	}
+	data := patternBytes(1000)
 	c := &noETagReader{data: data}
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+	got, err := collect(c, client.NewKey("k"), 100, 4)
 	assert.NoError(t, err)
-	assert.Equal(t, data, dst.buf)
+	assert.Equal(t, data, got)
 }
 
 func TestParallelGetNoETagSingleChunk(t *testing.T) {
 	data := []byte("0123456789")
 	c := &noETagReader{data: data}
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+	got, err := collect(c, client.NewKey("k"), 100, 4)
 	assert.NoError(t, err)
-	assert.Equal(t, data, dst.buf)
+	assert.Equal(t, data, got)
 }
 
+// changingSizeReader serves a multi-chunk body with no ETag on the ranged
+// discovery request, then a differently sized body on the subsequent full
+// (non-range) read, modelling an object rewritten between the two requests.
 type changingSizeReader struct {
 	discovery []byte
 	rewritten []byte
@@ -173,11 +183,21 @@ func (c *changingSizeReader) Open(_ context.Context, _ client.Key, opts ...clien
 	return io.NopCloser(bytes.NewReader(c.discovery[start : start+length])), headers, nil
 }
 
+func TestParallelGetNoETagSizeChangedBetweenRequests(t *testing.T) {
+	c := &changingSizeReader{discovery: make([]byte, 1000), rewritten: []byte("changed")}
+	got, err := collect(c, client.NewKey("k"), 100, 4)
+	assert.NoError(t, err)
+	assert.Equal(t, c.rewritten, got)
+}
+
 type openRecord struct {
 	Range   string
 	IfMatch string
 }
 
+// recordingReader serves byte ranges and records the Range and If-Match options
+// of every Open call (both "" for a full, non-ranged read), so tests can assert
+// how the object was fetched and how chunks were pinned.
 type recordingReader struct {
 	data []byte
 	etag string
@@ -209,27 +229,28 @@ func (r *recordingReader) Open(_ context.Context, _ client.Key, opts ...client.R
 	return io.NopCloser(bytes.NewReader(r.data[start : start+length])), headers, nil
 }
 
-func TestParallelGetSingleWorkerFullRead(t *testing.T) {
-	data := make([]byte, 1000)
-	for i := range data {
-		data[i] = byte(i % 251)
-	}
+func TestParallelGetReassembly(t *testing.T) {
+	data := patternBytes(10_000)
 	c := &recordingReader{data: data, etag: `"v1"`}
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 1)
+	got, err := collect(c, client.NewKey("k"), 1000, 4)
 	assert.NoError(t, err)
-	assert.Equal(t, data, dst.buf)
+	assert.Equal(t, data, got)
+}
+
+func TestParallelGetSingleWorkerFullRead(t *testing.T) {
+	data := patternBytes(1000)
+	c := &recordingReader{data: data, etag: `"v1"`}
+	got, err := collect(c, client.NewKey("k"), 100, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, data, got)
 	assert.Equal(t, []openRecord{{}}, c.opens)
 }
 
 func TestParallelGetPinsChunksWithIfMatch(t *testing.T) {
-	data := make([]byte, 1000)
-	for i := range data {
-		data[i] = byte(i % 251)
-	}
+	data := patternBytes(1000)
 	c := &recordingReader{data: data, etag: `"v1"`}
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+	dst := &bufferAt{}
+	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), dst, 100, 4)
 	assert.NoError(t, err)
 	assert.Equal(t, data, dst.buf)
 
@@ -241,19 +262,189 @@ func TestParallelGetPinsChunksWithIfMatch(t *testing.T) {
 	assert.Equal(t, expected, c.opens)
 }
 
-func TestParallelGetNoETagSizeChangedBetweenRequests(t *testing.T) {
-	c := &changingSizeReader{discovery: make([]byte, 1000), rewritten: []byte("changed")}
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+func TestParallelGetEmptyObject(t *testing.T) {
+	c := &recordingReader{data: nil, etag: `"v1"`}
+	got, err := collect(c, client.NewKey("k"), 100, 4)
 	assert.NoError(t, err)
-	assert.Equal(t, c.rewritten, dst.buf)
+	assert.Equal(t, 0, len(got))
+}
+
+func TestParallelGetServerIgnoresRange(t *testing.T) {
+	data := patternBytes(1000)
+	c := &ignoreRangeReader{data: data}
+	got, err := collect(c, client.NewKey("k"), 100, 4)
+	assert.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestParallelGetOutOfOrderCompletion(t *testing.T) {
+	data := patternBytes(10_000)
+	c := &reorderReader{data: data, etag: `"v1"`, chunkSize: 1000}
+	got, err := collect(c, client.NewKey("k"), 1000, 4)
+	assert.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestParallelGetPropagatesOpenError(t *testing.T) {
+	c := &failingChunkReader{data: patternBytes(10_000), etag: `"v1"`, failAtStart: 5000}
+	_, err := collect(c, client.NewKey("k"), 1000, 4)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestParallelGetRejectsOverlongChunk(t *testing.T) {
+	c := &fullBodyOnChunkReader{data: patternBytes(10_000), etag: `"v1"`}
+	_, err := collect(c, client.NewKey("k"), 1000, 4)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "more than the expected 1000 bytes")
+}
+
+func TestParallelGetRejectsMidflightRangeIgnore(t *testing.T) {
+	c := &midflightRangeIgnoreReader{data: patternBytes(10_000), etag: `"v1"`}
+	_, err := collect(c, client.NewKey("k"), 1000, 4)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "server ignored range")
+}
+
+// bufferAt is an in-memory io.WriterAt that extends like a file, zero-filling
+// gaps, so tests can assert reassembly without touching disk.
+type bufferAt struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (b *bufferAt) WriteAt(p []byte, off int64) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if end := int(off) + len(p); end > len(b.buf) {
+		b.buf = append(b.buf, make([]byte, end-len(b.buf))...)
+	}
+	copy(b.buf[off:], p)
+	return len(p), nil
+}
+
+// fullBodyOnChunkReader honours the discovery range (start 0) with a proper 206
+// but ignores the range on any later chunk, returning the entire object with the
+// same ETag — modelling a backend that degrades to full responses mid-download.
+type fullBodyOnChunkReader struct {
+	data []byte
+	etag string
+}
+
+func (r *fullBodyOnChunkReader) Open(_ context.Context, _ client.Key, opts ...client.RequestOption) (io.ReadCloser, http.Header, error) {
+	size := int64(len(r.data))
+	start, length, outcome := client.NewRequestOptions(opts...).ResolveRange(size, r.etag)
+	headers := http.Header{}
+	headers.Set(client.ETagKey, r.etag)
+	if outcome == client.RangePartial && start == 0 {
+		headers.Set("Content-Length", strconv.FormatInt(length, 10))
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+length-1, size))
+		return io.NopCloser(bytes.NewReader(r.data[start : start+length])), headers, nil
+	}
+	if outcome == client.RangePartial {
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+length-1, size))
+	}
+	headers.Set("Content-Length", strconv.FormatInt(size, 10))
+	return io.NopCloser(bytes.NewReader(r.data)), headers, nil
+}
+
+// midflightRangeIgnoreReader ranges the discovery chunk but answers subsequent
+// chunk requests with the full body and no Content-Range, modelling a replica
+// that stops honouring ranges mid-download.
+type midflightRangeIgnoreReader struct {
+	data []byte
+	etag string
+}
+
+func (r *midflightRangeIgnoreReader) Open(_ context.Context, _ client.Key, opts ...client.RequestOption) (io.ReadCloser, http.Header, error) {
+	size := int64(len(r.data))
+	start, length, outcome := client.NewRequestOptions(opts...).ResolveRange(size, r.etag)
+	headers := http.Header{}
+	headers.Set(client.ETagKey, r.etag)
+	if outcome == client.RangePartial && start == 0 {
+		headers.Set("Content-Length", strconv.FormatInt(length, 10))
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+length-1, size))
+		return io.NopCloser(bytes.NewReader(r.data[start : start+length])), headers, nil
+	}
+	headers.Set("Content-Length", strconv.FormatInt(size, 10))
+	return io.NopCloser(bytes.NewReader(r.data)), headers, nil
+}
+
+// ignoreRangeReader returns the whole object with no Content-Range regardless of
+// the requested range, modelling a backend that doesn't honour ranges.
+type ignoreRangeReader struct{ data []byte }
+
+func (r *ignoreRangeReader) Open(_ context.Context, _ client.Key, _ ...client.RequestOption) (io.ReadCloser, http.Header, error) {
+	headers := http.Header{}
+	headers.Set("Content-Length", strconv.Itoa(len(r.data)))
+	return io.NopCloser(bytes.NewReader(r.data)), headers, nil
+}
+
+// reorderReader serves correct byte ranges but delays earlier offsets longer
+// than later ones, so within the in-flight window chunks complete out of order
+// and the writer must buffer and reorder them.
+type reorderReader struct {
+	data      []byte
+	etag      string
+	chunkSize int64
+}
+
+func (r *reorderReader) Open(_ context.Context, _ client.Key, opts ...client.RequestOption) (io.ReadCloser, http.Header, error) {
+	size := int64(len(r.data))
+	o := client.NewRequestOptions(opts...)
+	start, length, outcome := o.ResolveRange(size, r.etag)
+	headers := http.Header{}
+	if outcome == client.RangeNotSatisfiable {
+		headers.Set("Content-Range", fmt.Sprintf("bytes */%d", size))
+		return nil, headers, client.ErrRangeNotSatisfiable
+	}
+	// Earlier chunks within a window sleep longer, so higher offsets finish
+	// first and the writer is forced to reorder.
+	if outcome == client.RangePartial {
+		chunks := (size - start) / r.chunkSize
+		time.Sleep(time.Duration(chunks) * time.Millisecond)
+	}
+	headers.Set(client.ETagKey, r.etag)
+	headers.Set("Content-Length", strconv.FormatInt(length, 10))
+	if outcome == client.RangePartial {
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+length-1, size))
+	}
+	return io.NopCloser(bytes.NewReader(r.data[start : start+length])), headers, nil
+}
+
+// failingChunkReader serves ranges normally but errors when the requested range
+// starts at failAtStart, modelling a mid-download fetch failure.
+type failingChunkReader struct {
+	data        []byte
+	etag        string
+	failAtStart int64
+
+	opens atomic.Int64
+}
+
+func (r *failingChunkReader) Open(_ context.Context, _ client.Key, opts ...client.RequestOption) (io.ReadCloser, http.Header, error) {
+	r.opens.Add(1)
+	size := int64(len(r.data))
+	o := client.NewRequestOptions(opts...)
+	start, length, outcome := o.ResolveRange(size, r.etag)
+	if outcome == client.RangePartial && start == r.failAtStart {
+		return nil, nil, errors.New("boom")
+	}
+	headers := http.Header{}
+	if outcome == client.RangeNotSatisfiable {
+		headers.Set("Content-Range", fmt.Sprintf("bytes */%d", size))
+		return nil, headers, client.ErrRangeNotSatisfiable
+	}
+	headers.Set(client.ETagKey, r.etag)
+	headers.Set("Content-Length", strconv.FormatInt(length, 10))
+	if outcome == client.RangePartial {
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+length-1, size))
+	}
+	return io.NopCloser(bytes.NewReader(r.data[start : start+length])), headers, nil
 }
 
 func TestParallelGetClient(t *testing.T) {
-	content := make([]byte, 1000)
-	for i := range content {
-		content[i] = byte(i % 251)
-	}
+	content := patternBytes(1000)
 	etag := fakeETag(content)
 
 	mux := http.NewServeMux()
@@ -291,8 +482,8 @@ func TestParallelGetClient(t *testing.T) {
 
 	c := client.New(srv.URL, nil).Namespace("test")
 	defer c.Close()
-	var dst bufferAt
-	err := client.ParallelGet(context.Background(), c, client.NewKey("parallel-client"), &dst, 100, 4)
+	dst := &bufferAt{}
+	err := client.ParallelGet(context.Background(), c, client.NewKey("parallel-client"), dst, 100, 4)
 	assert.NoError(t, err)
 	assert.Equal(t, content, dst.buf)
 }

--- a/client/stream_buffer.go
+++ b/client/stream_buffer.go
@@ -1,0 +1,175 @@
+package client
+
+import (
+	"cmp"
+	"io"
+	"slices"
+	"sync"
+
+	"github.com/alecthomas/errors"
+)
+
+// streamBuffer reorders concurrent WriteAt calls back into a sequential byte
+// stream readable via Read, buffering in memory. A fixed ring of 2*concurrency
+// chunk-sized pages bounds memory: WriteAt blocks while its target page is
+// more than 2*concurrency pages past the page being read, applying
+// backpressure to fetchers, so peak buffering is capped at
+// 2*concurrency*chunkSize regardless of object size.
+//
+// WriteAt carries no context, so a blocked write is only released by reader
+// progress, Close, or closeWrite. ParallelGet guarantees release by never
+// dispatching a chunk more than 2*concurrency past the oldest incomplete one:
+// every in-flight write fits the window once the reader drains to the frontier.
+type streamBuffer struct {
+	chunkSize int64
+	n         int64 // page count = 2*concurrency
+
+	mu       sync.Mutex
+	cond     *sync.Cond
+	pages    [][]byte        // n lazily allocated chunk-sized pages, indexed by (off/chunkSize)%n
+	pending  []writeInterval // written ranges not yet contiguous with the frontier
+	frontier int64           // contiguous bytes written from offset 0
+	readOff  int64           // next byte Read will emit
+	closed   bool            // write side finished
+	err      error           // surfaced to Read once buffered bytes drain
+	rclosed  bool            // read side closed
+}
+
+type writeInterval struct{ start, end int64 }
+
+// newStreamBuffer returns a streamBuffer with a ring of 2*concurrency pages
+// of chunkSize bytes each, allocated lazily.
+func newStreamBuffer(chunkSize int64, concurrency int) *streamBuffer {
+	n := int64(2 * max(concurrency, 1))
+	s := &streamBuffer{
+		chunkSize: chunkSize,
+		n:         n,
+		pages:     make([][]byte, n),
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// WriteAt implements io.WriterAt. Writes at non-overlapping offsets may run
+// concurrently; a write beyond the window blocks until the reader catches up.
+func (s *streamBuffer) WriteAt(p []byte, off int64) (int, error) {
+	written := 0
+	for len(p) > 0 {
+		n, err := s.writeSome(p, off)
+		written += n
+		off += int64(n)
+		p = p[n:]
+		if err != nil {
+			return written, err
+		}
+	}
+	return written, nil
+}
+
+// writeSome copies as much of p as fits the current page, blocking until the
+// page's ring slot is free. The window is page-granular: a slot is reusable
+// only once the reader has moved wholly past its previous page, otherwise a
+// write one ring ahead would clobber the unread tail of a partially read page.
+func (s *streamBuffer) writeSome(p []byte, off int64) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for off/s.chunkSize >= s.readOff/s.chunkSize+s.n {
+		if s.rclosed || s.closed {
+			return 0, errors.WithStack(io.ErrClosedPipe)
+		}
+		s.cond.Wait()
+	}
+	if s.rclosed || s.closed {
+		return 0, errors.WithStack(io.ErrClosedPipe)
+	}
+	n := min(int64(len(p)), s.chunkSize-off%s.chunkSize)
+	slot := (off / s.chunkSize) % s.n
+	if s.pages[slot] == nil {
+		s.pages[slot] = make([]byte, s.chunkSize)
+	}
+	copy(s.pages[slot][off%s.chunkSize:], p[:n])
+	s.extendLocked(off, off+n)
+	s.cond.Broadcast()
+	return int(n), nil
+}
+
+// Read emits bytes in offset order as the contiguous write frontier advances,
+// blocking until data arrives or the write side finishes. After closeWrite it
+// drains the remaining buffered bytes, then returns the recorded error or
+// io.EOF.
+func (s *streamBuffer) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for {
+		if s.rclosed {
+			return 0, errors.WithStack(io.ErrClosedPipe)
+		}
+		if s.readOff < s.frontier {
+			break
+		}
+		if s.closed {
+			if s.err != nil {
+				return 0, s.err
+			}
+			return 0, io.EOF
+		}
+		s.cond.Wait()
+	}
+	n := min(int64(len(p)), s.frontier-s.readOff, s.chunkSize-s.readOff%s.chunkSize)
+	slot := (s.readOff / s.chunkSize) % s.n
+	copy(p[:n], s.pages[slot][s.readOff%s.chunkSize:][:n])
+	s.readOff += n
+	s.cond.Broadcast()
+	return int(n), nil
+}
+
+// closeWrite marks the write side finished; err (nil on success) is surfaced
+// to Read after the buffered bytes drain. A nil err with incomplete coverage
+// from offset 0 is reported as an error so a gap can never silently truncate
+// the stream.
+func (s *streamBuffer) closeWrite(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err == nil && len(s.pending) > 0 {
+		err = errors.Errorf("stream buffer: write coverage gap at offset %d", s.frontier)
+	}
+	s.closed = true
+	if s.err == nil {
+		s.err = err
+	}
+	s.cond.Broadcast()
+}
+
+// Close releases the buffer, unblocking any blocked WriteAt or Read.
+// Cancelling the download itself is the caller's responsibility.
+func (s *streamBuffer) Close() error {
+	s.mu.Lock()
+	s.rclosed = true
+	s.cond.Broadcast()
+	s.mu.Unlock()
+	return nil
+}
+
+// extendLocked records [start, end) as written and advances the contiguous
+// frontier over any pending intervals it now reaches. Callers must hold mu.
+func (s *streamBuffer) extendLocked(start, end int64) {
+	if start == s.frontier && len(s.pending) == 0 {
+		s.frontier = end
+		return
+	}
+	s.pending = append(s.pending, writeInterval{start, end})
+	slices.SortFunc(s.pending, func(a, b writeInterval) int { return cmp.Compare(a.start, b.start) })
+	merged := s.pending[:1]
+	for _, iv := range s.pending[1:] {
+		if last := &merged[len(merged)-1]; iv.start <= last.end {
+			last.end = max(last.end, iv.end)
+		} else {
+			merged = append(merged, iv)
+		}
+	}
+	s.pending = merged
+	for len(s.pending) > 0 && s.pending[0].start <= s.frontier {
+		s.frontier = max(s.frontier, s.pending[0].end)
+		s.pending = s.pending[1:]
+	}
+}

--- a/client/stream_buffer_internal_test.go
+++ b/client/stream_buffer_internal_test.go
@@ -1,0 +1,222 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
+)
+
+func testPattern(n int) []byte {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	return data
+}
+
+func TestStreamBufferRoundTrip(t *testing.T) {
+	data := testPattern(1000)
+	buf := newStreamBuffer(16, 2) // window 64, much smaller than the object
+	read := make(chan []byte, 1)
+	go func() {
+		got, err := io.ReadAll(buf)
+		assert.NoError(t, err)
+		read <- got
+	}()
+	n, err := buf.WriteAt(data, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	buf.closeWrite(nil)
+	assert.Equal(t, data, <-read)
+}
+
+func TestStreamBufferOutOfOrderChunks(t *testing.T) {
+	data := testPattern(64)
+	buf := newStreamBuffer(16, 2)
+	for _, off := range []int64{48, 16, 32, 0} {
+		_, err := buf.WriteAt(data[off:off+16], off)
+		assert.NoError(t, err)
+	}
+	buf.closeWrite(nil)
+	got, err := io.ReadAll(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestStreamBufferBackpressure(t *testing.T) {
+	buf := newStreamBuffer(16, 1) // window 32
+	_, err := buf.WriteAt(make([]byte, 32), 0)
+	assert.NoError(t, err)
+
+	var wrote atomic.Bool
+	unblocked := make(chan struct{})
+	go func() {
+		_, err := buf.WriteAt(make([]byte, 16), 32) // beyond the window: must block
+		assert.NoError(t, err)
+		wrote.Store(true)
+		close(unblocked)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	assert.False(t, wrote.Load())
+
+	got := make([]byte, 16)
+	_, err = io.ReadFull(buf, got)
+	assert.NoError(t, err)
+	select {
+	case <-unblocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("write did not unblock after reader progress")
+	}
+}
+
+func TestStreamBufferPartialReadDoesNotFreeSlot(t *testing.T) {
+	// A write one full ring ahead shares a page slot with the page currently
+	// being read; it must stay blocked until that page is wholly consumed, or
+	// it would overwrite the unread tail.
+	data := testPattern(48)
+	buf := newStreamBuffer(16, 1) // 2 pages: offset 32 reuses page 0's slot
+	_, err := buf.WriteAt(data[:32], 0)
+	assert.NoError(t, err)
+
+	head := make([]byte, 4)
+	_, err = io.ReadFull(buf, head) // partial read of page 0
+	assert.NoError(t, err)
+
+	var wrote atomic.Bool
+	unblocked := make(chan struct{})
+	go func() {
+		_, err := buf.WriteAt(data[32:48], 32)
+		assert.NoError(t, err)
+		wrote.Store(true)
+		close(unblocked)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	assert.False(t, wrote.Load(), "write into a partially read page's slot must block")
+
+	rest := make([]byte, 12)
+	_, err = io.ReadFull(buf, rest) // finish page 0: slot is now free
+	assert.NoError(t, err)
+	select {
+	case <-unblocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("write did not unblock after the page was fully read")
+	}
+	buf.closeWrite(nil)
+	tail, err := io.ReadAll(buf)
+	assert.NoError(t, err)
+	got := slices.Concat(head, rest, tail)
+	assert.Equal(t, data, got)
+}
+
+func TestStreamBufferCoverageGap(t *testing.T) {
+	buf := newStreamBuffer(16, 2)
+	_, err := buf.WriteAt(make([]byte, 16), 32) // never write [0, 32)
+	assert.NoError(t, err)
+	buf.closeWrite(nil)
+	_, err = io.ReadAll(buf)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "coverage gap")
+}
+
+func TestStreamBufferWriteErrorSurfacesAfterDrain(t *testing.T) {
+	data := testPattern(16)
+	buf := newStreamBuffer(16, 2)
+	_, err := buf.WriteAt(data, 0)
+	assert.NoError(t, err)
+	buf.closeWrite(errors.New("boom"))
+	got := make([]byte, 16)
+	_, err = io.ReadFull(buf, got)
+	assert.NoError(t, err)
+	assert.Equal(t, data, got)
+	_, err = buf.Read(got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestStreamBufferCloseUnblocksWriter(t *testing.T) {
+	buf := newStreamBuffer(16, 1) // window 32
+	_, err := buf.WriteAt(make([]byte, 32), 0)
+	assert.NoError(t, err)
+	result := make(chan error, 1)
+	go func() {
+		_, err := buf.WriteAt(make([]byte, 16), 32)
+		result <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	assert.NoError(t, buf.Close())
+	select {
+	case err := <-result:
+		assert.IsError(t, err, io.ErrClosedPipe)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not unblock the writer")
+	}
+}
+
+// rangedReader serves correct byte ranges with an ETag, optionally delaying
+// earlier offsets so chunks complete out of order, and optionally failing the
+// chunk starting at failAt (-1 to disable).
+type rangedReader struct {
+	data   []byte
+	delay  bool
+	failAt int64
+}
+
+func (r *rangedReader) Open(_ context.Context, _ Key, opts ...RequestOption) (io.ReadCloser, http.Header, error) {
+	const etag = `"v1"`
+	size := int64(len(r.data))
+	start, length, outcome := NewRequestOptions(opts...).ResolveRange(size, etag)
+	headers := http.Header{}
+	if outcome == RangeNotSatisfiable {
+		headers.Set("Content-Range", fmt.Sprintf("bytes */%d", size))
+		return nil, headers, ErrRangeNotSatisfiable
+	}
+	if outcome == RangePartial {
+		if start == r.failAt {
+			return nil, nil, errors.New("boom")
+		}
+		if r.delay {
+			time.Sleep(time.Duration(size-start) / 100 * time.Millisecond)
+		}
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+length-1, size))
+	}
+	headers.Set(ETagKey, etag)
+	headers.Set("Content-Length", strconv.FormatInt(length, 10))
+	return io.NopCloser(bytes.NewReader(r.data[start : start+length])), headers, nil
+}
+
+func TestParallelGetIntoStreamBuffer(t *testing.T) {
+	data := testPattern(10_000)
+	c := &rangedReader{data: data, delay: true, failAt: -1}
+	buf := newStreamBuffer(1000, 4)
+	go func() {
+		buf.closeWrite(ParallelGet(context.Background(), c, NewKey("k"), buf, 1000, 4))
+	}()
+	got, err := io.ReadAll(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestParallelGetIntoStreamBufferChunkFailure(t *testing.T) {
+	// A failing chunk must not deadlock workers blocked in WriteAt: dispatch
+	// run-ahead is bounded so their writes fit the window once the reader
+	// drains to the gap, and the reader then surfaces the download error.
+	data := testPattern(100_000)
+	c := &rangedReader{data: data, failAt: 50_000}
+	buf := newStreamBuffer(1000, 4)
+	go func() {
+		buf.closeWrite(ParallelGet(context.Background(), c, NewKey("k"), buf, 1000, 4))
+	}()
+	_, err := io.ReadAll(buf)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}

--- a/cmd/cachew/git.go
+++ b/cmd/cachew/git.go
@@ -47,17 +47,14 @@ type GitCmd struct {
 // ensure those refs/commits are fresh and runs `git pull --ff-only` so the
 // working tree catches up to upstream.
 type GitRestoreCmd struct {
-	RepoURL     string            `arg:"" help:"Repository URL (e.g. https://github.com/org/repo)."`
-	Directory   string            `arg:"" help:"Target directory for the clone." type:"path"`
-	Ref         map[string]string `help:"Required refs to freshen on the server before pulling, in the form 'name=sha' (e.g. 'refs/heads/main=abc123'). An empty SHA means any SHA is acceptable. Setting this (or --commit) runs a final 'git pull' from origin so the working tree is brought up to date."`
-	Commit      []string          `help:"Required commit SHAs that must exist on the server, regardless of which ref points at them. May be repeated."`
-	NoBundle    bool              `help:"Skip applying delta bundle."`
-	ZstdThreads int               `help:"Threads for zstd decompression (0 = all CPU cores)." default:"0"`
-	// DownloadConcurrency > 1 fetches the snapshot with that many concurrent
-	// range requests (requires server range support; falls back to a single
-	// request otherwise). 1 keeps the streaming single-request download.
-	DownloadConcurrency int `help:"Concurrent range requests for the snapshot download (1 = single streaming request)." default:"1"`
-	DownloadChunkSizeMB int `help:"Chunk size in MiB for parallel snapshot downloads." default:"8"`
+	RepoURL             string            `arg:"" help:"Repository URL (e.g. https://github.com/org/repo)."`
+	Directory           string            `arg:"" help:"Target directory for the clone." type:"path"`
+	Ref                 map[string]string `help:"Required refs to freshen on the server before pulling, in the form 'name=sha' (e.g. 'refs/heads/main=abc123'). An empty SHA means any SHA is acceptable. Setting this (or --commit) runs a final 'git pull' from origin so the working tree is brought up to date."`
+	Commit              []string          `help:"Required commit SHAs that must exist on the server, regardless of which ref points at them. May be repeated."`
+	NoBundle            bool              `help:"Skip applying delta bundle."`
+	ZstdThreads         int               `help:"Threads for zstd decompression (0 = all CPU cores)." default:"0"`
+	DownloadConcurrency int               `help:"Concurrent range requests for the snapshot download (1 = single streaming request)." default:"8"`
+	DownloadChunkSizeMB int               `help:"Chunk size in MiB for parallel snapshot downloads." default:"16"`
 }
 
 func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
@@ -116,27 +113,19 @@ func (c *GitRestoreCmd) Run(ctx context.Context, api *client.Client) error {
 	return nil
 }
 
-// fetchAndExtractSnapshot downloads the snapshot and extracts it into the target
-// directory, returning its freshen metadata (commit and bundle URL). With a
-// download concurrency above 1 it downloads in parallel into a temp file, since
-// ParallelGet needs a WriterAt; otherwise it streams the single response
-// directly into extraction.
+// fetchAndExtractSnapshot pipes the snapshot download straight into extraction
+// and returns its freshen metadata (commit and bundle URL).
 func (c *GitRestoreCmd) fetchAndExtractSnapshot(ctx context.Context, api *client.Client) (commit, bundleURL string, err error) {
-	if c.DownloadConcurrency > 1 {
-		return c.parallelFetchAndExtract(ctx, api)
-	}
-	return c.streamFetchAndExtract(ctx, api)
-}
-
-// streamFetchAndExtract downloads the snapshot in a single request and pipes the
-// response body straight into extraction, overlapping download and extraction.
-func (c *GitRestoreCmd) streamFetchAndExtract(ctx context.Context, api *client.Client) (string, string, error) {
 	var snap *client.GitSnapshot
 	if err := inSpan(ctx, "cachew.download_snapshot",
-		[]attribute.KeyValue{attribute.String("cachew.repo_url", c.RepoURL)},
+		[]attribute.KeyValue{
+			attribute.String("cachew.repo_url", c.RepoURL),
+			attribute.Int("cachew.download_concurrency", c.DownloadConcurrency),
+			attribute.Int("cachew.download_chunk_size_mb", c.DownloadChunkSizeMB),
+		},
 		func(ctx context.Context) error {
 			downloadStart := time.Now()
-			s, err := api.OpenGitSnapshot(ctx, c.RepoURL)
+			s, err := api.OpenGitSnapshotParallel(ctx, c.RepoURL, int64(c.DownloadChunkSizeMB)<<20, c.DownloadConcurrency)
 			if err != nil {
 				return err //nolint:wrapcheck // wrapped by caller
 			}
@@ -158,76 +147,52 @@ func (c *GitRestoreCmd) streamFetchAndExtract(ctx context.Context, api *client.C
 	return snap.Commit, snap.BundleURL, nil
 }
 
-// parallelFetchAndExtract downloads the snapshot into a temp file using bounded
-// concurrent range requests, then extracts from the file. ParallelGet writes via
-// WriteAt so it cannot stream into extraction; the temp file is removed on
-// return.
-func (c *GitRestoreCmd) parallelFetchAndExtract(ctx context.Context, api *client.Client) (string, string, error) {
-	// Stage the temp snapshot on the same filesystem as the restore target so a
-	// small or separate /tmp can't fail a restore the target directory has room
-	// for. The parent of c.Directory shares its filesystem and is created by
-	// extraction anyway.
-	tmpDir := filepath.Dir(c.Directory)
-	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
-		return "", "", errors.Wrap(err, "create snapshot temp dir")
-	}
-	tmp, err := os.CreateTemp(tmpDir, ".cachew-snapshot-*.tar.zst")
-	if err != nil {
-		return "", "", errors.Wrap(err, "create snapshot temp file")
-	}
-	defer func() {
-		_ = tmp.Close()
-		_ = os.Remove(tmp.Name()) //nolint:gosec // name is from os.CreateTemp, not external input
-	}()
-
-	var meta client.GitSnapshotMetadata
-	if err := inSpan(ctx, "cachew.download_snapshot",
-		[]attribute.KeyValue{
-			attribute.String("cachew.repo_url", c.RepoURL),
-			attribute.Int("cachew.download_concurrency", c.DownloadConcurrency),
-			attribute.Int("cachew.download_chunk_size_mb", c.DownloadChunkSizeMB),
-		},
-		func(ctx context.Context) error {
-			downloadStart := time.Now()
-			m, err := api.DownloadGitSnapshot(ctx, c.RepoURL, tmp, int64(c.DownloadChunkSizeMB)<<20, c.DownloadConcurrency)
-			if err != nil {
-				return err //nolint:wrapcheck // wrapped by caller
-			}
-			meta = m
-			trace.SpanFromContext(ctx).SetAttributes(
-				attribute.String("cachew.snapshot_commit", m.Commit),
-				attribute.String("cachew.bundle_url", m.BundleURL),
-				attribute.Float64("cachew.elapsed_seconds", time.Since(downloadStart).Seconds()),
-			)
-			return nil
-		}); err != nil {
-		return "", "", err
-	}
-
-	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
-		return "", "", errors.Wrap(err, "rewind snapshot temp file")
-	}
-	if err := c.extract(ctx, tmp); err != nil {
-		return "", "", err
-	}
-	return meta.Commit, meta.BundleURL, nil
-}
-
-// extract decompresses and unpacks the snapshot body into the target directory.
+// extract unpacks the snapshot into a staging directory renamed into place on
+// success, so a mid-download failure cannot leave a half-written checkout.
+// When the target directory already exists it extracts directly into it,
+// preserving restores over an existing checkout (rename would fail on a
+// non-empty destination).
 func (c *GitRestoreCmd) extract(ctx context.Context, body io.Reader) error {
+	// Clean strips trailing separators so filepath.Dir yields the true parent;
+	// otherwise MkdirAll would create the target itself and bypass staging.
+	target := filepath.Clean(c.Directory)
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return errors.Wrap(err, "create restore parent directory")
+	}
+	dest := target
+	staged := false
+	if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+		staging, err := os.MkdirTemp(parent, ".cachew-restore-*")
+		if err != nil {
+			return errors.Wrap(err, "create restore staging directory")
+		}
+		defer os.RemoveAll(staging) //nolint:errcheck // best-effort cleanup; a no-op once renamed into place
+		dest, staged = staging, true
+	}
+
 	fmt.Fprintf(os.Stderr, "Extracting to %s...\n", c.Directory) //nolint:forbidigo,gosec // c.Directory is an operator-supplied CLI path
-	return inSpan(ctx, "cachew.extract",
+	if err := inSpan(ctx, "cachew.extract",
 		[]attribute.KeyValue{attribute.String("cachew.directory", c.Directory)},
 		func(ctx context.Context) error {
 			extractStart := time.Now()
-			if err := snapshot.Extract(ctx, body, c.Directory, c.ZstdThreads); err != nil {
+			if err := snapshot.Extract(ctx, body, dest, c.ZstdThreads); err != nil {
 				return err //nolint:wrapcheck // wrapped by caller
 			}
 			elapsed := time.Since(extractStart)
 			trace.SpanFromContext(ctx).SetAttributes(attribute.Float64("cachew.elapsed_seconds", elapsed.Seconds()))
 			fmt.Fprintf(os.Stderr, "Snapshot extracted in %s\n", elapsed) //nolint:forbidigo
 			return nil
-		})
+		}); err != nil {
+		return err
+	}
+
+	if staged {
+		if err := os.Rename(dest, target); err != nil {
+			return errors.Wrap(err, "move restored snapshot into place")
+		}
+	}
+	return nil
 }
 
 // satisfyRefs ensures the working tree contains every requested ref and

--- a/cmd/cachew/git_test.go
+++ b/cmd/cachew/git_test.go
@@ -177,6 +177,49 @@ func TestGitRestoreSnapshotParallel(t *testing.T) {
 	}
 }
 
+func TestGitRestoreIntoExistingDirectory(t *testing.T) {
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir, map[string]string{"hello.txt": "hello world"})
+	snapshotData := createTarZst(t, srcDir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/snapshot.tar.zst") {
+			w.Header().Set("Content-Type", "application/zstd")
+			w.Write(snapshotData) //nolint:errcheck
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	assert.NoError(t, os.MkdirAll(dstDir, 0o750))
+	assert.NoError(t, os.WriteFile(filepath.Join(dstDir, "existing.txt"), []byte("keep me"), 0o600))
+
+	cmd := &GitRestoreCmd{
+		RepoURL:   "https://github.com/test/repo",
+		Directory: dstDir,
+	}
+	api := client.NewWithHTTPClient(srv.URL, srv.Client())
+	assert.NoError(t, cmd.Run(context.Background(), api))
+
+	content, err := os.ReadFile(filepath.Join(dstDir, "hello.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", string(content))
+	content, err = os.ReadFile(filepath.Join(dstDir, "existing.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, "keep me", string(content))
+}
+
+func TestGitRestoreExtractStagesTrailingSlashTarget(t *testing.T) {
+	dstDir := filepath.Join(t.TempDir(), "restored")
+	cmd := &GitRestoreCmd{Directory: dstDir + string(filepath.Separator)}
+	err := cmd.extract(context.Background(), strings.NewReader("not a zstd stream"))
+	assert.Error(t, err)
+	_, err = os.Stat(dstDir)
+	assert.True(t, os.IsNotExist(err), "failed restore must not create the target directory")
+}
+
 func TestGitRestoreWithBundle(t *testing.T) {
 	srcDir := t.TempDir()
 	initGitRepo(t, srcDir, map[string]string{"file.txt": "v1"})


### PR DESCRIPTION
Downloads git snapshots with up to N concurrent range requests (`--download-concurrency`, default 8) reassembled in order by an in-memory `StreamSink` that pipes straight into zstd→tar extraction, so transfer and extraction overlap.

Memory is bounded regardless of snapshot size: the sink holds a fixed arena of 2×concurrency chunk buffers, and fetchers block once they are a full window ahead of the consumer, capping peak buffering at 2×concurrency×chunkSize — 256 MiB at the best-observed tuning of 16 MiB chunks × concurrency 8.

Chunks are pinned to the discovery response's ETag, so a mid-download rewrite fails the download rather than splicing bytes from different object versions. Servers without range support, objects without ETags, and small objects fall back transparently to a single streaming request. Extraction goes to a staging directory renamed into place only on success, so a failed download cannot leave a half-written checkout.

End-to-end benchmarking against a real multi-replica deployment showed this in-memory streaming approach consistently outperformed disk-backed reassembly (ring buffer and spill-file variants, which lack backpressure or pay a disk round-trip), restoring large repositories 1.4–2.8× faster than the sequential baseline.
