### PR TITLE
fix: invalidate stale tiered cache entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ proxy {}
 Multiple backends can be configured simultaneously — they are automatically combined into a tiered cache. Cache blocks
 are ordered from lowest/nearest to highest/authoritative. Reads check each tier in order and backfill lower tiers on a
 hit. Writes go to all tiers in parallel. Replica invalidations evict only non-authoritative tiers; the final cache block
-is authoritative.
+is authoritative. Tiered caches use the metadata backend to track authoritative ETags and invalidate stale lower-tier
+copies before falling through to the authoritative tier.
 
 ### Memory
 

--- a/internal/cache/remote_test.go
+++ b/internal/cache/remote_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/cache/cachetest"
 	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/metadatadb"
 	"github.com/block/cachew/internal/strategy"
 )
 
@@ -50,7 +51,7 @@ func TestRemoteInvalidateSkipsRemoteAuthoritativeTier(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() { authoritative.Close() })
 
-	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, authoritative})
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, authoritative}, metadatadb.New(ctx, metadatadb.NewMemoryBackend()))
 	mux := http.NewServeMux()
 	_, err = strategy.NewAPIV1(ctx, struct{}{}, tiered, mux)
 	assert.NoError(t, err)

--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alecthomas/errors"
 
 	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/metadatadb"
 )
 
 // The Tiered cache combines multiple caches.
