### PR TITLE
fix(git): freshen mirror in snapshot job, not per request

### DIFF
--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -377,7 +377,6 @@ func (s *Strategy) serveReadyRepo(w http.ResponseWriter, r *http.Request, repo *
 		s.forwardToUpstream(w, r, host, pathValue)
 		return nil
 	}
-	s.maybeBackgroundFetch(repo)
 
 	// Buffer the request body so it can be replayed if serveFromBackend
 	// signals a fallback to upstream (e.g. on "not our ref").
@@ -706,13 +705,6 @@ func (s *Strategy) tryRestoreSnapshot(ctx context.Context, repo *gitclone.Reposi
 
 	logger.InfoContext(ctx, "Repository restored from snapshot", "upstream", repo.UpstreamURL())
 	return nil
-}
-
-func (s *Strategy) maybeBackgroundFetch(repo *gitclone.Repository) {
-	if !repo.NeedsFetch(s.cloneManager.Config().FetchInterval) {
-		return
-	}
-	s.submitFetch(repo)
 }
 
 // submitFetch schedules a fetch unconditionally. Use this when ls-remote has

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -204,6 +204,9 @@ func (s *Strategy) generateAndUploadMirrorSnapshot(ctx context.Context, repo *gi
 
 func (s *Strategy) scheduleSnapshotJobs(repo *gitclone.Repository) {
 	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "snapshot-periodic", s.config.SnapshotInterval, func(ctx context.Context) error {
+		if err := s.doFetch(ctx, repo); err != nil {
+			logging.FromContext(ctx).WarnContext(ctx, "Pre-snapshot fetch failed", "upstream", repo.UpstreamURL(), "error", err)
+		}
 		return s.generateAndUploadSnapshot(ctx, repo)
 	})
 	s.scheduler.SubmitPeriodicJob(repo.UpstreamURL(), "lfs-snapshot-periodic", s.config.SnapshotInterval, func(ctx context.Context) error {
@@ -307,7 +310,6 @@ func (s *Strategy) handleSnapshotRequest(w http.ResponseWriter, r *http.Request,
 		http.Error(w, "Repository unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	s.maybeBackgroundFetch(repo)
 
 	// Forward the full conditional/range set: the cache resolves If-Match /
 	// If-None-Match before Range, so 304/412 already take precedence over a


### PR DESCRIPTION
Snapshot and git request paths called maybeBackgroundFetch on every
request, which is time-based and un-deduplicated. A parallel snapshot
restore burst made every concurrent request enqueue its own fetch,
flooding the per-repo fetch queue with back-to-back fetches.

Move mirror freshening into the periodic snapshot job (fetch then
snapshot) and drop maybeBackgroundFetch from the request paths.
