### PR TITLE
fix(cache): make disk ranged reads revision-atomic

### DIFF
--- a/internal/cache/disk.go
+++ b/internal/cache/disk.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"hash/fnv"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,7 +47,10 @@ type Disk struct {
 	runEviction  chan struct{}
 	stop         context.CancelFunc
 	evictionDone chan struct{}
+	locks        *[diskLockStripes]sync.RWMutex
 }
+
+const diskLockStripes = 1024
 
 var _ Cache = (*Disk)(nil)
 
@@ -119,12 +124,20 @@ func NewDisk(ctx context.Context, config DiskConfig) (*Disk, error) {
 		runEviction:  make(chan struct{}),
 		stop:         stop,
 		evictionDone: make(chan struct{}),
+		locks:        &[diskLockStripes]sync.RWMutex{},
 	}
 	disk.size.Store(size)
 
 	go disk.evictionLoop(ctx)
 
 	return disk, nil
+}
+
+func (d *Disk) keyLock(namespace Namespace, key Key) *sync.RWMutex {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(namespace))
+	_, _ = h.Write(key[:])
+	return &d.locks[h.Sum32()&(diskLockStripes-1)]
 }
 
 func (d *Disk) String() string { return "disk:" + d.config.Root }
@@ -211,16 +224,17 @@ func (d *Disk) Delete(_ context.Context, key Key) error {
 		expired = true
 	}
 
+	lock := d.keyLock(d.namespace, key)
+	lock.Lock()
+	defer lock.Unlock()
+
 	info, err := os.Stat(fullPath)
 	if err != nil {
 		return errors.Errorf("failed to stat file: %w", err)
 	}
-
 	if err := os.Remove(fullPath); err != nil {
 		return errors.Errorf("failed to remove file: %w", err)
 	}
-
-	// Remove metadata
 	if err := d.db.delete(d.namespace, key); err != nil {
 		return errors.Errorf("failed to delete TTL metadata: %w", err)
 	}
@@ -271,28 +285,43 @@ func (d *Disk) Stat(ctx context.Context, key Key, opts ...Option) (http.Header, 
 	return headers, nil
 }
 
+func (d *Disk) openLocked(key Key, fullPath string, now time.Time) (f *os.File, headers http.Header, expired bool, err error) {
+	lock := d.keyLock(d.namespace, key)
+	lock.RLock()
+	defer lock.RUnlock()
+
+	f, err = os.Open(fullPath)
+	if err != nil {
+		return nil, nil, false, errors.Errorf("failed to open file: %w", err)
+	}
+	expiresAt, err := d.db.getTTL(d.namespace, key)
+	if err != nil {
+		return nil, nil, false, errors.Join(err, f.Close())
+	}
+	if now.After(expiresAt) {
+		return f, nil, true, nil
+	}
+	headers, err = d.db.getHeaders(d.namespace, key)
+	if err != nil {
+		return nil, nil, false, errors.Join(errors.Errorf("failed to get headers: %w", err), f.Close())
+	}
+	ttl := min(expiresAt.Sub(now), d.config.MaxTTL)
+	if err := d.db.setTTL(d.namespace, key, now.Add(ttl)); err != nil {
+		return nil, nil, false, errors.Join(errors.Errorf("failed to update expiration time: %w", err), f.Close())
+	}
+	return f, headers, false, nil
+}
+
 func (d *Disk) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser, http.Header, error) {
 	path := d.keyToPath(d.namespace, key)
 	fullPath := filepath.Join(d.config.Root, path)
 
-	f, err := os.Open(fullPath)
+	f, headers, expired, err := d.openLocked(key, fullPath, time.Now())
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to open file: %w", err)
+		return nil, nil, err
 	}