@@ -20,13 +21,15 @@ import (
 // It is not directly selectable from configuration, but instead is automatically used if multiple caches are
 // configured.
 type Tiered struct {
-	caches []Cache
+	caches    []Cache
+	metadata  *metadatadb.Store
+	namespace Namespace
 }
 
 // MaybeNewTiered creates a [Tiered] cache from one or more caches.
 //
 // If no caches are passed it will panic.
-func MaybeNewTiered(ctx context.Context, caches []Cache) Cache {
+func MaybeNewTiered(ctx context.Context, caches []Cache, metadata *metadatadb.Store) Cache {
 	logging.FromContext(ctx).InfoContext(ctx, "Constructing tiered cache", "tiers", len(caches))
 	if len(caches) == 0 {
 		panic("Tiered cache requires at least one backing cache")
@@ -34,7 +37,10 @@ func MaybeNewTiered(ctx context.Context, caches []Cache) Cache {
 	if len(caches) == 1 {
 		return authoritativeCache{Cache: caches[0]}
 	}
-	return Tiered{caches}
+	if metadata == nil {
+		panic("Tiered cache requires a metadata store")
+	}
+	return Tiered{caches: caches, metadata: metadata}
 }
 
 type authoritativeCache struct {
@@ -73,7 +79,13 @@ func (t Tiered) Create(ctx context.Context, key Key, headers http.Header, ttl ti
 	// The first error will cancel all outstanding writes.
 	ctx, cancel := context.WithCancelCause(ctx)
 
-	tw := &tieredWriter{writers: make([]Writer, len(t.caches)), cancel: cancel}
+	tw := &tieredWriter{
+		writers: make([]Writer, len(t.caches)),
+		cancel:  cancel,
+		etags:   t.etags(),
+		key:     key,
+		rawETag: rawETag,
+	}
 	// Note: we can't use errgroup here because we do not want to cancel the context on Wait().
 	wg := sync.WaitGroup{}
 	for i, cache := range t.caches {
@@ -104,7 +116,11 @@ func (t Tiered) Delete(ctx context.Context, key Key) error {
 		wg.Go(func() { errs[i] = errors.WithStack(cache.Delete(ctx, key)) })
 	}
 	wg.Wait()
-	return errors.Join(errs...)
+	err := errors.Join(errs...)
+	if err == nil {
+		t.deleteETag(key)
+	}
+	return err
 }
 
 // Invalidate evicts stale local copies from every non-authoritative tier.
@@ -148,6 +164,11 @@ func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header,
 		case err != nil && !errors.Is(err, ErrNotModified) && rejected:
 			probeErrs = append(probeErrs, errors.WithStack(err))
 			continue
+		case err != nil && !errors.Is(err, ErrNotModified):
+			return headers, errors.WithStack(err)
+		}
+		if i < len(t.caches)-1 && t.invalidateStale(ctx, c, key, headers) {
+			continue
 		}
 		// Any other outcome (success, ErrNotModified, or a hard error) is
 		// definitive for this tier; surface it with its headers.
@@ -189,11 +210,6 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 	var fallbackHeaders http.Header
 	var probeErrs []error
 	rejected := false // a tier failed If-Match; deeper tiers may hold the named version
-	discard := func(r io.ReadCloser) {
-		if err := r.Close(); err != nil {
-			logging.FromContext(ctx).WarnContext(ctx, "Tiered: failed to close superseded reader", "key", key, "error", err)
-		}
-	}
 
 	errs := make([]error, len(t.caches))
 	for i, c := range t.caches {
@@ -205,12 +221,14 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 		case errors.Is(err, ErrPreconditionFailed):
 			rejected = true
 			continue
+		case t.invalidateStaleConditional(ctx, i, c, key, headers, err, errs):
+			continue
 		case errors.Is(err, ErrNotModified), errors.Is(err, ErrRangeNotSatisfiable):
 			// This tier's version satisfies the request's validator, so the
 			// outcome is definitive. Surface headers so callers can build the
 			// conditional response. No body to backfill.
 			if fallback != nil {
-				discard(fallback)
+				discardTieredReader(ctx, key, fallback)
 			}
 			return nil, headers, errors.WithStack(err)
 		case err != nil:
@@ -223,18 +241,21 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 			}
 			probeErrs = append(probeErrs, errors.WithStack(err))
 			continue
+		case i < len(t.caches)-1 && t.invalidateStale(ctx, c, key, headers):
+			discardTieredReader(ctx, key, r)
+			continue
 		case ro.IfRangeMisses(headers.Get(ETagKey)):
 			// This tier holds a different version than the range is pinned to:
 			// hold its full body as the fallback and probe deeper tiers.
 			if fallback != nil {
-				discard(r)
+				discardTieredReader(ctx, key, r)
 				continue
 			}
 			fallback, fallbackHeaders = r, headers
 			continue
 		}
 		if fallback != nil {
-			discard(fallback)
+			discardTieredReader(ctx, key, fallback)
 		}
 		if i > 0 && !partial {
 			r = t.backfillReader(ctx, key, r, headers, t.caches[0])
@@ -256,6 +277,12 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 	return nil, nil, errors.Join(errs...)
 }
 
+func discardTieredReader(ctx context.Context, key Key, r io.ReadCloser) {
+	if err := r.Close(); err != nil {
+		logging.FromContext(ctx).WarnContext(ctx, "Tiered: failed to close superseded reader", "key", key, "error", err)
+	}
+}
+
 // backfillReader wraps src so that every byte read is also written to dst.
 // On successful close the dst entry becomes available for future reads.
 // On error or partial read the dst entry is discarded per the Cache contract
@@ -273,6 +300,46 @@ func (t Tiered) backfillReader(ctx context.Context, key Key, src io.ReadCloser, 
 		return src
 	}
 	return newBackfillReadCloser(ctx, src, w, cancel)
+}
+
+const tieredETagsMap = "cache-etags"
+
+func (t Tiered) etags() *metadatadb.Map[Key, string] {
+	return metadatadb.NewMap[Key, string](t.metadata.Namespace(string(t.namespace)), tieredETagsMap)
+}
+
+func (t Tiered) deleteETag(key Key) {
+	t.etags().Delete(key)
+}
+
+func (t Tiered) invalidateStale(ctx context.Context, c Cache, key Key, headers http.Header) bool {
+	want, ok := t.etags().Get(key)
+	if !ok || want == headers.Get(ETagKey) {
+		return false
+	}
+	if err := c.Invalidate(ctx, key); err != nil {
+		logging.FromContext(ctx).WarnContext(ctx, "Tiered: failed to invalidate stale tier", "key", key, "error", err)
+	}
+	return true
+}
+
+func (t Tiered) invalidateStaleConditional(
+	ctx context.Context,
+	tier int,
+	c Cache,
+	key Key,
+	headers http.Header,
+	err error,
+	errs []error,
+) bool {
+	if tier == len(t.caches)-1 || (!errors.Is(err, ErrNotModified) && !errors.Is(err, ErrRangeNotSatisfiable)) {
+		return false
+	}
+	if !t.invalidateStale(ctx, c, key, headers) {
+		return false
+	}
+	errs[tier] = os.ErrNotExist
+	return true
 }
 
 func backfillCreateOptions(headers http.Header) []Option {
@@ -405,12 +472,17 @@ func (t Tiered) Stats(ctx context.Context) (Stats, error) {
 type tieredWriter struct {
 	writers []Writer
 	cancel  context.CancelCauseFunc
+	etags   *metadatadb.Map[Key, string]
+	key     Key
+	rawETag string
 	closed  bool
+	aborted bool
 }
 
 var _ Writer = (*tieredWriter)(nil)
 
 func (t *tieredWriter) Abort(err error) error {
+	t.aborted = true
 	t.cancel(err)
 	return t.Close()
 }
@@ -428,7 +500,15 @@ func (t *tieredWriter) Close() error {
 		wg.Go(func() { errs[i] = errors.WithStack(cache.Close()) })
 	}
 	wg.Wait()
-	return errors.Join(errs...)
+	err := errors.Join(errs...)
+	if err == nil && !t.aborted && t.etags != nil {
+		quoted, qerr := FormatETag(t.rawETag)
+		if qerr != nil {
+			return errors.WithStack(qerr)
+		}
+		t.etags.Set(t.key, quoted)
+	}
+	return err
 }
 
 func (t *tieredWriter) Write(p []byte) (n int, err error) {
@@ -451,7 +531,7 @@ func (t Tiered) Namespace(namespace Namespace) Cache {
 	for i, c := range t.caches {
 		namespaced[i] = c.Namespace(namespace)
 	}
-	return Tiered{caches: namespaced}
+	return Tiered{caches: namespaced, metadata: t.metadata, namespace: namespace}
 }
 
 // ListNamespaces returns unique namespaces from all underlying caches.

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/cache/cachetest"
 	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/metadatadb"
 	"github.com/block/cachew/internal/s3client"
 	"github.com/block/cachew/internal/s3client/s3clienttest"
 )
@@ -43,6 +44,18 @@ func readAllAndClose(t *testing.T, r io.ReadCloser) []byte {
 	return data
 }
 
+func newMetadataStore(ctx context.Context) *metadatadb.Store {
+	return metadatadb.New(ctx, metadatadb.NewMemoryBackend())
+}
+
+func tieredETags(store *metadatadb.Store, namespace cache.Namespace) *metadatadb.Map[cache.Key, string] {
+	return metadatadb.NewMap[cache.Key, string](store.Namespace(string(namespace)), "cache-etags")
+}
+
+func newTiered(ctx context.Context, caches ...cache.Cache) cache.Cache {
+	return cache.MaybeNewTiered(ctx, caches, newMetadataStore(ctx))
+}
+
 type failingCache struct {
 	cache.Cache
 	err error
@@ -60,6 +73,19 @@ func (c failingCache) Stat(_ context.Context, _ cache.Key, _ ...cache.Option) (h
 
 func (c failingCache) Open(_ context.Context, _ cache.Key, _ ...cache.Option) (io.ReadCloser, http.Header, error) {
 	return nil, nil, c.err
+}
+
+type statFailingCache struct {
+	cache.Cache
+	err error
+}
+
+func newStatFailingCache(c cache.Cache, err error) cache.Cache {
+	return statFailingCache{Cache: c, err: err}
+}
+
+func (c statFailingCache) Stat(_ context.Context, _ cache.Key, _ ...cache.Option) (http.Header, error) {
+	return nil, c.err
 }
 
 type cacheFactory struct {
@@ -175,7 +201,7 @@ func TestTieredCachePermutations(t *testing.T) {
 				_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 				lower := perm.lower.new(t)
 				upper := perm.upper.new(t)
-				return cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper})
+				return newTiered(ctx, lower, upper)
 			}, cachetest.WithoutInvalidate())
 		})
 	}
@@ -187,7 +213,7 @@ func TestTieredBackfillPermutations(t *testing.T) {
 			_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 			lower := perm.lower.new(t)
 			upper := perm.upper.new(t)
-			tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper})
+			tiered := newTiered(ctx, lower, upper)
 			defer tiered.Close()
 
 			key := cache.NewKey("backfill-test")
