### PR TITLE
feat(cache): heal divergent tier 0 on ranged reads

### DIFF
--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -25,6 +25,7 @@ type Tiered struct {
 	metadata  *metadatadb.Store
 	etags     *metadatadb.Map[Key, string]
 	namespace Namespace
+	healer    *tieredHealer
 }
 
 // MaybeNewTiered creates a [Tiered] cache from one or more caches.
@@ -41,7 +42,7 @@ func MaybeNewTiered(ctx context.Context, caches []Cache, metadata *metadatadb.St
 	if metadata == nil {
 		panic("Tiered cache requires a metadata store")
 	}
-	return Tiered{caches: caches, metadata: metadata, etags: tieredETags(metadata, "")}
+	return Tiered{caches: caches, metadata: metadata, etags: tieredETags(metadata, ""), healer: newTieredHealer(ctx)}
 }
 
 type authoritativeCache struct {
@@ -60,6 +61,11 @@ var _ Cache = (*Tiered)(nil)
 
 // Close all underlying caches.
 func (t Tiered) Close() error {
+	// Drain in-flight heals before closing the caches they operate on.
+	if t.healer != nil {
+		t.healer.cancel()
+		t.healer.wg.Wait()
+	}
 	wg := sync.WaitGroup{}
 	errs := make([]error, len(t.caches))
 	for i, cache := range t.caches {
@@ -276,10 +282,7 @@ func (t Tiered) Open(ctx context.Context, key Key, opts ...Option) (io.ReadClose
 		if fallback != nil {
 			discardTieredReader(ctx, key, fallback)
 		}
-		if i > 0 && !partial {
-			r = t.backfillReader(ctx, key, r, headers, t.caches[0])
-		}
-		return r, headers, nil
+		return t.convergeTier0(ctx, key, r, headers, c, i, partial), headers, nil
 	}
 	if len(probeErrs) > 0 {
 		if fallback != nil {
@@ -363,6 +366,126 @@ func backfillCreateOptions(headers http.Header) []Option {
 		return nil
 	}
 	return []Option{WithETag(rawETag)}
+}
+
+const tieredHealTimeout = 5 * time.Minute
+
+type healKey struct {
+	namespace Namespace
+	key       Key
+}
+
+const tieredHealMaxConcurrency = 8
+
+var errHealSuperseded = errors.New("heal superseded by concurrent write")
+
+type tieredHealer struct {
+	mu       sync.Mutex
+	inflight map[healKey]struct{}
+	sem      chan struct{}
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+func newTieredHealer(ctx context.Context) *tieredHealer {
+	hctx, cancel := context.WithCancel(context.WithoutCancel(ctx)) //nolint:gosec // cancel is stored and called in Close
+	return &tieredHealer{inflight: map[healKey]struct{}{}, sem: make(chan struct{}, tieredHealMaxConcurrency), ctx: hctx, cancel: cancel}
+}
+
+func (h *tieredHealer) trigger(reqCtx context.Context, id healKey, heal func(context.Context)) {
+	h.mu.Lock()
+	if _, ok := h.inflight[id]; ok {
+		h.mu.Unlock()
+		return
+	}
+	// Opportunistically skip when saturated; a later divergent read re-triggers.
+	select {
+	case h.sem <- struct{}{}:
+	default:
+		h.mu.Unlock()
+		return
+	}
+	h.inflight[id] = struct{}{}
+	h.mu.Unlock()
+
+	ctx := logging.ContextWithLogger(h.ctx, logging.FromContext(reqCtx))
+	h.wg.Go(func() {
+		defer func() {
+			h.mu.Lock()
+			delete(h.inflight, id)
+			h.mu.Unlock()
+			<-h.sem
+		}()
+		heal(ctx)
+	})
+}
+
+func (t Tiered) convergeTier0(ctx context.Context, key Key, r io.ReadCloser, headers http.Header, source Cache, tier int, partial bool) io.ReadCloser {
+	switch {
+	case tier == 0:
+		return r
+	case !partial:
+		return t.backfillReader(ctx, key, r, headers, t.caches[0])
+	default:
+		// A ranged body can't backfill tier 0, so refresh it out of band;
+		// otherwise a divergent tier 0 never converges under ParallelGet.
+		t.healTier0(ctx, key, source, headers.Get(ETagKey))
+		return r
+	}
+}
+
+func (t Tiered) healTier0(reqCtx context.Context, key Key, source Cache, servedETag string) {
+	if t.healer == nil || servedETag == "" {
+		return
+	}
+	// Skip if tier 0 is legitimately newer than the served version, so a lagging
+	// deeper tier never overwrites it.
+	want, ok := t.etags.Get(key)
+	if !ok || want != servedETag {
+		return
+	}
+	t.healer.trigger(reqCtx, healKey{namespace: t.namespace, key: key}, func(ctx context.Context) {
+		t.backfillTier0FromSource(ctx, key, source, want)
+	})
+}
+
+func (t Tiered) backfillTier0FromSource(ctx context.Context, key Key, source Cache, wantETag string) {
+	logger := logging.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, tieredHealTimeout)
+	defer cancel()
+
+	r, headers, err := source.Open(ctx, key, IfMatch(wantETag))
+	if err != nil {
+		logger.WarnContext(ctx, "Tiered: ranged heal source read failed", "key", key, "etag", wantETag, "error", err)
+		return
+	}
+	defer discardTieredReader(ctx, key, r)
+	if headers.Get(ETagKey) != wantETag {
+		return
+	}
+
+	w, err := t.caches[0].Create(ctx, key, headers, 0, backfillCreateOptions(headers)...) // 0 → cache's max TTL
+	if err != nil {
+		logger.WarnContext(ctx, "Tiered: ranged heal writer create failed", "key", key, "error", err)
+		return
+	}
+	if _, err := io.Copy(w, r); err != nil {
+		logger.WarnContext(ctx, "Tiered: ranged heal copy failed", "key", key, "error", errors.Join(err, w.Abort(err)))
+		return
+	}
+	// A concurrent Delete drops the etag entry; committing then would resurrect an
+	// object that invalidateStale can no longer clean up (it only fires on an
+	// etag mismatch, not a missing entry). Re-check narrows that window.
+	if got, ok := t.etags.Get(key); !ok || got != wantETag {
+		if err := w.Abort(errHealSuperseded); err != nil {
+			logger.WarnContext(ctx, "Tiered: ranged heal abort failed", "key", key, "error", err)
+		}
+		return
+	}
+	if err := w.Close(); err != nil {
+		logger.WarnContext(ctx, "Tiered: ranged heal commit failed", "key", key, "error", err)
+	}
 }
 
 // backfillReadCloser tees reads from src into dst asynchronously. Chunks are
@@ -543,7 +666,7 @@ func (t Tiered) Namespace(namespace Namespace) Cache {
 	for i, c := range t.caches {
 		namespaced[i] = c.Namespace(namespace)
 	}
-	return Tiered{caches: namespaced, metadata: t.metadata, etags: tieredETags(t.metadata, namespace), namespace: namespace}
+	return Tiered{caches: namespaced, metadata: t.metadata, etags: tieredETags(t.metadata, namespace), namespace: namespace, healer: t.healer}
 }
 
 // ListNamespaces returns unique namespaces from all underlying caches.

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -631,6 +633,203 @@ func TestTieredDivergentValidatorPermutations(t *testing.T) {
 				assert.Equal(t, pinned, readAllAndClose(t, r2))
 			})
 		})
+	}
+}
+
+func eventually(t *testing.T, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}
+
+func tierHolds(ctx context.Context, t *testing.T, c cache.Cache, key cache.Key, wantBody []byte, wantETag string) bool {
+	t.Helper()
+	r, headers, err := c.Open(ctx, key)
+	if err != nil {
+		return false
+	}
+	got := readAllAndClose(t, r)
+	return string(got) == string(wantBody) && headers.Get(cache.ETagKey) == wantETag
+}
+
+func TestTieredRangedReadHealsDivergentTier0(t *testing.T) {
+	pinned := []byte("abcdefghij")
+	stale := []byte("0123456789")
+
+	for _, validator := range []struct {
+		name string
+		opts []cache.Option
+	}{
+		{"IfRange", []cache.Option{cache.Range(2, 6), cache.IfRange(`"pinned-etag"`)}},
+		{"IfMatch", []cache.Option{cache.Range(2, 6), cache.IfMatch(`"pinned-etag"`)}},
+	} {
+		t.Run(validator.name, func(t *testing.T) {
+			_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+			store := newMetadataStore(ctx)
+			lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+			assert.NoError(t, err)
+			upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+			assert.NoError(t, err)
+			tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+			defer tiered.Close()
+
+			key := cache.NewKey("heal-ranged")
+			seedTier(ctx, t, tiered, key, stale, "stale-etag")
+			seedTier(ctx, t, tiered, key, pinned, "pinned-etag")
+			seedTier(ctx, t, lower, key, stale, "stale-etag")
+
+			r, headers, err := tiered.Open(ctx, key, validator.opts...)
+			assert.NoError(t, err)
+			assert.Equal(t, []byte("cdef"), readAllAndClose(t, r))
+			assert.Equal(t, `"pinned-etag"`, headers.Get(cache.ETagKey))
+
+			eventually(t, func() bool { return tierHolds(ctx, t, lower, key, pinned, `"pinned-etag"`) })
+
+			assert.NoError(t, upper.Delete(ctx, key))
+			r, headers, err = tiered.Open(ctx, key)
+			assert.NoError(t, err)
+			assert.Equal(t, pinned, readAllAndClose(t, r))
+			assert.Equal(t, `"pinned-etag"`, headers.Get(cache.ETagKey))
+		})
+	}
+}
+
+func TestTieredRangedReadKeepsNewerTier0(t *testing.T) {
+	newer := []byte("abcdefghij")
+	lagging := []byte("0123456789")
+
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("heal-newer-tier0")
+	seedTier(ctx, t, lower, key, newer, "newer-etag")
+	seedTier(ctx, t, upper, key, lagging, "lagging-etag")
+	assert.NoError(t, tieredETags(store, "").Set(key, `"newer-etag"`))
+
+	r, headers, err := tiered.Open(ctx, key, cache.Range(2, 6), cache.IfRange(`"lagging-etag"`))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("2345"), readAllAndClose(t, r))
+	assert.Equal(t, `"lagging-etag"`, headers.Get(cache.ETagKey))
+
+	time.Sleep(100 * time.Millisecond)
+	assert.True(t, tierHolds(ctx, t, lower, key, newer, `"newer-etag"`))
+}
+
+type gatedCache struct {
+	cache.Cache
+	opens   atomic.Int32
+	gate    chan struct{}
+	reached chan struct{}
+	once    sync.Once
+}
+
+func (c *gatedCache) Open(ctx context.Context, key cache.Key, opts ...cache.Option) (io.ReadCloser, http.Header, error) {
+	r, h, err := c.Cache.Open(ctx, key, opts...)
+	if err == nil && c.opens.Add(1) == 2 {
+		return &gatedReader{ReadCloser: r, gate: c.gate, reached: c.reached, once: &c.once}, h, nil
+	}
+	return r, h, err
+}
+
+type gatedReader struct {
+	io.ReadCloser
+	gate    chan struct{}
+	reached chan struct{}
+	once    *sync.Once
+}
+
+func (g *gatedReader) Read(p []byte) (int, error) {
+	g.once.Do(func() {
+		close(g.reached)
+		<-g.gate
+	})
+	return g.ReadCloser.Read(p) //nolint:wrapcheck
+}
+
+type recordingCache struct {
+	cache.Cache
+	armed     atomic.Bool
+	committed chan struct{}
+	aborted   chan struct{}
+}
+
+func (c *recordingCache) Create(ctx context.Context, key cache.Key, headers http.Header, ttl time.Duration, opts ...cache.Option) (cache.Writer, error) {
+	w, err := c.Cache.Create(ctx, key, headers, ttl, opts...)
+	if err == nil && c.armed.Load() {
+		return &recordingWriter{Writer: w, committed: c.committed, aborted: c.aborted}, nil
+	}
+	return w, err
+}
+
+type recordingWriter struct {
+	cache.Writer
+	committed chan struct{}
+	aborted   chan struct{}
+	once      sync.Once
+}
+
+func (w *recordingWriter) Close() error {
+	w.once.Do(func() { close(w.committed) })
+	return w.Writer.Close() //nolint:wrapcheck
+}
+
+func (w *recordingWriter) Abort(err error) error {
+	w.once.Do(func() { close(w.aborted) })
+	return w.Writer.Abort(err) //nolint:wrapcheck
+}
+
+func TestTieredRangedReadHealAbortsAfterConcurrentDelete(t *testing.T) {
+	pinned := []byte("abcdefghij")
+	stale := []byte("0123456789")
+
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	store := newMetadataStore(ctx)
+	lowerMem, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	lower := &recordingCache{Cache: lowerMem, committed: make(chan struct{}), aborted: make(chan struct{})}
+	upperMem, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	upper := &gatedCache{Cache: upperMem, gate: make(chan struct{}), reached: make(chan struct{})}
+	tiered := cache.MaybeNewTiered(ctx, []cache.Cache{lower, upper}, store)
+	defer tiered.Close()
+
+	key := cache.NewKey("heal-delete-race")
+	seedTier(ctx, t, tiered, key, stale, "stale-etag")
+	seedTier(ctx, t, tiered, key, pinned, "pinned-etag")
+	seedTier(ctx, t, lowerMem, key, stale, "stale-etag")
+	lower.armed.Store(true)
+
+	r, _, err := tiered.Open(ctx, key, cache.Range(2, 6), cache.IfRange(`"pinned-etag"`))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("cdef"), readAllAndClose(t, r))
+
+	select {
+	case <-upper.reached:
+	case <-time.After(2 * time.Second):
+		close(upper.gate)
+		t.Fatal("heal did not open source")
+	}
+	assert.NoError(t, tieredETags(store, "").Delete(key))
+	close(upper.gate)
+
+	select {
+	case <-lower.aborted:
+	case <-lower.committed:
+		t.Fatal("heal committed after the etag entry was removed (resurrection)")
+	case <-time.After(2 * time.Second):
+		t.Fatal("heal did not finish")
 	}
 }
 


### PR DESCRIPTION
Ranged pinned reads (`client.ParallelGet` chunks) served from a deeper tier can't backfill tier 0 — a partial body must never be stored as the whole object — so a stale/divergent tier-0 replica never converges under parallel downloads. Every chunk pays a wasted tier-0 open plus a deeper-tier fetch indefinitely.

When `Tiered.Open` serves a ranged body from a deeper tier, it now schedules an async full-object refresh of tier 0 from that tier. The refresh is:

- **Gated** on the served version being the authoritative one tracked in the etag map, so a tier 0 that is legitimately newer than a lagging deeper tier is never overwritten (re-checked immediately before commit; a residual race self-corrects via `invalidateStale` on the next read).
- **Version-pinned** (`IfMatch` on the source read) and aborted on any copy/mismatch failure.
- **Per-key deduplicated**, bounded by a concurrency semaphore (opportunistic — skips when saturated, a later divergent read re-triggers), and drained on `Close`.

Full-body reads still heal via the existing inline backfill. Closes #368.