### PR TITLE
fix(s3): tag data and metadata to detect write races

### DIFF
--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -60,9 +62,33 @@ var _ Cache = (*S3)(nil)
 // s3Meta stores mutable metadata in a companion object alongside the
 // data object, avoiding expensive server-side copies when updating
 // headers or refreshing expiry.
+//
+// Tag correlates the metadata with the data object it describes. The data
+// object and its companion are written in two separate, non-atomic S3
+// operations, so concurrent writers to the same key can interleave and leave
+// the metadata describing a different data object than the one actually
+// stored. Stamping both objects with the same random tag lets readers detect
+// this mismatch (see statAndHeaders) and treat it as a cache miss.
 type s3Meta struct {
 	Headers   http.Header `json:"headers,omitempty"`
 	ExpiresAt time.Time   `json:"expires_at"`
+	Tag       string      `json:"tag,omitempty"`
+}
+
+// s3TagMetadataKey is the data object's user-metadata key holding the tag that
+// must match the companion s3Meta.Tag. Objects written before tagging was
+// introduced carry no tag on either object, so an empty-to-empty comparison
+// keeps them readable.
+const s3TagMetadataKey = "Tag"
+
+// newS3Tag returns a random hex tag used to correlate a data object with its
+// companion metadata object.
+func newS3Tag() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", errors.Wrap(err, "generate tag")
+	}
+	return hex.EncodeToString(buf[:]), nil
 }
 
 // NewS3 creates a new S3-based cache instance.