@@ -222,7 +248,7 @@ func TestTieredCreateUsesSameETagInEveryTier(t *testing.T) {
 	assert.NoError(t, err)
 	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
 	assert.NoError(t, err)
-	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper})
+	tiered := newTiered(ctx, lower, upper)
 	defer tiered.Close()
 
 	key := cache.NewKey("tiered-create-etag")
@@ -237,6 +263,217 @@ func TestTieredCreateUsesSameETagInEveryTier(t *testing.T) {
 	assert.Equal(t, lowerHeaders.Get(cache.ETagKey), upperHeaders.Get(cache.ETagKey))
 }
 
+func TestTieredRequiresMetadataStore(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+
+	assert.Panics(t, func() {
+		cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, nil)
+	})
+}
+
+func TestTieredCreatePublishesMetadataETag(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-create-metadata-etag")
+	w, err := tiered.Create(ctx, key, nil, time.Minute, cache.WithETag("metadata-etag"))
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("content"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	etag, ok := tieredETags(store, "").Get(key)
+	assert.True(t, ok)
+	assert.Equal(t, `"metadata-etag"`, etag)
+}
+
+func TestTieredAbortDoesNotPublishMetadataETag(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-abort-metadata-etag")
+	w, err := tiered.Create(ctx, key, nil, time.Minute, cache.WithETag("aborted-etag"))
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("partial"))
+	assert.NoError(t, err)
+	assert.Error(t, w.Abort(errors.New("abort write")))
+
+	_, ok := tieredETags(store, "").Get(key)
+	assert.False(t, ok)
+}
+
+func TestTieredMetadataInvalidatesStaleLowerOnStat(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-stale-stat")
+	seedTier(ctx, t, lower, key, []byte("stale"), "stale-etag")
+	seedTier(ctx, t, upper, key, []byte("fresh"), "fresh-etag")
+	tieredETags(store, "").Set(key, `"fresh-etag"`)
+
+	headers, err := tiered.Stat(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, `"fresh-etag"`, headers.Get(cache.ETagKey))
+	_, _, err = lower.Open(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+}
+
+func TestTieredMetadataInvalidatesStaleLowerBeforeNotModified(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-stale-not-modified")
+	seedTier(ctx, t, lower, key, []byte("stale"), "stale-etag")
+	seedTier(ctx, t, upper, key, []byte("fresh"), "fresh-etag")
+	tieredETags(store, "").Set(key, `"fresh-etag"`)
+
+	r, headers, err := tiered.Open(ctx, key, cache.IfNoneMatch(`"stale-etag"`))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("fresh"), readAllAndClose(t, r))
+	assert.Equal(t, `"fresh-etag"`, headers.Get(cache.ETagKey))
+	r, headers, err = lower.Open(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("fresh"), readAllAndClose(t, r))
+	assert.Equal(t, `"fresh-etag"`, headers.Get(cache.ETagKey))
+}
+
+func TestTieredMetadataReturnsHardStatErrorBeforeInvalidating(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	statErr := errors.New("stat unavailable")
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{newStatFailingCache(lower, statErr), upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-stale-hard-stat-error")
+	seedTier(ctx, t, lower, key, []byte("lower"), "lower-etag")
+	seedTier(ctx, t, upper, key, []byte("upper"), "upper-etag")
+	tieredETags(store, "").Set(key, `"upper-etag"`)
+
+	_, err = tiered.Stat(ctx, key)
+	assert.IsError(t, err, statErr)
+	r, headers, err := lower.Open(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("lower"), readAllAndClose(t, r))
+	assert.Equal(t, `"lower-etag"`, headers.Get(cache.ETagKey))
+}
+
+func TestTieredMetadataClearsDiscardedConditionalError(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-clears-stale-conditional")
+	seedTier(ctx, t, lower, key, []byte("stale"), "stale-etag")
+	tieredETags(store, "").Set(key, `"fresh-etag"`)
+
+	_, _, err = tiered.Open(ctx, key, cache.IfNoneMatch(`"stale-etag"`))
+	assert.IsError(t, err, os.ErrNotExist)
+	assert.False(t, errors.Is(err, cache.ErrNotModified))
+}
+
+func TestTieredMetadataAllowsMatchingLower(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-matching-lower")
+	seedTier(ctx, t, lower, key, []byte("lower"), "lower-etag")
+	seedTier(ctx, t, upper, key, []byte("upper"), "upper-etag")
+	tieredETags(store, "").Set(key, `"lower-etag"`)
+
+	r, headers, err := tiered.Open(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("lower"), readAllAndClose(t, r))
+	assert.Equal(t, `"lower-etag"`, headers.Get(cache.ETagKey))
+}
+
+func TestTieredMissingMetadataPreservesExistingBehavior(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-missing-metadata")
+	seedTier(ctx, t, lower, key, []byte("lower"), "lower-etag")
+	seedTier(ctx, t, upper, key, []byte("upper"), "upper-etag")
+
+	r, headers, err := tiered.Open(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("lower"), readAllAndClose(t, r))
+	assert.Equal(t, `"lower-etag"`, headers.Get(cache.ETagKey))
+}
+
+func TestTieredMetadataIsNamespaced(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("tiered-namespaced-metadata")
+	namespaced := tiered.Namespace("alpha")
+	w, err := namespaced.Create(ctx, key, nil, time.Minute, cache.WithETag("alpha-etag"))
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("content"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	etag, ok := tieredETags(store, "alpha").Get(key)
+	assert.True(t, ok)
+	assert.Equal(t, `"alpha-etag"`, etag)
+	_, ok = tieredETags(store, "beta").Get(key)
+	assert.False(t, ok)
+}
+
 func TestTieredDivergentValidatorPermutations(t *testing.T) {
 	stale := []byte("0123456789")
 	pinned := []byte("abcdefghij")
@@ -248,7 +485,7 @@ func TestTieredDivergentValidatorPermutations(t *testing.T) {
 			_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 			lower := perm.lower.new(t)
 			upper := perm.upper.new(t)
-			tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper})
+			tiered := newTiered(ctx, lower, upper)
 			defer tiered.Close()
 
 			keyBoth := cache.NewKey("divergent-both")
@@ -350,7 +587,7 @@ func TestTieredDivergentValidatorProbeErrors(t *testing.T) {
 	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
 	assert.NoError(t, err)
 	outage := errors.New("backend unavailable")
-	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, newFailingCache(outage)})
+	tiered := newTiered(ctx, lower, newFailingCache(outage))
 	defer tiered.Close()
 
 	key := cache.NewKey("divergent-probe-error")
@@ -395,7 +632,7 @@ func TestTieredDeletePermutations(t *testing.T) {
 			_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 			lower := perm.lower.new(t)
 			upper := perm.upper.new(t)
-			tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper})
+			tiered := newTiered(ctx, lower, upper)
 			defer tiered.Close()
 
 			key := cache.NewKey("delete-test")