-
-	expiresAt, err := d.db.getTTL(d.namespace, key)
-	if err != nil {
-		return nil, nil, errors.Join(err, f.Close())
-	}
-
-	now := time.Now()
-	if now.After(expiresAt) {
+	if expired {
 		return nil, nil, errors.Join(fs.ErrNotExist, f.Close(), d.Delete(ctx, key))
-	}
-
-	headers, err := d.db.getHeaders(d.namespace, key)
-	if err != nil {
-		return nil, nil, errors.Join(errors.Errorf("failed to get headers: %w", err), f.Close())
 	}
 
 	finfo, err := f.Stat()
@@ -300,14 +329,6 @@ func (d *Disk) Open(ctx context.Context, key Key, opts ...Option) (io.ReadCloser
 		return nil, nil, errors.Join(errors.Errorf("failed to stat file for size: %w", err), f.Close())
 	}
 	headers.Set("Content-Length", strconv.FormatInt(finfo.Size(), 10))
-
-	// Reset expiration time to implement LRU
-	ttl := min(expiresAt.Sub(now), d.config.MaxTTL)
-	newExpiresAt := now.Add(ttl)
-
-	if err := d.db.setTTL(d.namespace, key, newExpiresAt); err != nil {
-		return nil, nil, errors.Join(errors.Errorf("failed to update expiration time: %w", err), f.Close())
-	}
 
 	if h, condErr := conditionalShortCircuit(headers, opts); condErr != nil {
 		return nil, h, errors.Join(condErr, f.Close())
@@ -505,17 +526,8 @@ func (w *diskWriter) Close() error {
 		return errors.Errorf("failed to create directory: %w", err)
 	}
 
-	// Check if we're overwriting an existing file and subtract its size
-	if info, err := os.Stat(w.path); err == nil {
-		w.disk.size.Add(-info.Size())
-	}
-
-	if err := os.Rename(w.tempPath, w.path); err != nil {
-		return errors.Errorf("failed to rename temp file: %w", err)
-	}
-
-	if err := w.disk.db.set(w.key, w.namespace, w.expiresAt, w.headers); err != nil {
-		return errors.Join(errors.Errorf("failed to set metadata: %w", err), os.Remove(w.path))
+	if err := w.commitLocked(); err != nil {
+		return err
 	}
 
 	w.disk.size.Add(w.size)
@@ -525,6 +537,23 @@ func (w *diskWriter) Close() error {
 	default:
 	}
 
+	return nil
+}
+
+func (w *diskWriter) commitLocked() error {
+	lock := w.disk.keyLock(w.namespace, w.key)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if info, err := os.Stat(w.path); err == nil {
+		w.disk.size.Add(-info.Size())
+	}
+	if err := os.Rename(w.tempPath, w.path); err != nil {
+		return errors.Errorf("failed to rename temp file: %w", err)
+	}
+	if err := w.disk.db.set(w.key, w.namespace, w.expiresAt, w.headers); err != nil {
+		return errors.Join(errors.Errorf("failed to set metadata: %w", err), os.Remove(w.path))
+	}
 	return nil
 }
 

--- a/internal/cache/disk_test.go
+++ b/internal/cache/disk_test.go
@@ -1,12 +1,19 @@
 package cache_test
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
 	"log/slog"
+	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
 
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/cache/cachetest"
@@ -51,4 +58,84 @@ func TestDiskCacheSoak(t *testing.T) {
 		Concurrency:      8,
 		TTL:              5 * time.Minute,
 	})
+}
+
+func TestDiskOpenRevisionAtomic(t *testing.T) {
+	dir := t.TempDir()
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelError})
+	c, err := cache.NewDisk(ctx, cache.DiskConfig{Root: dir, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	defer c.Close()
+
+	key := cache.NewKey("revision-atomic")
+
+	write := func(rev int) {
+		body := bytes.Repeat([]byte{byte(rev)}, 4096+rev)
+		sum := sha256.Sum256(body)
+		raw := hex.EncodeToString(sum[:])
+		w, err := c.Create(ctx, key, http.Header{}, time.Hour, cache.WithETag(raw))
+		if err != nil {
+			t.Errorf("create: %v", err)
+			return
+		}
+		if _, err := w.Write(body); err != nil {
+			t.Errorf("write: %v", errors.Join(err, w.Abort(err)))
+			return
+		}
+		if err := w.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	}
+
+	write(0)
+
+	const writers, readsPerReader, readers = 4, 500, 4
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for range writers {
+		wg.Go(func() {
+			for rev := 1; ; rev++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				write(rev % 251)
+			}
+		})
+	}
+
+	for range readers {
+		wg.Go(func() {
+			for range readsPerReader {
+				r, headers, err := c.Open(ctx, key)
+				if err != nil {
+					t.Errorf("open: %v", err)
+					continue
+				}
+				body, err := io.ReadAll(r)
+				_ = r.Close()
+				if err != nil {
+					t.Errorf("read: %v", err)
+					continue
+				}
+				sum := sha256.Sum256(body)
+				want, err := cache.FormatETag(hex.EncodeToString(sum[:]))
+				if err != nil {
+					t.Errorf("format etag: %v", err)
+					continue
+				}
+				if got := headers.Get(cache.ETagKey); got != want {
+					t.Errorf("etag/body mismatch: header %s does not match body hash %s (spliced revision)", got, want)
+				}
+			}
+		})
+	}
+
+	go func() {
+		time.Sleep(time.Second)
+		close(stop)
+	}()
+	wg.Wait()
 }


### PR DESCRIPTION
`Disk.Open` read the file descriptor and the ETag from BoltDB without synchronisation, while `diskWriter.Close` renamed the body then wrote metadata as two separate steps. A concurrent replacement interleaving those reads could return one revision's bytes with another's ETag. With `ParallelGet` this passes the chunk-0 consistency check but splices old and new bytes across later chunks, so per-chunk ETag pinning did not actually bind the served body to the returned metadata.

Guard each key's body swap with a striped `RWMutex`: `Open` captures the `(descriptor, headers)` pair under a read lock, and `Close`/`Delete` perform the rename/remove plus metadata write under the write lock. `os.Open` binds the descriptor to a stable inode, so the captured pair stays revision-consistent for the descriptor's lifetime.

Adds `TestDiskOpenRevisionAtomic`, which asserts the returned ETag re-hashes to the returned body under concurrent replacement (fails on `main`, passes with the fix).

Closes #348