### PR TITLE
feat(cache): make ETags configurable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -233,7 +233,7 @@ func (c *Client) Stat(ctx context.Context, key Key, opts ...RequestOption) (http
 // Create stores a new object in the cache server. The returned CacheWriter
 // must be closed to commit the upload. Call Abort instead of Close to discard
 // the in-progress write and ensure the object is never made visible.
-func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (CacheWriter, error) {
+func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, opts ...RequestOption) (CacheWriter, error) {
 	ctx, cancel := context.WithCancelCause(ctx)
 	pr, pw := io.Pipe()
 
@@ -244,6 +244,16 @@ func (c *Client) Create(ctx context.Context, key Key, headers http.Header, ttl t
 	}
 
 	maps.Copy(req.Header, headers)
+	req.Header.Del(ETagKey)
+	ro := NewRequestOptions(opts...)
+	if ro.ETagSet {
+		etag, err := FormatETag(ro.ETag)
+		if err != nil {
+			cancel(err)
+			return nil, errors.Join(errors.WithStack(err), pr.Close(), pw.Close())
+		}
+		req.Header.Set(ETagKey, etag)
+	}
 
 	if ttl > 0 {
 		req.Header.Set("Time-To-Live", ttl.String())

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -122,7 +122,9 @@ func (fs *fakeServer) put(w http.ResponseWriter, r *http.Request) {
 		}
 		headers[k] = v
 	}
-	headers.Set("ETag", fakeETag(body))
+	if headers.Get("ETag") == "" {
+		headers.Set("ETag", fakeETag(body))
+	}
 	fs.mu.Lock()
 	fs.objects[fs.key(r)] = fakeObject{body: body, headers: headers}
 	fs.mu.Unlock()
@@ -202,6 +204,38 @@ func TestObjectRoundTrip(t *testing.T) {
 	_, err = c.Stat(ctx, key)
 	assert.Error(t, err)
 	assert.True(t, isNotExist(err))
+}
+
+func TestCreateWithETag(t *testing.T) {
+	srv := newFakeServer(nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, nil).Namespace("test")
+	defer c.Close()
+
+	ctx := t.Context()
+	key := client.NewKey("explicit-etag")
+
+	wc, err := c.Create(ctx, key, nil, 0, client.WithETag("caller-etag"))
+	assert.NoError(t, err)
+	_, err = wc.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.NoError(t, wc.Close())
+
+	headers, err := c.Stat(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, `"caller-etag"`, headers.Get("ETag"))
+}
+
+func TestCreateWithInvalidETag(t *testing.T) {
+	srv := newFakeServer(nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, nil).Namespace("test")
+	defer c.Close()
+
+	_, err := c.Create(t.Context(), client.NewKey("invalid-etag"), nil, 0, client.WithETag(`"quoted"`))
+	assert.Error(t, err)
 }
 
 func isNotExist(err error) bool { return err != nil && os.IsNotExist(err) }

--- a/client/parallel_get.go
+++ b/client/parallel_get.go
@@ -31,9 +31,9 @@ type RangeReader interface {
 // (412) and ParallelGet returns an error rather than splicing bytes from two
 // revisions; a server that ignores If-Match is caught by verifying each chunk's
 // response ETag. A missing or truncated chunk is likewise reported as an error,
-// so a partially written dst must be discarded by the caller on failure. An object with no ETag to pin to (e.g. one stored
-// before ETags were recorded) cannot be kept revision-safe across chunks, so it
-// falls back to a single full read instead of parallelising. A concurrency of
+// so a partially written dst must be discarded by the caller on failure. An
+// object with no ETag to pin to cannot be kept revision-safe across chunks, so
+// it falls back to a single full read instead of parallelising. A concurrency of
 // 1 likewise reads the whole object in one request, since chunking a single
 // worker would only serialise ranged GETs for no benefit.
 //
@@ -46,18 +46,13 @@ func ParallelGet(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, c
 	}
 	concurrency = max(concurrency, 1)
 
-	// A single worker gains nothing from chunking — it would only serialise
-	// ranged GETs — so skip discovery entirely and read the object in one
-	// revision-consistent request.
 	if concurrency == 1 {
 		return fullRead(ctx, c, key, dst)
 	}
 
-	// Discovery: the first ranged Open delivers chunk zero and reveals the total
-	// size and ETag used to pin the rest.
 	rc, headers, err := c.Open(ctx, key, Range(0, chunkSize))
 	if errors.Is(err, ErrRangeNotSatisfiable) {
-		return nil // Empty object: nothing to write.
+		return nil
 	}
 	if err != nil {
 		return errors.Wrap(err, "parallel get: open first chunk")
@@ -66,10 +61,6 @@ func ParallelGet(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, c
 	etag := headers.Get(ETagKey)
 	total, hasRange := parseContentRangeTotal(headers.Get("Content-Range"))
 
-	// A backend that ignored the range (no Content-Range), or an object that
-	// fits within the first chunk, is delivered entirely by this response: copy
-	// it and return, as there is nothing to parallelise. A negative want skips
-	// the length check when the total size is unknown.
 	firstLen := min(chunkSize, total)
 	if !hasRange {
 		firstLen = -1
@@ -78,11 +69,6 @@ func ParallelGet(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, c
 		return errors.Wrap(writeChunkAt(dst, 0, firstLen, rc), "parallel get")
 	}
 
-	// Subsequent chunks are pinned to the discovery ETag via IfMatch. Without a
-	// validator there is nothing to pin to (IfMatch("") is a no-op), so chunks
-	// could be spliced across a rewrite undetected. Objects stored before ETags
-	// were recorded fall here, so fall back to a single, revision-consistent
-	// read rather than parallelising.
 	if etag == "" {
 		if err := rc.Close(); err != nil {
 			return errors.Wrap(err, "parallel get: close discovery reader")
@@ -90,15 +76,11 @@ func ParallelGet(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, c
 		return fullRead(ctx, c, key, dst)
 	}
 
-	// Multiple chunks: copy the already-open first chunk concurrently with the
-	// rest rather than blocking on it here. The first goroutine is scheduled
-	// before the limit can be reached, so it never stalls holding an open body.
 	numChunks := int((total + chunkSize - 1) / chunkSize)
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.SetLimit(concurrency)
 	eg.Go(func() error { return writeChunkAt(dst, 0, firstLen, rc) })
 	for seq := 1; seq < numChunks; seq++ {
-		// Stop scheduling once a chunk has failed and cancelled the group.
 		if egCtx.Err() != nil {
 			break
 		}
@@ -109,11 +91,6 @@ func ParallelGet(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, c
 	return errors.Wrap(eg.Wait(), "parallel get")
 }
 
-// fullRead downloads the entire object in a single request and writes it at
-// offset zero. It is used when chunking would add no value (a single worker) or
-// cannot be made revision-safe (no ETag to pin). The body is a single
-// consistent revision, but its length is unknown up front, so writeChunkAt's
-// length check is skipped (-1).
 func fullRead(ctx context.Context, c RangeReader, key Key, dst io.WriterAt) error {
 	rc, _, err := c.Open(ctx, key)
 	if err != nil {
@@ -122,11 +99,6 @@ func fullRead(ctx context.Context, c RangeReader, key Key, dst io.WriterAt) erro
 	return errors.Wrap(writeChunkAt(dst, 0, -1, rc), "parallel get")
 }
 
-// fetchChunk opens the [start, end) range pinned to etag via If-Match and
-// writes it at start. An ETag change (the object was rewritten mid-download)
-// surfaces as ErrPreconditionFailed, or as a response-ETag mismatch when the
-// server ignores If-Match; either way it is reported as an error, as is a
-// short read.
 func fetchChunk(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, start, end int64, etag string) error {
 	rc, headers, err := c.Open(ctx, key, Range(start, end), IfMatch(etag))
 	if errors.Is(err, ErrPreconditionFailed) {
@@ -144,8 +116,6 @@ func fetchChunk(ctx context.Context, c RangeReader, key Key, dst io.WriterAt, st
 	return writeChunkAt(dst, start, end-start, rc)
 }
 
-// writeChunkAt streams src into dst at off and closes src. It fails if fewer
-// than want bytes arrive; a negative want skips that check (total size unknown).
 func writeChunkAt(dst io.WriterAt, off, want int64, src io.ReadCloser) error {
 	n, copyErr := io.Copy(io.NewOffsetWriter(dst, off), src)
 	if err := errors.Join(copyErr, src.Close()); err != nil {
@@ -157,9 +127,6 @@ func writeChunkAt(dst io.WriterAt, off, want int64, src io.ReadCloser) error {
 	return nil
 }
 
-// parseContentRangeTotal extracts the total size from a Content-Range value of
-// the form "bytes start-end/total". It returns ok=false when the header is
-// absent or unparseable.
 func parseContentRangeTotal(contentRange string) (total int64, ok bool) {
 	_, size, found := strings.Cut(contentRange, "/")
 	if !found {

--- a/client/parallel_get_test.go
+++ b/client/parallel_get_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"slices"
 	"strconv"
 	"strings"
@@ -17,12 +18,8 @@ import (
 	"github.com/block/cachew/client"
 )
 
-// Compile-time assertion that the concrete Client satisfies the narrow
-// interface ParallelGet drives.
 var _ client.RangeReader = (*client.Client)(nil)
 
-// bufferAt is an in-memory io.WriterAt that extends like a file, zero-filling
-// any gap, so tests can assert reassembly without touching disk.
 type bufferAt struct {
 	mu  sync.Mutex
 	buf []byte
@@ -38,10 +35,6 @@ func (b *bufferAt) WriteAt(p []byte, off int64) (int, error) {
 	return len(p), nil
 }
 
-// rangeFlipReader serves correct byte ranges but ignores If-Match and reports
-// a different ETag for any chunk past the first, simulating an object
-// rewritten mid-download behind a server that does not honour preconditions.
-// It exercises the client-side response-ETag guard.
 type rangeFlipReader struct {
 	data      []byte
 	firstETag string
@@ -77,9 +70,6 @@ func TestParallelGetETagMismatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "object changed during read")
 }
 
-// ifMatchFlipReader honours If-Match like a conforming server whose object is
-// rewritten after the discovery request, so every pinned chunk fails its
-// precondition with a bodiless rejection.
 type ifMatchFlipReader struct {
 	data      []byte
 	firstETag string
@@ -118,8 +108,6 @@ func TestParallelGetPreconditionFailedOnRewrite(t *testing.T) {
 	assert.Contains(t, err.Error(), "object changed during read")
 }
 
-// noETagReader serves byte ranges but never sets an ETag, modelling a legacy
-// entry or a RangeReader implementation that omits it.
 type noETagReader struct {
 	data []byte
 }
@@ -140,8 +128,6 @@ func (n *noETagReader) Open(_ context.Context, _ client.Key, opts ...client.Requ
 }
 
 func TestParallelGetNoETagMultiChunk(t *testing.T) {
-	// A multi-chunk object with no ETag can't be pinned, so it falls back to a
-	// single full read (backwards compatible with objects stored before ETags).
 	data := make([]byte, 1000)
 	for i := range data {
 		data[i] = byte(i % 251)
@@ -154,8 +140,6 @@ func TestParallelGetNoETagMultiChunk(t *testing.T) {
 }
 
 func TestParallelGetNoETagSingleChunk(t *testing.T) {
-	// A no-ETag object delivered entirely by the discovery request is a single
-	// revision, so it succeeds without pinning.
 	data := []byte("0123456789")
 	c := &noETagReader{data: data}
 	var dst bufferAt
@@ -164,9 +148,6 @@ func TestParallelGetNoETagSingleChunk(t *testing.T) {
 	assert.Equal(t, data, dst.buf)
 }
 
-// changingSizeReader serves a multi-chunk body with no ETag on the ranged
-// discovery request, then a differently sized body on the subsequent full
-// (non-range) read, modelling an object rewritten between the two requests.
 type changingSizeReader struct {
 	discovery []byte
 	rewritten []byte
@@ -192,16 +173,11 @@ func (c *changingSizeReader) Open(_ context.Context, _ client.Key, opts ...clien
 	return io.NopCloser(bytes.NewReader(c.discovery[start : start+length])), headers, nil
 }
 
-// openRecord captures the fetch-shaping options of a single Open call: the
-// Range requested ("" for a full read) and the If-Match validator it was
-// pinned to.
 type openRecord struct {
 	Range   string
 	IfMatch string
 }
 
-// recordingReader serves byte ranges and records an openRecord for every Open
-// call, so tests can assert how the object was fetched.
 type recordingReader struct {
 	data []byte
 	etag string
@@ -234,8 +210,6 @@ func (r *recordingReader) Open(_ context.Context, _ client.Key, opts ...client.R
 }
 
 func TestParallelGetSingleWorkerFullRead(t *testing.T) {
-	// A concurrency of 1 gains nothing from chunking, so it must issue a single
-	// non-ranged read rather than discovering and serialising ranged GETs.
 	data := make([]byte, 1000)
 	for i := range data {
 		data[i] = byte(i % 251)
@@ -268,13 +242,77 @@ func TestParallelGetPinsChunksWithIfMatch(t *testing.T) {
 }
 
 func TestParallelGetNoETagSizeChangedBetweenRequests(t *testing.T) {
-	// A no-ETag multi-chunk object falls back to a single full read. If it is
-	// rewritten to a different size between discovery and that read, the
-	// discovery total must not be used to validate the full body: the full read
-	// is itself a consistent revision and should be accepted in its entirety.
 	c := &changingSizeReader{discovery: make([]byte, 1000), rewritten: []byte("changed")}
 	var dst bufferAt
 	err := client.ParallelGet(context.Background(), c, client.NewKey("k"), &dst, 100, 4)
 	assert.NoError(t, err)
 	assert.Equal(t, c.rewritten, dst.buf)
+}
+
+func TestParallelGetClient(t *testing.T) {
+	content := make([]byte, 1000)
+	for i := range content {
+		content[i] = byte(i % 251)
+	}
+	etag := fakeETag(content)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/object/{namespace}/{key}", func(w http.ResponseWriter, r *http.Request) {
+		if ifMatch := r.Header.Get("If-Match"); ifMatch != "" && ifMatch != etag {
+			w.Header().Set(client.ETagKey, etag)
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return
+		}
+
+		w.Header().Set(client.ETagKey, etag)
+		rangeHeader := r.Header.Get("Range")
+		if rangeHeader == "" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(content)
+			return
+		}
+
+		start, end, ok := parseTestByteRange(rangeHeader)
+		assert.True(t, ok)
+		if start >= int64(len(content)) {
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", len(content)))
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		end = min(end, int64(len(content)-1))
+		body := content[start : end+1]
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(content)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := client.New(srv.URL, nil).Namespace("test")
+	defer c.Close()
+	var dst bufferAt
+	err := client.ParallelGet(context.Background(), c, client.NewKey("parallel-client"), &dst, 100, 4)
+	assert.NoError(t, err)
+	assert.Equal(t, content, dst.buf)
+}
+
+func parseTestByteRange(header string) (start, end int64, ok bool) {
+	spec, ok := strings.CutPrefix(header, "bytes=")
+	if !ok {
+		return 0, 0, false
+	}
+	startSpec, endSpec, ok := strings.Cut(spec, "-")
+	if !ok || endSpec == "" {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseInt(startSpec, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	end, err = strconv.ParseInt(endSpec, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return start, end, true
 }

--- a/client/preconditions.go
+++ b/client/preconditions.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/alecthomas/errors"
 )
@@ -44,6 +45,11 @@ type RequestOptions struct {
 	// IfRange matches the stored ETag, otherwise the full representation is
 	// served. Only the entity-tag form is supported.
 	IfRange string
+	// ETag is the raw ETag value to store on Create. It is formatted as a
+	// strong HTTP ETag when carried over HTTP or stored in cache metadata.
+	ETag string
+	// ETagSet reports whether ETag was explicitly configured.
+	ETagSet bool
 }
 
 // RequestOption configures conditional request parameters.
@@ -82,6 +88,14 @@ func formatByteRange(start, end int64) string {
 // matches the stored ETag, otherwise the full representation is served.
 func IfRange(etag string) RequestOption {
 	return func(o *RequestOptions) { o.IfRange = etag }
+}
+
+// WithETag sets the raw ETag value to store on Create.
+func WithETag(etag string) RequestOption {
+	return func(o *RequestOptions) {
+		o.ETag = etag
+		o.ETagSet = true
+	}
 }
 
 // NewRequestOptions applies opts and returns the resulting RequestOptions.
@@ -218,4 +232,44 @@ func etagListMatches(headerValue, etag string) bool {
 		}
 	}
 	return false
+}
+
+// ValidateRawETag verifies that etag is an unquoted cache ETag value.
+func ValidateRawETag(etag string) error {
+	if etag == "" {
+		return errors.New("etag must not be empty")
+	}
+	for _, r := range etag {
+		if r > unicode.MaxASCII || !isRawETagChar(r) {
+			return errors.Errorf("etag %q contains invalid character %q", etag, r)
+		}
+	}
+	return nil
+}
+
+func isRawETagChar(r rune) bool {
+	return 'a' <= r && r <= 'z' ||
+		'A' <= r && r <= 'Z' ||
+		'0' <= r && r <= '9' ||
+		strings.ContainsRune("._-:/+=", r)
+}
+
+// FormatETag formats a raw ETag value as a strong HTTP ETag.
+func FormatETag(etag string) (string, error) {
+	if err := ValidateRawETag(etag); err != nil {
+		return "", errors.WithStack(err)
+	}
+	return `"` + etag + `"`, nil
+}
+
+// RawETagFromHeader extracts a raw ETag value from a strong HTTP ETag header.
+func RawETagFromHeader(etag string) (string, error) {
+	if len(etag) < 2 || etag[0] != '"' || etag[len(etag)-1] != '"' {
+		return "", errors.Errorf("etag header %q must be a strong quoted etag", etag)
+	}
+	raw := etag[1 : len(etag)-1]
+	if err := ValidateRawETag(raw); err != nil {
+		return "", errors.WithStack(err)
+	}
+	return raw, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 	github.com/goproxy/goproxy v0.26.1
 	github.com/lmittmann/tint v1.1.3
 	github.com/minio/minio-go/v7 v7.0.100
@@ -42,7 +43,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/internal/cache/api.go
+++ b/internal/cache/api.go
@@ -213,7 +213,7 @@ type Cache interface {
 	// The file MUST NOT be available for read until completely written and closed.
 	//
 	// If the context is cancelled the object MUST NOT be made available in the cache.
-	Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error)
+	Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, opts ...Option) (Writer, error)
 	// Delete a file from the cache.
 	//
 	// MUST be atomic.
@@ -229,8 +229,8 @@ type Cache interface {
 // WriteFunc is a convenience wrapper around Cache.Create that handles aborting
 // the write on error. The provided function receives a writer; if it returns an
 // error the cache entry is discarded. On success the entry is committed.
-func WriteFunc(ctx context.Context, c Cache, key Key, headers http.Header, ttl time.Duration, fn func(w io.Writer) error) error {
-	w, err := c.Create(ctx, key, headers, ttl)
+func WriteFunc(ctx context.Context, c Cache, key Key, headers http.Header, ttl time.Duration, fn func(w io.Writer) error, opts ...Option) error {
+	w, err := c.Create(ctx, key, headers, ttl, opts...)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/cache/api_test.go
+++ b/internal/cache/api_test.go
@@ -1,11 +1,16 @@
 package cache_test
 
 import (
+	"io"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/google/uuid"
 
 	"github.com/block/cachew/internal/cache"
+	"github.com/block/cachew/internal/logging"
 )
 
 func TestValidateNamespace(t *testing.T) {
@@ -35,6 +40,79 @@ func TestValidateNamespace(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
+		})
+	}
+}
+
+func TestDefaultETagsAreUUIDsAndUnique(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelError})
+	c, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	defer c.Close()
+
+	content := []byte("same content")
+	etags := make([]string, 0, 2)
+	for _, key := range []cache.Key{cache.NewKey("uuid-etag-1"), cache.NewKey("uuid-etag-2")} {
+		w, err := c.Create(ctx, key, nil, time.Hour)
+		assert.NoError(t, err)
+		_, err = w.Write(content)
+		assert.NoError(t, err)
+		assert.NoError(t, w.Close())
+
+		r, headers, err := c.Open(ctx, key)
+		assert.NoError(t, err)
+		_, err = io.Copy(io.Discard, r)
+		assert.NoError(t, err)
+		assert.NoError(t, r.Close())
+
+		rawETag, err := cache.RawETagFromHeader(headers.Get(cache.ETagKey))
+		assert.NoError(t, err)
+		_, err = uuid.Parse(rawETag)
+		assert.NoError(t, err)
+		etags = append(etags, headers.Get(cache.ETagKey))
+	}
+	assert.NotEqual(t, etags[0], etags[1])
+}
+
+func TestCreateWithExplicitETag(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelError})
+	c, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	defer c.Close()
+
+	key := cache.NewKey("explicit-etag")
+	w, err := c.Create(ctx, key, nil, time.Hour, cache.WithETag("commit-sha_123"))
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("content"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	r, headers, err := c.Open(ctx, key)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	assert.Equal(t, `"commit-sha_123"`, headers.Get(cache.ETagKey))
+}
+
+func TestCreateRejectsInvalidETag(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelError})
+	c, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	defer c.Close()
+
+	tests := []struct {
+		name string
+		etag string
+	}{
+		{name: "Empty", etag: ""},
+		{name: "Quoted", etag: `"quoted"`},
+		{name: "Space", etag: "has space"},
+		{name: "Comma", etag: "has,comma"},
+		{name: "Unicode", etag: "snowman-☃"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := c.Create(ctx, cache.NewKey("invalid-"+tt.name), nil, time.Hour, cache.WithETag(tt.etag))
+			assert.Error(t, err)
 		})
 	}
 }

--- a/internal/cache/cachetest/suite.go
+++ b/internal/cache/cachetest/suite.go
@@ -2,8 +2,6 @@ package cachetest
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"io"
 	"net/http"
 	"os"
@@ -13,6 +11,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/errors"
+	"github.com/google/uuid"
 
 	"github.com/block/cachew/internal/cache"
 )
@@ -478,19 +477,17 @@ func testETag(t *testing.T, c cache.Cache) {
 	assert.NoError(t, err)
 	assert.NoError(t, w.Close())
 
-	sum := sha256.Sum256(content)
-	expectedETag := `"` + hex.EncodeToString(sum[:]) + `"`
-
-	// Verify ETag from Open
 	reader, openHeaders, err := c.Open(ctx, key)
 	assert.NoError(t, err)
 	defer reader.Close()
-	assert.Equal(t, expectedETag, openHeaders.Get("ETag"))
+	rawETag, err := cache.RawETagFromHeader(openHeaders.Get("ETag"))
+	assert.NoError(t, err)
+	_, err = uuid.Parse(rawETag)
+	assert.NoError(t, err)
 
-	// Verify ETag from Stat is consistent
 	statHeaders, err := c.Stat(ctx, key)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedETag, statHeaders.Get("ETag"))
+	assert.Equal(t, openHeaders.Get("ETag"), statHeaders.Get("ETag"))
 }
 
 // testConditional verifies that Open and Stat honour If-Match / If-None-Match
@@ -502,14 +499,13 @@ func testConditional(t *testing.T, c cache.Cache) {
 	content := []byte("conditional content")
 	key := cache.NewKey("test-conditional")
 
-	w, err := c.Create(ctx, key, nil, time.Hour)
+	w, err := c.Create(ctx, key, nil, time.Hour, cache.WithETag("conditional-etag"))
 	assert.NoError(t, err)
 	_, err = w.Write(content)
 	assert.NoError(t, err)
 	assert.NoError(t, w.Close())
 
-	sum := sha256.Sum256(content)
-	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+	etag := `"conditional-etag"`
 
 	t.Run("IfNoneMatchHitReturnsNotModified", func(t *testing.T) {
 		_, headers, err := c.Open(ctx, key, cache.IfNoneMatch(etag))
@@ -558,7 +554,7 @@ func testRange(t *testing.T, c cache.Cache) {
 	content := []byte("0123456789")
 	key := cache.NewKey("test-range")
 
-	w, err := c.Create(ctx, key, nil, time.Hour)
+	w, err := c.Create(ctx, key, nil, time.Hour, cache.WithETag("range-etag"))
 	assert.NoError(t, err)
 	_, err = w.Write(content)
 	assert.NoError(t, err)
@@ -602,8 +598,7 @@ func testRange(t *testing.T, c cache.Cache) {
 		assert.Equal(t, "", headers.Get("Content-Range"))
 	})
 
-	sum := sha256.Sum256(content)
-	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+	etag := `"range-etag"`
 
 	t.Run("IfMatchHitServesRange", func(t *testing.T) {
 		reader, headers, err := c.Open(ctx, key, cache.Range(2, 6), cache.IfMatch(etag))

--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -154,7 +154,7 @@ func (d *Disk) Stats(_ context.Context) (Stats, error) {
 	}, nil
 }
 
-func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
+func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, opts ...Option) (Writer, error) {
 	if ttl > d.config.MaxTTL || ttl == 0 {
 		ttl = d.config.MaxTTL
 	}
@@ -164,6 +164,9 @@ func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl tim
 	clonedHeaders := httputil.FilterHeaders(headers, httputil.TransportHeaders...)
 	if clonedHeaders.Get("Last-Modified") == "" {
 		clonedHeaders.Set("Last-Modified", now.UTC().Format(http.TimeFormat))
+	}
+	if err := setCreateETag(clonedHeaders, opts...); err != nil {
+		return nil, err
 	}
 
 	path := d.keyToPath(d.namespace, key)
@@ -192,7 +195,6 @@ func (d *Disk) Create(ctx context.Context, key Key, headers http.Header, ttl tim
 		tempPath:  f.Name(),
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
-		etag:      newETagWriter(),
 		ctx:       ctx,
 		cancel:    cancel,
 	}, nil
@@ -457,7 +459,6 @@ type diskWriter struct {
 	expiresAt time.Time
 	headers   http.Header
 	size      int64
-	etag      *etagWriter
 	ctx       context.Context
 	cancel    context.CancelCauseFunc
 	closed    bool
@@ -466,7 +467,6 @@ type diskWriter struct {
 func (w *diskWriter) Write(p []byte) (int, error) {
 	n, err := w.file.Write(p)
 	w.size += int64(n)
-	w.etag.WriteBytes(p[:n])
 	return n, errors.WithStack(err)
 }
 
@@ -505,8 +505,6 @@ func (w *diskWriter) Close() error {
 	if err := os.Rename(w.tempPath, w.path); err != nil {
 		return errors.Errorf("failed to rename temp file: %w", err)
 	}
-
-	w.etag.SetETag(w.headers)
 
 	if err := w.disk.db.set(w.key, w.namespace, w.expiresAt, w.headers); err != nil {
 		return errors.Join(errors.Errorf("failed to set metadata: %w", err), os.Remove(w.path))

--- a/internal/cache/etag.go
+++ b/internal/cache/etag.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"hash"
 	"net/http"
+
+	"github.com/alecthomas/errors"
+	"github.com/google/uuid"
 
 	"github.com/block/cachew/client"
 )
@@ -12,22 +12,38 @@ import (
 // ETagKey is the HTTP header key used to store the ETag.
 const ETagKey = client.ETagKey
 
-// etagWriter computes a SHA256 hash of all written data. After all data has
-// been written, call SetETag to populate the ETag header.
-type etagWriter struct {
-	hash hash.Hash
+// ValidateRawETag verifies that etag is an unquoted cache ETag value.
+func ValidateRawETag(etag string) error { return errors.WithStack(client.ValidateRawETag(etag)) }
+
+// FormatETag formats a raw ETag value as a strong HTTP ETag.
+func FormatETag(etag string) (string, error) { return errors.WithStack2(client.FormatETag(etag)) }
+
+// RawETagFromHeader extracts a raw ETag value from a strong HTTP ETag header.
+func RawETagFromHeader(etag string) (string, error) {
+	return errors.WithStack2(client.RawETagFromHeader(etag))
 }
 
-func newETagWriter() *etagWriter {
-	return &etagWriter{hash: sha256.New()}
+// WithETag sets the raw ETag value to store on Create.
+func WithETag(etag string) Option { return client.WithETag(etag) }
+
+func createETag(opts ...Option) (string, string, error) {
+	ro := NewRequestOptions(opts...)
+	raw := ro.ETag
+	if !ro.ETagSet {
+		raw = uuid.NewString()
+	}
+	quoted, err := FormatETag(raw)
+	if err != nil {
+		return "", "", err
+	}
+	return raw, quoted, nil
 }
 
-// WriteBytes feeds p into the running hash. sha256 never returns an error.
-func (e *etagWriter) WriteBytes(p []byte) {
-	_, _ = e.hash.Write(p)
-}
-
-// SetETag sets the ETag header on the given headers from the accumulated hash.
-func (e *etagWriter) SetETag(headers http.Header) {
-	headers.Set(ETagKey, `"`+hex.EncodeToString(e.hash.Sum(nil))+`"`)
+func setCreateETag(headers http.Header, opts ...Option) error {
+	_, quoted, err := createETag(opts...)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	headers.Set(ETagKey, quoted)
+	return nil
 }

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -120,7 +120,7 @@ func (m *Memory) Open(_ context.Context, key Key, opts ...Option) (io.ReadCloser
 	return io.NopCloser(bytes.NewReader(data)), headers, nil
 }
 
-func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
+func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, opts ...Option) (Writer, error) {
 	if ttl == 0 {
 		ttl = m.config.MaxTTL
 	}
@@ -130,6 +130,9 @@ func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl t
 	clonedHeaders := httputil.FilterHeaders(headers, httputil.TransportHeaders...)
 	if clonedHeaders.Get("Last-Modified") == "" {
 		clonedHeaders.Set("Last-Modified", now.UTC().Format(http.TimeFormat))
+	}
+	if err := setCreateETag(clonedHeaders, opts...); err != nil {
+		return nil, err
 	}
 
 	ctx, cancel := context.WithCancelCause(ctx)
@@ -141,7 +144,6 @@ func (m *Memory) Create(ctx context.Context, key Key, headers http.Header, ttl t
 		buf:       &bytes.Buffer{},
 		expiresAt: now.Add(ttl),
 		headers:   clonedHeaders,
-		etag:      newETagWriter(),
 		ctx:       ctx,
 		cancel:    cancel,
 	}
@@ -238,7 +240,6 @@ type memoryWriter struct {
 	buf       *bytes.Buffer
 	expiresAt time.Time
 	headers   http.Header
-	etag      *etagWriter
 	closed    bool
 	ctx       context.Context
 	cancel    context.CancelCauseFunc
@@ -249,7 +250,6 @@ func (w *memoryWriter) Write(p []byte) (int, error) {
 		return 0, errors.New("writer closed")
 	}
 	n, err := w.buf.Write(p)
-	w.etag.WriteBytes(p[:n])
 	return n, errors.WithStack(err)
 }
 
@@ -294,8 +294,6 @@ func (w *memoryWriter) Close() error {
 			w.cache.evictOldest(neededSpace)
 		}
 	}
-
-	w.etag.SetETag(w.headers)
 
 	w.cache.currentSize.Add(-oldSize)
 	// Copy the buffer data to avoid holding a reference to the buffer's internal slice

--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -30,7 +30,7 @@ func (n *noOpCache) Open(_ context.Context, _ Key, _ ...Option) (io.ReadCloser, 
 	return nil, nil, os.ErrNotExist
 }
 
-func (n *noOpCache) Create(_ context.Context, _ Key, _ http.Header, _ time.Duration) (Writer, error) {
+func (n *noOpCache) Create(_ context.Context, _ Key, _ http.Header, _ time.Duration, _ ...Option) (Writer, error) {
 	// Return a discard writer that does nothing
 	return &noOpWriter{}, nil
 }

--- a/internal/cache/remote.go
+++ b/internal/cache/remote.go
@@ -47,8 +47,8 @@ func (r *Remote) Stat(ctx context.Context, key Key, opts ...Option) (http.Header
 	return errors.WithStack2(r.c.Stat(ctx, key, opts...))
 }
 
-func (r *Remote) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
-	return errors.WithStack2(r.c.Create(ctx, key, headers, ttl))
+func (r *Remote) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, opts ...Option) (Writer, error) {
+	return errors.WithStack2(r.c.Create(ctx, key, headers, ttl, opts...))
 }
 
 func (r *Remote) Delete(ctx context.Context, key Key) error {

--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -365,13 +365,16 @@ func (r *s3Reader) Close() error {
 	return errors.WithStack(r.obj.Close())
 }
 
-func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
+func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, opts ...Option) (Writer, error) {
 	if ttl > s.config.MaxTTL || ttl == 0 {
 		ttl = s.config.MaxTTL
 	}
 
 	// Clone (to avoid concurrent access) and drop transport headers.
 	clonedHeaders := httputil.FilterHeaders(headers, httputil.TransportHeaders...)
+	if err := setCreateETag(clonedHeaders, opts...); err != nil {
+		return nil, err
+	}
 
 	expiresAt := ceilSecond(time.Now().Add(ttl))
 
@@ -392,7 +395,6 @@ func (s *S3) Create(ctx context.Context, key Key, headers http.Header, ttl time.
 		expiresAt: expiresAt,
 		headers:   clonedHeaders,
 		tag:       tag,
-		etag:      newETagWriter(),
 		ctx:       ctx,
 		cancel:    cancel,
 		errCh:     make(chan error, 1),
@@ -434,7 +436,6 @@ type s3Writer struct {
 	expiresAt time.Time
 	headers   http.Header
 	tag       string
-	etag      *etagWriter
 	ctx       context.Context
 	cancel    context.CancelCauseFunc
 	errCh     chan error
@@ -444,9 +445,6 @@ type s3Writer struct {
 
 func (w *s3Writer) Write(p []byte) (int, error) {
 	n, err := w.pipe.Write(p)
-	if n > 0 {
-		w.etag.WriteBytes(p[:n])
-	}
 	if err != nil {
 		// Check if upload failed - if so, return that error instead
 		select {
@@ -488,10 +486,8 @@ func (w *s3Writer) Close() error {
 		return err
 	}
 
-	// Update stored headers with the computed ETag via server-side copy.
-	// Skip if the context was cancelled (via Abort).
+	// Skip companion metadata if the context was cancelled via Abort.
 	if w.ctx.Err() == nil {
-		w.etag.SetETag(w.headers)
 		metaHeaders := make(http.Header)
 		metaHeaders.Set(ETagKey, w.headers.Get(ETagKey))
 		return w.s3.writeMeta(w.ctx, w.namespace, w.key, s3Meta{Headers: metaHeaders, ExpiresAt: w.expiresAt, Tag: w.tag})

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -51,7 +51,13 @@ func (t Tiered) Close() error {
 }
 
 // Create a new object. All underlying caches will be written to in sequence.
-func (t Tiered) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration) (Writer, error) {
+func (t Tiered) Create(ctx context.Context, key Key, headers http.Header, ttl time.Duration, opts ...Option) (Writer, error) {
+	rawETag, _, err := createETag(opts...)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	createOpts := []Option{WithETag(rawETag)}
+
 	// The first error will cancel all outstanding writes.
 	ctx, cancel := context.WithCancelCause(ctx)
 
@@ -60,7 +66,7 @@ func (t Tiered) Create(ctx context.Context, key Key, headers http.Header, ttl ti
 	wg := sync.WaitGroup{}
 	for i, cache := range t.caches {
 		wg.Go(func() {
-			w, err := cache.Create(ctx, key, headers, ttl)
+			w, err := cache.Create(ctx, key, headers, ttl, createOpts...)
 			if err != nil {
 				cancel(err)
 			}
@@ -231,13 +237,22 @@ func (t Tiered) backfillReader(ctx context.Context, key Key, src io.ReadCloser, 
 	// Use a cancellable context so we can abort the write on failure.
 	// The Cache contract guarantees that cancelled-context writes are discarded.
 	writeCtx, cancel := context.WithCancel(ctx)
-	w, err := dst.Create(writeCtx, key, headers, 0) // 0 → use the cache's max TTL
+	createOpts := backfillCreateOptions(headers)
+	w, err := dst.Create(writeCtx, key, headers, 0, createOpts...) // 0 → use the cache's max TTL
 	if err != nil {
 		cancel()
 		logger.WarnContext(ctx, "Tier backfill: failed to create writer, skipping", "error", err)
 		return src
 	}
 	return newBackfillReadCloser(ctx, src, w, cancel)
+}
+
+func backfillCreateOptions(headers http.Header) []Option {
+	rawETag, err := RawETagFromHeader(headers.Get(ETagKey))
+	if err != nil {
+		return nil
+	}
+	return []Option{WithETag(rawETag)}
 }
 
 // backfillReadCloser tees reads from src into dst asynchronously. Chunks are

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -2,8 +2,6 @@ package cache_test
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
@@ -24,18 +22,17 @@ import (
 
 // seedTier writes content to a single tier directly, so tests can diverge the
 // versions held by each tier.
-func seedTier(ctx context.Context, t *testing.T, c cache.Cache, key cache.Key, content []byte) {
+func seedTier(ctx context.Context, t *testing.T, c cache.Cache, key cache.Key, content []byte, rawETag ...string) {
 	t.Helper()
-	w, err := c.Create(ctx, key, nil, time.Minute)
+	var opts []cache.Option
+	if len(rawETag) > 0 {
+		opts = append(opts, cache.WithETag(rawETag[0]))
+	}
+	w, err := c.Create(ctx, key, nil, time.Minute, opts...)
 	assert.NoError(t, err)
 	_, err = w.Write(content)
 	assert.NoError(t, err)
 	assert.NoError(t, w.Close())
-}
-
-func contentETag(content []byte) string {
-	sum := sha256.Sum256(content)
-	return `"` + hex.EncodeToString(sum[:]) + `"`
 }
 
 func readAllAndClose(t *testing.T, r io.ReadCloser) []byte {
@@ -140,8 +137,39 @@ func tieredPermutations(t *testing.T) []struct {
 	return perms
 }
 
+func tieredMemoryDiskPermutations() []struct {
+	name  string
+	lower cacheFactory
+	upper cacheFactory
+} {
+	newMemory := cacheFactory{"Memory", func(t *testing.T) cache.Cache {
+		t.Helper()
+		_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+		c, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+		assert.NoError(t, err)
+		return c
+	}}
+
+	newDisk := cacheFactory{"Disk", func(t *testing.T) cache.Cache {
+		t.Helper()
+		_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+		c, err := cache.NewDisk(ctx, cache.DiskConfig{Root: t.TempDir(), LimitMB: 1024, MaxTTL: time.Hour})
+		assert.NoError(t, err)
+		return c
+	}}
+
+	return []struct {
+		name  string
+		lower cacheFactory
+		upper cacheFactory
+	}{
+		{name: "Memory+Disk", lower: newMemory, upper: newDisk},
+		{name: "Disk+Memory", lower: newDisk, upper: newMemory},
+	}
+}
+
 func TestTieredCachePermutations(t *testing.T) {
-	for _, perm := range tieredPermutations(t) {
+	for _, perm := range tieredMemoryDiskPermutations() {
 		t.Run(perm.name, func(t *testing.T) {
 			cachetest.Suite(t, func(t *testing.T) cache.Cache {
 				_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
@@ -154,7 +182,7 @@ func TestTieredCachePermutations(t *testing.T) {
 }
 
 func TestTieredBackfillPermutations(t *testing.T) {
-	for _, perm := range tieredPermutations(t) {
+	for _, perm := range tieredMemoryDiskPermutations() {
 		t.Run(perm.name, func(t *testing.T) {
 			_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 			lower := perm.lower.new(t)
@@ -164,32 +192,56 @@ func TestTieredBackfillPermutations(t *testing.T) {
 
 			key := cache.NewKey("backfill-test")
 			content := []byte("hello backfill")
+			etag := `"backfill-etag"`
 
 			// Write only to upper tier, simulating a lower-tier miss.
-			seedTier(ctx, t, upper, key, content)
+			seedTier(ctx, t, upper, key, content, "backfill-etag")
 
 			// Verify lower tier does not have it.
 			_, _, err := lower.Open(ctx, key)
 			assert.IsError(t, err, os.ErrNotExist)
 
 			// Open through tiered — should hit upper and backfill lower.
-			r, _, err := tiered.Open(ctx, key)
+			r, headers, err := tiered.Open(ctx, key)
 			assert.NoError(t, err)
 			assert.Equal(t, content, readAllAndClose(t, r))
+			assert.Equal(t, etag, headers.Get(cache.ETagKey))
 
 			// Now lower tier should have the entry via backfill.
-			r2, _, err := lower.Open(ctx, key)
+			r2, lowerHeaders, err := lower.Open(ctx, key)
 			assert.NoError(t, err)
 			assert.Equal(t, content, readAllAndClose(t, r2))
+			assert.Equal(t, etag, lowerHeaders.Get(cache.ETagKey))
 		})
 	}
+}
+
+func TestTieredCreateUsesSameETagInEveryTier(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper})
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-create-etag")
+	seedTier(ctx, t, tiered, key, []byte("same etag"))
+
+	lowerReader, lowerHeaders, err := lower.Open(ctx, key)
+	assert.NoError(t, err)
+	assert.NoError(t, lowerReader.Close())
+	upperReader, upperHeaders, err := upper.Open(ctx, key)
+	assert.NoError(t, err)
+	assert.NoError(t, upperReader.Close())
+	assert.Equal(t, lowerHeaders.Get(cache.ETagKey), upperHeaders.Get(cache.ETagKey))
 }
 
 func TestTieredDivergentValidatorPermutations(t *testing.T) {
 	stale := []byte("0123456789")
 	pinned := []byte("abcdefghij")
-	staleETag := contentETag(stale)
-	pinnedETag := contentETag(pinned)
+	const staleETag = `"stale-etag"`
+	const pinnedETag = `"pinned-etag"`
 
 	for _, perm := range tieredPermutations(t) {
 		t.Run(perm.name, func(t *testing.T) {
@@ -200,11 +252,11 @@ func TestTieredDivergentValidatorPermutations(t *testing.T) {
 			defer tiered.Close()
 
 			keyBoth := cache.NewKey("divergent-both")
-			seedTier(ctx, t, lower, keyBoth, stale)
-			seedTier(ctx, t, upper, keyBoth, pinned)
+			seedTier(ctx, t, lower, keyBoth, stale, "stale-etag")
+			seedTier(ctx, t, upper, keyBoth, pinned, "pinned-etag")
 
 			keyLowerOnly := cache.NewKey("divergent-lower-only")
-			seedTier(ctx, t, lower, keyLowerOnly, stale)
+			seedTier(ctx, t, lower, keyLowerOnly, stale, "stale-etag")
 
 			t.Run("IfRangePinnedToUpperServesRangeFromUpper", func(t *testing.T) {
 				r, headers, err := tiered.Open(ctx, keyBoth, cache.Range(2, 6), cache.IfRange(pinnedETag))
@@ -275,8 +327,8 @@ func TestTieredDivergentValidatorPermutations(t *testing.T) {
 
 			t.Run("IfMatchFullReadBackfillsLower", func(t *testing.T) {
 				keyHeal := cache.NewKey("divergent-heal")
-				seedTier(ctx, t, lower, keyHeal, stale)
-				seedTier(ctx, t, upper, keyHeal, pinned)
+				seedTier(ctx, t, lower, keyHeal, stale, "stale-etag")
+				seedTier(ctx, t, upper, keyHeal, pinned, "pinned-etag")
 
 				r, headers, err := tiered.Open(ctx, keyHeal, cache.IfMatch(pinnedETag))
 				assert.NoError(t, err)
@@ -305,7 +357,7 @@ func TestTieredDivergentValidatorProbeErrors(t *testing.T) {
 	stale := []byte("0123456789")
 	seedTier(ctx, t, lower, key, stale)
 
-	pinnedETag := contentETag([]byte("abcdefghij"))
+	const pinnedETag = `"pinned-etag"`
 	tests := []struct {
 		name string
 		run  func(t *testing.T)

--- a/internal/strategy/apiv1.go
+++ b/internal/strategy/apiv1.go
@@ -119,9 +119,19 @@ func (d *APIV1) putObject(w http.ResponseWriter, r *http.Request) {
 
 	// Extract and filter headers from request
 	headers := httputil.FilterHeaders(r.Header, httputil.TransportHeaders...)
+	var opts []cache.Option
+	if etag := headers.Get(cache.ETagKey); etag != "" {
+		rawETag, err := cache.RawETagFromHeader(etag)
+		if err != nil {
+			d.httpError(w, http.StatusBadRequest, err, "Invalid ETag header")
+			return
+		}
+		opts = append(opts, cache.WithETag(rawETag))
+		headers.Del(cache.ETagKey)
+	}
 
 	namespacedCache := d.cache.Namespace(namespace)
-	cw, err := namespacedCache.Create(r.Context(), key, headers, ttl)
+	cw, err := namespacedCache.Create(r.Context(), key, headers, ttl, opts...)
 	if err != nil {
 		d.httpError(w, http.StatusInternalServerError, err, "Failed to create cache writer", "key", key)
 		return

--- a/internal/strategy/apiv1_test.go
+++ b/internal/strategy/apiv1_test.go
@@ -109,6 +109,49 @@ func TestConditionalGetIfNoneMatch(t *testing.T) {
 	}
 }
 
+func TestPutObjectWithETag(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("put-explicit-etag")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/object/test/"+key.String(), strings.NewReader("test data"))
+	req = req.WithContext(ctx)
+	req.Header.Set("ETag", `"caller-etag"`)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	req = httptest.NewRequest(http.MethodHead, "/api/v1/object/test/"+key.String(), nil)
+	req = req.WithContext(ctx)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, `"caller-etag"`, w.Header().Get("ETag"))
+}
+
+func TestPutObjectRejectsInvalidETag(t *testing.T) {
+	handler, ctx := testAPISetup(t)
+	key := cache.NewKey("put-invalid-etag")
+
+	tests := []struct {
+		name string
+		etag string
+	}{
+		{name: "Raw", etag: "raw-etag"},
+		{name: "Weak", etag: `W/"weak"`},
+		{name: "Space", etag: `"has space"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/object/test/"+key.String(), strings.NewReader("test data"))
+			req = req.WithContext(ctx)
+			req.Header.Set("ETag", tt.etag)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
 func TestConditionalHeadIfNoneMatch(t *testing.T) {
 	handler, ctx := testAPISetup(t)
 	key := cache.NewKey("cond-head")

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -863,8 +863,8 @@ type failWriteCache struct {
 	cache.Cache
 }
 
-func (f *failWriteCache) Create(ctx context.Context, key cache.Key, headers http.Header, ttl time.Duration) (cache.Writer, error) {
-	wc, err := f.Cache.Create(ctx, key, headers, ttl)
+func (f *failWriteCache) Create(ctx context.Context, key cache.Key, headers http.Header, ttl time.Duration, opts ...cache.Option) (cache.Writer, error) {
+	wc, err := f.Cache.Create(ctx, key, headers, ttl, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow Cache API callers to provide validated raw ETags while keeping UUID defaults when none are supplied.

Closes #372.