@@ -431,7 +668,7 @@ func TestTieredInvalidateSkipsAuthoritativeTier(t *testing.T) {
 			_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 			lower := perm.lower.new(t)
 			authoritative := perm.upper.new(t)
-			tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, authoritative})
+			tiered := newTiered(ctx, lower, authoritative)
 			defer tiered.Close()
 
 			key := cache.NewKey("invalidate-test")
@@ -455,7 +692,7 @@ func TestSingleTierInvalidateIsNoop(t *testing.T) {
 	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 	authoritative, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
 	assert.NoError(t, err)
-	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{authoritative})
+	tiered := newTiered(ctx, authoritative)
 	defer tiered.Close()
 
 	key := cache.NewKey("single-tier-invalidate")
@@ -471,7 +708,7 @@ func TestSingleTierInvalidateIsNoop(t *testing.T) {
 
 func TestSingleTierDelegatesUnsupportedOperations(t *testing.T) {
 	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
-	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{cache.NoOpCache()})
+	tiered := newTiered(ctx, cache.NoOpCache())
 	defer tiered.Close()
 
 	_, err := tiered.Stats(ctx)
@@ -500,7 +737,7 @@ func TestTieredCacheSoak(t *testing.T) {
 		EvictInterval: time.Second,
 	})
 	assert.NoError(t, err)
-	c := cache.MaybeNewTiered(ctx, []cache.Cache{memory, disk})
+	c := newTiered(ctx, memory, disk)
 	defer c.Close()
 
 	cachetest.Soak(t, c, cachetest.SoakConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,11 +191,10 @@ func Load(
 		return nil, nil, errors.Errorf("%s: %w", classified.metadata.Pos, err)
 	}
 
-	cache := cache.MaybeNewTiered(ctx, caches)
+	metadataStore := metadatadb.New(ctx, metadata)
+	cache := cache.MaybeNewTiered(ctx, caches, metadataStore)
 
 	logger.DebugContext(ctx, "Cache backend", "cache", cache)
-
-	metadataStore := metadatadb.New(ctx, metadata)
 
 	// Second pass, instantiate strategies and bind them to the mux.
 	// Collect strategies that implement Interceptor separately — they need


### PR DESCRIPTION
Track authoritative ETags in metadatadb and invalidate stale lower-tier entries before falling through to authoritative storage.

Closes #373
