### PR TITLE
fix(cache): consult deeper tiers on ETag mismatch

### DIFF
--- a/client/parallel_get.go
+++ b/client/parallel_get.go
@@ -26,11 +26,12 @@ type RangeReader interface {
 //
 // The first chunk is fetched with a ranged Open, whose response yields both the
 // total size (from Content-Range) and the object's ETag; every remaining chunk
-// is then requested with IfRange pinned to that ETag. If the object changes
-// mid-download, a chunk's ETag will differ and ParallelGet returns an error
-// rather than splicing bytes from two revisions. A missing or truncated chunk
-// is likewise reported as an error, so a partially written dst must be discarded
-// by the caller on failure. An object with no ETag to pin to (e.g. one stored
+// is then requested with IfMatch pinned to that ETag. If the object changes
+// mid-download, the chunk is rejected with a bodiless ErrPreconditionFailed
+// (412) and ParallelGet returns an error rather than splicing bytes from two
+// revisions; a server that ignores If-Match is caught by verifying each chunk's
+// response ETag. A missing or truncated chunk is likewise reported as an error,
+// so a partially written dst must be discarded by the caller on failure. An object with no ETag to pin to (e.g. one stored
 // before ETags were recorded) cannot be kept revision-safe across chunks, so it
 // falls back to a single full read instead of parallelising. A concurrency of
 // 1 likewise reads the whole object in one request, since chunking a single
@@ -77,11 +78,11 @@ func ParallelGet(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, c
 		return errors.Wrap(writeChunkAt(dst, 0, firstLen, rc), "parallel get")
 	}
 
-	// Subsequent chunks are pinned to the discovery ETag via IfRange. Without a
-	// validator there is nothing to pin to (IfRange("") is a no-op and an empty
-	// ETag matches an empty ETag), so chunks could be spliced across a rewrite
-	// undetected. Objects stored before ETags were recorded fall here, so fall
-	// back to a single, revision-consistent read rather than parallelising.
+	// Subsequent chunks are pinned to the discovery ETag via IfMatch. Without a
+	// validator there is nothing to pin to (IfMatch("") is a no-op), so chunks
+	// could be spliced across a rewrite undetected. Objects stored before ETags
+	// were recorded fall here, so fall back to a single, revision-consistent
+	// read rather than parallelising.
 	if etag == "" {
 		if err := rc.Close(); err != nil {
 			return errors.Wrap(err, "parallel get: close discovery reader")
@@ -121,11 +122,16 @@ func fullRead(ctx context.Context, c RangeReader, key Key, dst io.WriterAt) erro
 	return errors.Wrap(writeChunkAt(dst, 0, -1, rc), "parallel get")
 }
 
-// fetchChunk opens the [start, end) range pinned to etag and writes it at start.
-// An ETag change (the object was rewritten mid-download) or a short read is
-// reported as an error.
+// fetchChunk opens the [start, end) range pinned to etag via If-Match and
+// writes it at start. An ETag change (the object was rewritten mid-download)
+// surfaces as ErrPreconditionFailed, or as a response-ETag mismatch when the
+// server ignores If-Match; either way it is reported as an error, as is a
+// short read.
 func fetchChunk(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, start, end int64, etag string) error {
-	rc, headers, err := c.Open(ctx, key, Range(start, end), IfRange(etag))
+	rc, headers, err := c.Open(ctx, key, Range(start, end), IfMatch(etag))
+	if errors.Is(err, ErrPreconditionFailed) {
+		return errors.Errorf("open range %d-%d: object changed during read: %w", start, end, err)
+	}
 	if err != nil {
 		return errors.Errorf("open range %d-%d: %w", start, end, err)
 	}

--- a/client/parallel_get_test.go
+++ b/client/parallel_get_test.go
@@ -249,8 +249,6 @@ func TestParallelGetSingleWorkerFullRead(t *testing.T) {
 }
 
 func TestParallelGetPinsChunksWithIfMatch(t *testing.T) {
-	// Every chunk after discovery must carry the discovery ETag as an If-Match
-	// precondition, so a version change is rejected server-side without a body.
 	data := make([]byte, 1000)
 	for i := range data {
 		data[i] = byte(i % 251)

--- a/client/parallel_get_test.go
+++ b/client/parallel_get_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -36,8 +38,10 @@ func (b *bufferAt) WriteAt(p []byte, off int64) (int, error) {
 	return len(p), nil
 }
 
-// rangeFlipReader serves correct byte ranges but reports a different ETag for
-// any chunk past the first, simulating an object rewritten mid-download.
+// rangeFlipReader serves correct byte ranges but ignores If-Match and reports
+// a different ETag for any chunk past the first, simulating an object
+// rewritten mid-download behind a server that does not honour preconditions.
+// It exercises the client-side response-ETag guard.
 type rangeFlipReader struct {
 	data      []byte
 	firstETag string
@@ -70,6 +74,47 @@ func TestParallelGetETagMismatch(t *testing.T) {
 	var dst bufferAt
 	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "object changed during read")
+}
+
+// ifMatchFlipReader honours If-Match like a conforming server whose object is
+// rewritten after the discovery request, so every pinned chunk fails its
+// precondition with a bodiless rejection.
+type ifMatchFlipReader struct {
+	data      []byte
+	firstETag string
+	restETag  string
+}
+
+func (f *ifMatchFlipReader) Open(_ context.Context, _ client.Key, opts ...client.RequestOption) (io.ReadCloser, http.Header, error) {
+	o := client.NewRequestOptions(opts...)
+	etag := f.firstETag
+	if o.IfMatch != "" {
+		etag = f.restETag
+	}
+	if err := o.Check(etag); err != nil {
+		return nil, nil, err
+	}
+	size := int64(len(f.data))
+	start, length, outcome := o.ResolveRange(size, etag)
+	headers := http.Header{}
+	if outcome == client.RangeNotSatisfiable {
+		headers.Set("Content-Range", fmt.Sprintf("bytes */%d", size))
+		return nil, headers, client.ErrRangeNotSatisfiable
+	}
+	headers.Set(client.ETagKey, etag)
+	headers.Set("Content-Length", strconv.FormatInt(length, 10))
+	if outcome == client.RangePartial {
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, start+length-1, size))
+	}
+	return io.NopCloser(bytes.NewReader(f.data[start : start+length])), headers, nil
+}
+
+func TestParallelGetPreconditionFailedOnRewrite(t *testing.T) {
+	c := &ifMatchFlipReader{data: make([]byte, 1000), firstETag: `"v1"`, restETag: `"v2"`}
+	var dst bufferAt
+	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+	assert.IsError(t, err, client.ErrPreconditionFailed)
 	assert.Contains(t, err.Error(), "object changed during read")
 }
 
@@ -147,21 +192,28 @@ func (c *changingSizeReader) Open(_ context.Context, _ client.Key, opts ...clien
 	return io.NopCloser(bytes.NewReader(c.discovery[start : start+length])), headers, nil
 }
 
-// recordingReader serves byte ranges and records the Range option of every
-// Open call ("" for a full, non-ranged read), so tests can assert how the
-// object was fetched.
+// openRecord captures the fetch-shaping options of a single Open call: the
+// Range requested ("" for a full read) and the If-Match validator it was
+// pinned to.
+type openRecord struct {
+	Range   string
+	IfMatch string
+}
+
+// recordingReader serves byte ranges and records an openRecord for every Open
+// call, so tests can assert how the object was fetched.
 type recordingReader struct {
 	data []byte
 	etag string
 
 	mu    sync.Mutex
-	opens []string
+	opens []openRecord
 }
 
 func (r *recordingReader) Open(_ context.Context, _ client.Key, opts ...client.RequestOption) (io.ReadCloser, http.Header, error) {
 	o := client.NewRequestOptions(opts...)
 	r.mu.Lock()
-	r.opens = append(r.opens, o.Range)
+	r.opens = append(r.opens, openRecord{Range: o.Range, IfMatch: o.IfMatch})
 	r.mu.Unlock()
 
 	size := int64(len(r.data))
@@ -193,7 +245,28 @@ func TestParallelGetSingleWorkerFullRead(t *testing.T) {
 	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, data, dst.buf)
-	assert.Equal(t, []string{""}, c.opens)
+	assert.Equal(t, []openRecord{{}}, c.opens)
+}
+
+func TestParallelGetPinsChunksWithIfMatch(t *testing.T) {
+	// Every chunk after discovery must carry the discovery ETag as an If-Match
+	// precondition, so a version change is rejected server-side without a body.
+	data := make([]byte, 1000)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	c := &recordingReader{data: data, etag: `"v1"`}
+	var dst bufferAt
+	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
+	assert.NoError(t, err)
+	assert.Equal(t, data, dst.buf)
+
+	expected := []openRecord{{Range: "bytes=0-99"}}
+	for seq := 1; seq < 10; seq++ {
+		expected = append(expected, openRecord{Range: fmt.Sprintf("bytes=%d-%d", seq*100, seq*100+99), IfMatch: `"v1"`})
+	}
+	slices.SortFunc(c.opens, func(a, b openRecord) int { return strings.Compare(a.Range, b.Range) })
+	assert.Equal(t, expected, c.opens)
 }
 
 func TestParallelGetNoETagSizeChangedBetweenRequests(t *testing.T) {

--- a/client/preconditions.go
+++ b/client/preconditions.go
@@ -135,16 +135,18 @@ const (
 	RangeNotSatisfiable
 )
 
+// IfRangeMisses reports whether a requested Range is dropped because the
+// If-Range validator does not match etag, in which case the full
+// representation is served in place of the range.
+func (o RequestOptions) IfRangeMisses(etag string) bool {
+	return o.Range != "" && o.IfRange != "" && o.IfRange != etag
+}
+
 // ResolveRange evaluates the Range/If-Range options against an object of the
 // given size and ETag. On RangePartial it returns the [start, start+length)
 // window to serve.
 func (o RequestOptions) ResolveRange(size int64, etag string) (start, length int64, outcome RangeOutcome) {
-	if o.Range == "" {
-		return 0, size, RangeFull
-	}
-	// If-Range only applies the range when its validator matches the stored
-	// ETag; otherwise the client is told to serve the full representation.
-	if o.IfRange != "" && o.IfRange != etag {
+	if o.Range == "" || o.IfRangeMisses(etag) {
 		return 0, size, RangeFull
 	}
 	return resolveByteRange(o.Range, size)

--- a/client/preconditions_test.go
+++ b/client/preconditions_test.go
@@ -28,6 +28,28 @@ func TestRangeFormat(t *testing.T) {
 	}
 }
 
+func TestIfRangeMisses(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		ifRange string
+		etag    string
+		want    bool
+	}{
+		{name: "NoRange", ifRange: `"e"`, etag: `"e"`, want: false},
+		{name: "NoIfRange", spec: "bytes=0-4", etag: `"e"`, want: false},
+		{name: "Match", spec: "bytes=0-4", ifRange: `"e"`, etag: `"e"`, want: false},
+		{name: "Mismatch", spec: "bytes=0-4", ifRange: `"e"`, etag: `"other"`, want: true},
+		{name: "NoStoredETag", spec: "bytes=0-4", ifRange: `"e"`, etag: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := client.RequestOptions{Range: tt.spec, IfRange: tt.ifRange}
+			assert.Equal(t, tt.want, o.IfRangeMisses(tt.etag))
+		})
+	}
+}
+
 func TestResolveRange(t *testing.T) {
 	const etag = `"e"`
 	tests := []struct {

--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -602,6 +602,24 @@ func testRange(t *testing.T, c cache.Cache) {
 		assert.Equal(t, "", headers.Get("Content-Range"))
 	})
 
+	sum := sha256.Sum256(content)
+	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+
+	t.Run("IfMatchHitServesRange", func(t *testing.T) {
+		reader, headers, err := c.Open(ctx, key, cache.Range(2, 6), cache.IfMatch(etag))
+		assert.NoError(t, err)
+		defer reader.Close()
+		data, err := io.ReadAll(reader)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("2345"), data)
+		assert.Equal(t, "bytes 2-5/10", headers.Get("Content-Range"))
+	})
+
+	t.Run("IfMatchMissRejectsRange", func(t *testing.T) {
+		_, _, err := c.Open(ctx, key, cache.Range(2, 6), cache.IfMatch(`"stale"`))
+		assert.IsError(t, err, cache.ErrPreconditionFailed)
+	})
+
 	t.Run("StatIgnoresRange", func(t *testing.T) {
 		headers, err := c.Stat(ctx, key, cache.Range(2, 6))
 		assert.NoError(t, err)

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -99,6 +99,7 @@ func (t Tiered) Delete(ctx context.Context, key Key) error {
 // If all caches fail, all errors are returned.
 func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header, error) {
 	rejected := false
+	var probeErrs []error
 	errs := make([]error, len(t.caches))
 	for i, c := range t.caches {
 		headers, err := c.Stat(ctx, key, opts...)
@@ -110,14 +111,15 @@ func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header,
 			rejected = true
 			continue
 		case err != nil && !errors.Is(err, ErrNotModified) && rejected:
-			// Probing deeper tiers is opportunistic: a hard error must not make
-			// the response worse than the 412 already in hand.
-			logging.FromContext(ctx).WarnContext(ctx, "Tiered: tier probe failed, continuing", "tier", c.String(), "key", key, "error", err)
+			probeErrs = append(probeErrs, errors.WithStack(err))
 			continue
 		}
 		// Any other outcome (success, ErrNotModified, or a hard error) is
 		// definitive for this tier; surface it with its headers.
 		return headers, errors.WithStack(err)
+	}
+	if len(probeErrs) > 0 {
+		return nil, errors.Join(probeErrs...)
 	}
 	if rejected {
 		return nil, errors.WithStack(ErrPreconditionFailed)
@@ -148,6 +150,7 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 	// fallback, served only if no deeper tier holds the pinned version.
 	var fallback io.ReadCloser
 	var fallbackHeaders http.Header
+	var probeErrs []error
 	rejected := false // a tier failed If-Match; deeper tiers may hold the named version
 	discard := func(r io.ReadCloser) {
 		if err := r.Close(); err != nil {
@@ -180,7 +183,7 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 			if fallback == nil && !rejected {
 				return nil, headers, errors.WithStack(err)
 			}
-			logging.FromContext(ctx).WarnContext(ctx, "Tiered: tier probe failed, continuing", "tier", c.String(), "key", key, "error", err)
+			probeErrs = append(probeErrs, errors.WithStack(err))
 			continue
 		case ro.IfRangeMisses(headers.Get(ETagKey)):
 			// This tier holds a different version than the range is pinned to:
@@ -199,6 +202,12 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 			r = t.backfillReader(ctx, key, r, headers, t.caches[0])
 		}
 		return r, headers, nil
+	}
+	if len(probeErrs) > 0 {
+		if fallback != nil {
+			probeErrs = append(probeErrs, fallback.Close())
+		}
+		return nil, nil, errors.Join(probeErrs...)
 	}
 	if fallback != nil {
 		return fallback, fallbackHeaders, nil

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -94,7 +94,8 @@ func (t Tiered) Delete(ctx context.Context, key Key) error {
 // A tier that fails an If-Match precondition holds a different version of the
 // object, not a definitive answer: deeper tiers are consulted for the version
 // the validator names, and ErrPreconditionFailed is only returned when none
-// holds it.
+// holds it. A tier that errored while being probed takes precedence, so
+// outages are not misreported as missing versions.
 //
 // If all caches fail, all errors are returned.
 func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header, error) {
@@ -137,7 +138,9 @@ func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header,
 // consulted for the named version, so a replica whose local tier has diverged
 // can still satisfy a pinned request from a shared tier. When no tier holds
 // it, the first tier's outcome stands: the full representation for an If-Range
-// miss (per RFC 9110), ErrPreconditionFailed for a failed If-Match.
+// miss (per RFC 9110), ErrPreconditionFailed for a failed If-Match. A tier
+// that errored while being probed takes precedence over both, so outages are
+// not misreported as missing versions.
 //
 // If all caches fail, all errors are returned.
 func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser, http.Header, error) {
@@ -177,9 +180,10 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 			}
 			return nil, headers, errors.WithStack(err)
 		case err != nil:
-			// A hard error only fails the request when no earlier tier produced
-			// a servable outcome; probing deeper tiers is opportunistic and must
-			// not make the response worse.
+			// A hard error is definitive when no earlier tier produced a
+			// servable outcome. Otherwise defer it: a deeper tier may still
+			// satisfy the validator, but if none does the error is surfaced in
+			// preference to the degraded fallback/412.
 			if fallback == nil && !rejected {
 				return nil, headers, errors.WithStack(err)
 			}

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -91,18 +91,36 @@ func (t Tiered) Delete(ctx context.Context, key Key) error {
 
 // Stat returns headers from the first cache that succeeds.
 //
+// A tier that fails an If-Match precondition holds a different version of the
+// object, not a definitive answer: deeper tiers are consulted for the version
+// the validator names, and ErrPreconditionFailed is only returned when none
+// holds it.
+//
 // If all caches fail, all errors are returned.
 func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header, error) {
+	rejected := false
 	errs := make([]error, len(t.caches))
 	for i, c := range t.caches {
 		headers, err := c.Stat(ctx, key, opts...)
 		errs[i] = err
-		if errors.Is(err, os.ErrNotExist) {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			continue
+		case errors.Is(err, ErrPreconditionFailed):
+			rejected = true
+			continue
+		case err != nil && !errors.Is(err, ErrNotModified) && rejected:
+			// Probing deeper tiers is opportunistic: a hard error must not make
+			// the response worse than the 412 already in hand.
+			logging.FromContext(ctx).WarnContext(ctx, "Tiered: tier probe failed, continuing", "tier", c.String(), "key", key, "error", err)
 			continue
 		}
-		// Any other outcome (success, ErrNotModified, ErrPreconditionFailed, or a
-		// hard error) is definitive for this tier; surface it with its headers.
+		// Any other outcome (success, ErrNotModified, or a hard error) is
+		// definitive for this tier; surface it with its headers.
 		return headers, errors.WithStack(err)
+	}
+	if rejected {
+		return nil, errors.WithStack(ErrPreconditionFailed)
 	}
 	return nil, errors.Join(errs...)
 }
@@ -112,28 +130,81 @@ func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header,
 // transparently backfills the lowest tier as the caller reads, so that
 // subsequent Opens are served locally.
 //
+// A tier that holds a different version than the request's validators name —
+// a failed If-Match, or an If-Range miss — is not definitive: deeper tiers are
+// consulted for the named version, so a replica whose local tier has diverged
+// can still satisfy a pinned request from a shared tier. When no tier holds
+// it, the first tier's outcome stands: the full representation for an If-Range
+// miss (per RFC 9110), ErrPreconditionFailed for a failed If-Match.
+//
 // If all caches fail, all errors are returned.
 func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser, http.Header, error) {
+	ro := NewRequestOptions(opts...)
 	// A Range request yields a partial body, which must never be backfilled
 	// into a lower tier as if it were the whole object.
-	partial := NewRequestOptions(opts...).Range != ""
+	partial := ro.Range != ""
+
+	// The first tier whose version missed If-Range supplies the full-body
+	// fallback, served only if no deeper tier holds the pinned version.
+	var fallback io.ReadCloser
+	var fallbackHeaders http.Header
+	rejected := false // a tier failed If-Match; deeper tiers may hold the named version
+	discard := func(r io.ReadCloser) {
+		if err := r.Close(); err != nil {
+			logging.FromContext(ctx).WarnContext(ctx, "Tiered: failed to close superseded reader", "key", key, "error", err)
+		}
+	}
+
 	errs := make([]error, len(t.caches))
 	for i, c := range t.caches {
 		r, headers, err := c.Open(ctx, key, opts...)
 		errs[i] = err
-		if errors.Is(err, os.ErrNotExist) {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			continue
+		case errors.Is(err, ErrPreconditionFailed):
+			rejected = true
+			continue
+		case errors.Is(err, ErrNotModified), errors.Is(err, ErrRangeNotSatisfiable):
+			// This tier's version satisfies the request's validator, so the
+			// outcome is definitive. Surface headers so callers can build the
+			// conditional response. No body to backfill.
+			if fallback != nil {
+				discard(fallback)
+			}
+			return nil, headers, errors.WithStack(err)
+		case err != nil:
+			// A hard error only fails the request when no earlier tier produced
+			// a servable outcome; probing deeper tiers is opportunistic and must
+			// not make the response worse.
+			if fallback == nil && !rejected {
+				return nil, headers, errors.WithStack(err)
+			}
+			logging.FromContext(ctx).WarnContext(ctx, "Tiered: tier probe failed, continuing", "tier", c.String(), "key", key, "error", err)
+			continue
+		case ro.IfRangeMisses(headers.Get(ETagKey)):
+			// This tier holds a different version than the range is pinned to:
+			// hold its full body as the fallback and probe deeper tiers.
+			if fallback != nil {
+				discard(r)
+				continue
+			}
+			fallback, fallbackHeaders = r, headers
 			continue
 		}
-		if err != nil {
-			// Definitive non-miss error (incl. ErrNotModified/ErrPreconditionFailed/
-			// ErrRangeNotSatisfiable): surface headers so callers can build the
-			// conditional response. No body to backfill.
-			return nil, headers, errors.WithStack(err)
+		if fallback != nil {
+			discard(fallback)
 		}
 		if i > 0 && !partial {
 			r = t.backfillReader(ctx, key, r, headers, t.caches[0])
 		}
 		return r, headers, nil
+	}
+	if fallback != nil {
+		return fallback, fallbackHeaders, nil
+	}
+	if rejected {
+		return nil, nil, errors.WithStack(ErrPreconditionFailed)
 	}
 	return nil, nil, errors.Join(errs...)
 }

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -1,6 +1,9 @@
 package cache_test
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +19,30 @@ import (
 	"github.com/block/cachew/internal/s3client"
 	"github.com/block/cachew/internal/s3client/s3clienttest"
 )
+
+// seedTier writes content to a single tier directly, so tests can diverge the
+// versions held by each tier.
+func seedTier(ctx context.Context, t *testing.T, c cache.Cache, key cache.Key, content []byte) {
+	t.Helper()
+	w, err := c.Create(ctx, key, nil, time.Minute)
+	assert.NoError(t, err)
+	_, err = w.Write(content)
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+}
+
+func contentETag(content []byte) string {
+	sum := sha256.Sum256(content)
+	return `"` + hex.EncodeToString(sum[:]) + `"`
+}
+
+func readAllAndClose(t *testing.T, r io.ReadCloser) []byte {
+	t.Helper()
+	data, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	return data
+}
 
 type cacheFactory struct {
 	name string
@@ -118,31 +145,134 @@ func TestTieredBackfillPermutations(t *testing.T) {
 			content := []byte("hello backfill")
 
 			// Write only to upper tier, simulating a lower-tier miss.
-			w, err := upper.Create(ctx, key, nil, time.Minute)
-			assert.NoError(t, err)
-			_, err = w.Write(content)
-			assert.NoError(t, err)
-			assert.NoError(t, w.Close())
+			seedTier(ctx, t, upper, key, content)
 
 			// Verify lower tier does not have it.
-			_, _, err = lower.Open(ctx, key)
+			_, _, err := lower.Open(ctx, key)
 			assert.IsError(t, err, os.ErrNotExist)
 
 			// Open through tiered — should hit upper and backfill lower.
 			r, _, err := tiered.Open(ctx, key)
 			assert.NoError(t, err)
-			data, err := io.ReadAll(r)
-			assert.NoError(t, err)
-			assert.NoError(t, r.Close())
-			assert.Equal(t, content, data)
+			assert.Equal(t, content, readAllAndClose(t, r))
 
 			// Now lower tier should have the entry via backfill.
 			r2, _, err := lower.Open(ctx, key)
 			assert.NoError(t, err)
-			data2, err := io.ReadAll(r2)
-			assert.NoError(t, err)
-			assert.NoError(t, r2.Close())
-			assert.Equal(t, content, data2)
+			assert.Equal(t, content, readAllAndClose(t, r2))
+		})
+	}
+}
+
+// TestTieredDivergentValidatorPermutations covers a replica whose local (lower)
+// tier holds a different version of an object than the shared (upper) tier:
+// requests pinned to a version via If-Range or If-Match must be satisfied by
+// whichever tier holds that version rather than answered from the first tier
+// that has any version.
+func TestTieredDivergentValidatorPermutations(t *testing.T) {
+	stale := []byte("0123456789")
+	pinned := []byte("abcdefghij")
+	staleETag := contentETag(stale)
+	pinnedETag := contentETag(pinned)
+
+	for _, perm := range tieredPermutations(t) {
+		t.Run(perm.name, func(t *testing.T) {
+			_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+			lower := perm.lower.new(t)
+			upper := perm.upper.new(t)
+			tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper})
+			defer tiered.Close()
+
+			keyBoth := cache.NewKey("divergent-both")
+			seedTier(ctx, t, lower, keyBoth, stale)
+			seedTier(ctx, t, upper, keyBoth, pinned)
+
+			keyLowerOnly := cache.NewKey("divergent-lower-only")
+			seedTier(ctx, t, lower, keyLowerOnly, stale)
+
+			t.Run("IfRangePinnedToUpperServesRangeFromUpper", func(t *testing.T) {
+				r, headers, err := tiered.Open(ctx, keyBoth, cache.Range(2, 6), cache.IfRange(pinnedETag))
+				assert.NoError(t, err)
+				assert.Equal(t, []byte("cdef"), readAllAndClose(t, r))
+				assert.Equal(t, "bytes 2-5/10", headers.Get("Content-Range"))
+				assert.Equal(t, pinnedETag, headers.Get(cache.ETagKey))
+			})
+
+			t.Run("IfRangePinnedToLowerServesRangeFromLower", func(t *testing.T) {
+				r, headers, err := tiered.Open(ctx, keyBoth, cache.Range(2, 6), cache.IfRange(staleETag))
+				assert.NoError(t, err)
+				assert.Equal(t, []byte("2345"), readAllAndClose(t, r))
+				assert.Equal(t, staleETag, headers.Get(cache.ETagKey))
+			})
+
+			t.Run("IfRangeMissingEverywhereServesFullFromLower", func(t *testing.T) {
+				r, headers, err := tiered.Open(ctx, keyBoth, cache.Range(2, 6), cache.IfRange(`"unknown"`))
+				assert.NoError(t, err)
+				assert.Equal(t, stale, readAllAndClose(t, r))
+				assert.Equal(t, "", headers.Get("Content-Range"))
+				assert.Equal(t, staleETag, headers.Get(cache.ETagKey))
+			})
+
+			t.Run("IfRangePinnedUpperMissingServesFullFromLower", func(t *testing.T) {
+				r, headers, err := tiered.Open(ctx, keyLowerOnly, cache.Range(2, 6), cache.IfRange(pinnedETag))
+				assert.NoError(t, err)
+				assert.Equal(t, stale, readAllAndClose(t, r))
+				assert.Equal(t, "", headers.Get("Content-Range"))
+			})
+
+			t.Run("IfMatchPinnedToUpperServesRangeFromUpper", func(t *testing.T) {
+				r, headers, err := tiered.Open(ctx, keyBoth, cache.Range(2, 6), cache.IfMatch(pinnedETag))
+				assert.NoError(t, err)
+				assert.Equal(t, []byte("cdef"), readAllAndClose(t, r))
+				assert.Equal(t, "bytes 2-5/10", headers.Get("Content-Range"))
+				assert.Equal(t, pinnedETag, headers.Get(cache.ETagKey))
+
+				// A partial body must never be backfilled: the lower tier keeps
+				// its own version.
+				r2, _, err := lower.Open(ctx, keyBoth)
+				assert.NoError(t, err)
+				assert.Equal(t, stale, readAllAndClose(t, r2))
+			})
+
+			t.Run("IfMatchMissingEverywhereReturnsPreconditionFailed", func(t *testing.T) {
+				_, _, err := tiered.Open(ctx, keyBoth, cache.Range(2, 6), cache.IfMatch(`"unknown"`))
+				assert.IsError(t, err, cache.ErrPreconditionFailed)
+				_, err = tiered.Stat(ctx, keyBoth, cache.IfMatch(`"unknown"`))
+				assert.IsError(t, err, cache.ErrPreconditionFailed)
+			})
+
+			t.Run("IfMatchPinnedUpperMissingReturnsPreconditionFailed", func(t *testing.T) {
+				_, _, err := tiered.Open(ctx, keyLowerOnly, cache.Range(2, 6), cache.IfMatch(pinnedETag))
+				assert.IsError(t, err, cache.ErrPreconditionFailed)
+			})
+
+			t.Run("StatIfMatchPinnedToUpperReturnsUpperHeaders", func(t *testing.T) {
+				headers, err := tiered.Stat(ctx, keyBoth, cache.IfMatch(pinnedETag))
+				assert.NoError(t, err)
+				assert.Equal(t, pinnedETag, headers.Get(cache.ETagKey))
+			})
+
+			t.Run("IfNoneMatchLowerRemainsDefinitive", func(t *testing.T) {
+				_, _, err := tiered.Open(ctx, keyBoth, cache.IfNoneMatch(staleETag))
+				assert.IsError(t, err, cache.ErrNotModified)
+			})
+
+			t.Run("IfMatchFullReadBackfillsLower", func(t *testing.T) {
+				keyHeal := cache.NewKey("divergent-heal")
+				seedTier(ctx, t, lower, keyHeal, stale)
+				seedTier(ctx, t, upper, keyHeal, pinned)
+
+				r, headers, err := tiered.Open(ctx, keyHeal, cache.IfMatch(pinnedETag))
+				assert.NoError(t, err)
+				assert.Equal(t, pinned, readAllAndClose(t, r))
+				assert.Equal(t, pinnedETag, headers.Get(cache.ETagKey))
+
+				// A full-body serve from the upper tier heals the divergent
+				// lower tier via the usual backfill.
+				r2, _, err := lower.Open(ctx, keyHeal)
+				assert.NoError(t, err)
+				assert.Equal(t, pinned, readAllAndClose(t, r2))
+			})
 		})
 	}
 }
@@ -160,11 +290,7 @@ func TestTieredDeletePermutations(t *testing.T) {
 			content := []byte("delete me")
 
 			// Write through tiered so both tiers have the entry.
-			w, err := tiered.Create(ctx, key, nil, time.Minute)
-			assert.NoError(t, err)
-			_, err = w.Write(content)
-			assert.NoError(t, err)
-			assert.NoError(t, w.Close())
+			seedTier(ctx, t, tiered, key, content)
 
 			// Verify both tiers have it.
 			r, _, err := lower.Open(ctx, key)

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
 
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/cache/cachetest"
@@ -42,6 +44,25 @@ func readAllAndClose(t *testing.T, r io.ReadCloser) []byte {
 	assert.NoError(t, err)
 	assert.NoError(t, r.Close())
 	return data
+}
+
+type failingCache struct {
+	cache.Cache
+	err error
+}
+
+func newFailingCache(err error) cache.Cache {
+	return failingCache{Cache: cache.NoOpCache(), err: err}
+}
+
+func (c failingCache) String() string { return "failing" }
+
+func (c failingCache) Stat(_ context.Context, _ cache.Key, _ ...cache.Option) (http.Header, error) {
+	return nil, c.err
+}
+
+func (c failingCache) Open(_ context.Context, _ cache.Key, _ ...cache.Option) (io.ReadCloser, http.Header, error) {
+	return nil, nil, c.err
 }
 
 type cacheFactory struct {
@@ -164,11 +185,6 @@ func TestTieredBackfillPermutations(t *testing.T) {
 	}
 }
 
-// TestTieredDivergentValidatorPermutations covers a replica whose local (lower)
-// tier holds a different version of an object than the shared (upper) tier:
-// requests pinned to a version via If-Range or If-Match must be satisfied by
-// whichever tier holds that version rather than answered from the first tier
-// that has any version.
 func TestTieredDivergentValidatorPermutations(t *testing.T) {
 	stale := []byte("0123456789")
 	pinned := []byte("abcdefghij")
@@ -274,6 +290,50 @@ func TestTieredDivergentValidatorPermutations(t *testing.T) {
 				assert.Equal(t, pinned, readAllAndClose(t, r2))
 			})
 		})
+	}
+}
+
+func TestTieredDivergentValidatorProbeErrors(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	outage := errors.New("backend unavailable")
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, newFailingCache(outage)})
+	defer tiered.Close()
+
+	key := cache.NewKey("divergent-probe-error")
+	stale := []byte("0123456789")
+	seedTier(ctx, t, lower, key, stale)
+
+	pinnedETag := contentETag([]byte("abcdefghij"))
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "OpenIfMatchReturnsProbeError",
+			run: func(t *testing.T) {
+				_, _, err := tiered.Open(ctx, key, cache.IfMatch(pinnedETag))
+				assert.IsError(t, err, outage)
+			},
+		},
+		{
+			name: "StatIfMatchReturnsProbeError",
+			run: func(t *testing.T) {
+				_, err := tiered.Stat(ctx, key, cache.IfMatch(pinnedETag))
+				assert.IsError(t, err, outage)
+			},
+		},
+		{
+			name: "OpenIfRangeReturnsProbeError",
+			run: func(t *testing.T) {
+				_, _, err := tiered.Open(ctx, key, cache.Range(2, 6), cache.IfRange(pinnedETag))
+				assert.IsError(t, err, outage)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
 	}
 }
 


### PR DESCRIPTION
The Tiered cache treated the first tier holding an object as
definitive, so a replica whose local tier had diverged rejected
requests pinned to a version a deeper shared tier still holds.
Open/Stat now probe deeper tiers for the version named by
If-Range/If-Match before giving up.

ParallelGet now pins chunks with If-Match instead of If-Range, so a
version that no longer exists anywhere is rejected with a bodiless
412 rather than a full-body transfer the client would discard.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