@@ -166,6 +192,15 @@ func (s *S3) statAndHeaders(ctx context.Context, key Key) (minio.ObjectInfo, htt
 	if err != nil {
 		return minio.ObjectInfo{}, nil, s3Meta{}, err
 	}
+
+	// Reject metadata that describes a different data object than the one
+	// stored (e.g. interleaved concurrent writes to the same key, or a data
+	// object whose companion has not been written yet). Treating this as a
+	// miss lets the caller fall back to upstream; the next write reconciles.
+	if objInfo.UserMetadata[s3TagMetadataKey] != meta.Tag {
+		return minio.ObjectInfo{}, nil, s3Meta{}, os.ErrNotExist
+	}
+
 	maps.Copy(headers, meta.Headers)
 
 	// Companion expiry takes precedence over the data object's Expires header.
@@ -217,7 +252,7 @@ func (s *S3) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser, 
 			if etag := meta.Headers.Get(ETagKey); etag != "" {
 				refreshHeaders.Set(ETagKey, etag)
 			}
-			refreshMeta := s3Meta{Headers: refreshHeaders, ExpiresAt: newExpiresAt}
+			refreshMeta := s3Meta{Headers: refreshHeaders, ExpiresAt: newExpiresAt, Tag: meta.Tag}
 			go func() {
 				bgCtx := context.WithoutCancel(ctx)
 				if err := s.writeMeta(bgCtx, s.namespace, key, refreshMeta); err != nil {
@@ -340,6 +375,11 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 
 	expiresAt := ceilSecond(time.Now().Add(ttl))
 
+	tag, err := newS3Tag()
+	if err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithCancelCause(ctx)
 
 	pr, pw := io.Pipe()
@@ -351,6 +391,7 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 		pipe:      pw,
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
+		tag:       tag,
 		etag:      newETagWriter(),
 		ctx:       ctx,
 		cancel:    cancel,
@@ -392,6 +433,7 @@ type s3Writer struct {
 	pipe      *io.PipeWriter
 	expiresAt time.Time
 	headers   http.Header
+	tag       string
 	etag      *etagWriter
 	ctx       context.Context
 	cancel    context.CancelCauseFunc
@@ -452,7 +494,7 @@ func (w *s3Writer) Close() error {
 		w.etag.SetETag(w.headers)
 		metaHeaders := make(http.Header)
 		metaHeaders.Set(ETagKey, w.headers.Get(ETagKey))
-		return w.s3.writeMeta(w.ctx, w.namespace, w.key, s3Meta{Headers: metaHeaders, ExpiresAt: w.expiresAt})
+		return w.s3.writeMeta(w.ctx, w.namespace, w.key, s3Meta{Headers: metaHeaders, ExpiresAt: w.expiresAt, Tag: w.tag})
 	}
 	return nil
 }
@@ -466,7 +508,7 @@ func (w *s3Writer) upload(pr *io.PipeReader, r io.Reader) {
 
 	objectName := w.s3.keyToPath(w.namespace, w.key)
 
-	userMetadata := make(map[string]string)
+	userMetadata := map[string]string{s3TagMetadataKey: w.tag}
 	if len(w.headers) > 0 {
 		headersJSON, err := json.Marshal(w.headers)
 		if err != nil {

--- a/internal/cache/s3_internal_test.go
+++ b/internal/cache/s3_internal_test.go
@@ -1,0 +1,102 @@
+package cache
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/minio/minio-go/v7"
+
+	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/s3client"
+	"github.com/block/cachew/internal/s3client/s3clienttest"
+)
+
+func newS3(t *testing.T) *S3 {
+	t.Helper()
+	bucket := s3clienttest.Start(t)
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+
+	clientProvider := s3client.NewClientProvider(ctx, s3client.Config{
+		Endpoint: s3clienttest.Addr,
+		UseSSL:   false,
+	})
+
+	s, err := NewS3(ctx, S3Config{
+		Bucket:           bucket,
+		MaxTTL:           time.Hour,
+		UploadPartSizeMB: 16,
+	}, clientProvider)
+	assert.NoError(t, err)
+	return s
+}
+
+// TestS3TagMismatchIsMiss verifies that when the companion metadata object
+// describes a different data object than the one stored (the outcome of
+// interleaved concurrent writes to the same key), reads report a cache miss
+// rather than serving the data with mismatched metadata.
+func TestS3TagMismatchIsMiss(t *testing.T) {
+	s := newS3(t)
+	defer s.Close()
+
+	ctx := t.Context()
+	key := NewKey("tag-mismatch")
+
+	w, err := s.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("hello world"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	r, _, err := s.Open(ctx, key)
+	assert.NoError(t, err)
+	data, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	assert.Equal(t, "hello world", string(data))
+
+	// Simulate a stale companion left behind by an interleaved writer: the data
+	// object keeps its tag while the metadata is overwritten with a different
+	// one.
+	assert.NoError(t, s.writeMeta(ctx, s.namespace, key, s3Meta{
+		Tag:       "stale-tag",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}))
+
+	_, err = s.Stat(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+	_, _, err = s.Open(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+}
+
+// TestS3LegacyUntaggedObjectIsReadable verifies backwards compatibility: an
+// object written before tagging was introduced carries no tag on either the
+// data object or its companion metadata, and must still read as a hit.
+func TestS3LegacyUntaggedObjectIsReadable(t *testing.T) {
+	s := newS3(t)
+	defer s.Close()
+
+	ctx := t.Context()
+	key := NewKey("legacy-untagged")
+	data := []byte("legacy payload")
+
+	// Write the data object with no tag user-metadata, mirroring an object
+	// produced by the pre-tagging implementation.
+	_, err := s.client.PutObject(ctx, s.config.Bucket, s.keyToPath(s.namespace, key),
+		bytes.NewReader(data), int64(len(data)), minio.PutObjectOptions{})
+	assert.NoError(t, err)
+
+	// Companion metadata with no tag field, as older writers produced.
+	assert.NoError(t, s.writeMeta(ctx, s.namespace, key, s3Meta{ExpiresAt: time.Now().Add(time.Hour)}))
+
+	r, _, err := s.Open(ctx, key)
+	assert.NoError(t, err)
+	got, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	assert.Equal(t, string(data), string(got))
+}


### PR DESCRIPTION
The data object and its companion metadata object are written in two
separate, non-atomic S3 operations. Concurrent writers to the same key
can interleave so the stored data comes from one writer and the metadata
from another, serving bytes with mismatched headers/ETag.

Stamp both objects with a shared random tag and treat a mismatch as a
cache miss. Untagged legacy objects compare equal (empty to empty) and
remain readable.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
