### PR TITLE
fix(cache): serve aged S3 data objects whose companion metadata is stale

### DIFF
--- a/internal/cache/s3.go
+++ b/internal/cache/s3.go
@@ -51,11 +51,17 @@ type S3Config struct {
 }
 
 type S3 struct {
-	logger    *slog.Logger
-	config    S3Config
-	namespace Namespace
-	client    *minio.Client
+	logger         *slog.Logger
+	config         S3Config
+	namespace      Namespace
+	client         *minio.Client
+	companionGrace time.Duration
 }
+
+// s3CompanionGrace generously bounds the gap between a data object landing
+// and its companion write (one small PUT, normally milliseconds) so that
+// only provably orphaned objects are served without a matching companion.
+const s3CompanionGrace = 15 * time.Minute
 
 var _ Cache = (*S3)(nil)
 
@@ -140,9 +146,10 @@ func NewS3(ctx context.Context, config S3Config, clientProvider s3client.ClientP
 	}
 
 	return &S3{
-		logger: logging.FromContext(ctx),
-		config: config,
-		client: client,
+		logger:         logging.FromContext(ctx),
+		config:         config,
+		client:         client,
+		companionGrace: s3CompanionGrace,
 	}, nil
 }
 
@@ -193,12 +200,24 @@ func (s *S3) statAndHeaders(ctx context.Context, key Key) (minio.ObjectInfo, htt
 		return minio.ObjectInfo{}, nil, s3Meta{}, err
 	}
 
-	// Reject metadata that describes a different data object than the one
-	// stored (e.g. interleaved concurrent writes to the same key, or a data
-	// object whose companion has not been written yet). Treating this as a
-	// miss lets the caller fall back to upstream; the next write reconciles.
+	// A companion describing a different data object than the one stored is
+	// either a commit still in flight (the data object lands first, its
+	// companion follows within the same Close) or a companion lost to a crash
+	// or clobbered by an interleaved writer. Young objects stay misses so an
+	// unfinished commit is never readable, per the Create contract. Past the
+	// grace window no commit can still be in flight, and the data object is
+	// self-describing (immutable headers travel in its user metadata) and
+	// complete (uploads are atomic and checksummed), so serve it with its own
+	// expiry rather than hiding a valid object until the next regeneration.
+	// The next expiry refresh or write reconciles the companion. Objects from
+	// older formats that carried the ETag only in the companion stay misses:
+	// serving them without a validator would break conditional requests and
+	// ranged-download consistency checks.
 	if objInfo.UserMetadata[s3TagMetadataKey] != meta.Tag {
-		return minio.ObjectInfo{}, nil, s3Meta{}, os.ErrNotExist
+		if time.Since(objInfo.LastModified) < s.companionGrace || headers.Get(ETagKey) == "" {
+			return minio.ObjectInfo{}, nil, s3Meta{}, os.ErrNotExist
+		}
+		meta = s3Meta{ExpiresAt: objInfo.Expires, Tag: objInfo.UserMetadata[s3TagMetadataKey]}
 	}
 
 	maps.Copy(headers, meta.Headers)
@@ -490,11 +509,45 @@ func (w *s3Writer) Close() error {
 		return err
 	}
 
-	// Skip companion metadata if the context was cancelled via Abort.
-	if w.ctx.Err() == nil {
-		metaHeaders := make(http.Header)
-		metaHeaders.Set(ETagKey, w.headers.Get(ETagKey))
-		return w.s3.writeMeta(w.ctx, w.namespace, w.key, s3Meta{Headers: metaHeaders, ExpiresAt: w.expiresAt, Tag: w.tag})
+	// The data object landed but the write is not committed until the
+	// companion is written. If the write was aborted or the companion write
+	// fails, delete the data object so the uncommitted write cannot age into
+	// the stale-companion fallback and become readable. Cleanup failures
+	// propagate to the caller: a tagged object left behind would become
+	// readable once it ages past the grace window.
+	if w.ctx.Err() != nil {
+		return w.removeUncommitted()
+	}
+	metaHeaders := make(http.Header)
+	metaHeaders.Set(ETagKey, w.headers.Get(ETagKey))
+	if err := w.s3.writeMeta(w.ctx, w.namespace, w.key, s3Meta{Headers: metaHeaders, ExpiresAt: w.expiresAt, Tag: w.tag}); err != nil {
+		return errors.Join(err, w.removeUncommitted())
+	}
+	return nil
+}
+
+// removeUncommitted deletes the data object after its upload succeeded but
+// the write failed to commit. The delete only proceeds while the stored
+// object still carries this writer's tag, so an interleaved writer's
+// committed object is preserved; the residual stat-to-delete race just costs
+// that writer a miss. Failure leaves an orphan equivalent to a crash between
+// the two puts.
+func (w *s3Writer) removeUncommitted() error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(w.ctx), 30*time.Second)
+	defer cancel()
+	objectName := w.s3.keyToPath(w.namespace, w.key)
+	objInfo, err := w.s3.client.StatObject(ctx, w.s3.config.Bucket, objectName, minio.StatObjectOptions{})
+	if err != nil {
+		if minio.ToErrorResponse(err).Code == s3ErrNoSuchKey {
+			return nil
+		}
+		return errors.Errorf("failed to stat uncommitted S3 data object %s: %w", objectName, err)
+	}
+	if objInfo.UserMetadata[s3TagMetadataKey] != w.tag {
+		return nil
+	}
+	if err := w.s3.client.RemoveObject(ctx, w.s3.config.Bucket, objectName, minio.RemoveObjectOptions{}); err != nil {
+		return errors.Errorf("failed to remove uncommitted S3 data object %s: %w", objectName, err)
 	}
 	return nil
 }

--- a/internal/cache/s3_internal_test.go
+++ b/internal/cache/s3_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
 	"github.com/minio/minio-go/v7"
 
 	"github.com/block/cachew/internal/logging"
@@ -35,11 +36,11 @@ func newS3(t *testing.T) *S3 {
 	return s
 }
 
-// TestS3TagMismatchIsMiss verifies that when the companion metadata object
-// describes a different data object than the one stored (the outcome of
-// interleaved concurrent writes to the same key), reads report a cache miss
-// rather than serving the data with mismatched metadata.
-func TestS3TagMismatchIsMiss(t *testing.T) {
+// TestS3StaleCompanionFallsBackToObjectMetadata verifies that a companion
+// describing a different data object than the one stored reads as a miss
+// while the data object is young (a commit may still be in flight), and past
+// the grace window serves the data object with its own embedded metadata.
+func TestS3StaleCompanionFallsBackToObjectMetadata(t *testing.T) {
 	s := newS3(t)
 	defer s.Close()
 
@@ -52,12 +53,14 @@ func TestS3TagMismatchIsMiss(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, w.Close())
 
-	r, _, err := s.Open(ctx, key)
+	r, headers, err := s.Open(ctx, key)
 	assert.NoError(t, err)
 	data, err := io.ReadAll(r)
 	assert.NoError(t, err)
 	assert.NoError(t, r.Close())
 	assert.Equal(t, "hello world", string(data))
+	wantETag := headers.Get(ETagKey)
+	assert.NotEqual(t, "", wantETag)
 
 	// Simulate a stale companion left behind by an interleaved writer: the data
 	// object keeps its tag while the metadata is overwritten with a different
@@ -71,6 +74,157 @@ func TestS3TagMismatchIsMiss(t *testing.T) {
 	assert.IsError(t, err, os.ErrNotExist)
 	_, _, err = s.Open(ctx, key)
 	assert.IsError(t, err, os.ErrNotExist)
+
+	s.companionGrace = 0
+
+	headers, err = s.Stat(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, wantETag, headers.Get(ETagKey))
+
+	r, headers, err = s.Open(ctx, key)
+	assert.NoError(t, err)
+	data, err = io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	assert.Equal(t, "hello world", string(data))
+	assert.Equal(t, wantETag, headers.Get(ETagKey))
+
+	assert.NoError(t, s.client.RemoveObject(ctx, s.config.Bucket, s.metaPath(s.namespace, key), minio.RemoveObjectOptions{}))
+
+	r, headers, err = s.Open(ctx, key)
+	assert.NoError(t, err)
+	data, err = io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	assert.Equal(t, "hello world", string(data))
+	assert.Equal(t, wantETag, headers.Get(ETagKey))
+}
+
+// TestS3StaleCompanionWithoutETagStaysMiss verifies that a data object whose
+// embedded headers carry no ETag (an intermediate format stored the ETag only
+// in the companion) is never served via the stale-companion fallback, since
+// it would be a hit without a validator.
+func TestS3StaleCompanionWithoutETagStaysMiss(t *testing.T) {
+	s := newS3(t)
+	defer s.Close()
+
+	ctx := t.Context()
+	key := NewKey("no-embedded-etag")
+	data := []byte("payload")
+
+	// Write a tagged data object whose embedded headers lack an ETag,
+	// mirroring the format that stored the ETag only in the companion.
+	_, err := s.client.PutObject(ctx, s.config.Bucket, s.keyToPath(s.namespace, key),
+		bytes.NewReader(data), int64(len(data)), minio.PutObjectOptions{
+			UserMetadata: map[string]string{
+				s3TagMetadataKey: "data-tag",
+				"Headers":        `{"Content-Type":["application/octet-stream"]}`,
+			},
+		})
+	assert.NoError(t, err)
+	assert.NoError(t, s.writeMeta(ctx, s.namespace, key, s3Meta{
+		Tag:       "stale-tag",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}))
+
+	s.companionGrace = 0
+
+	_, err = s.Stat(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+	_, _, err = s.Open(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+
+	// Same with the companion missing entirely.
+	assert.NoError(t, s.client.RemoveObject(ctx, s.config.Bucket, s.metaPath(s.namespace, key), minio.RemoveObjectOptions{}))
+	_, _, err = s.Open(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+}
+
+// TestS3AbortedWriteNeverBecomesReadable verifies that a write aborted after
+// its data object upload already succeeded deletes the data object, so the
+// uncommitted write cannot age into the stale-companion fallback.
+func TestS3AbortedWriteNeverBecomesReadable(t *testing.T) {
+	s := newS3(t)
+	defer s.Close()
+
+	ctx := t.Context()
+	key := NewKey("aborted-write")
+
+	w, err := s.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("uncommitted"))
+	assert.NoError(t, err)
+
+	// Complete the upload before aborting: close the pipe so PutObject sees
+	// EOF and finishes, then wait for the data object to land.
+	sw := w.(*s3Writer)
+	assert.NoError(t, sw.pipe.Close())
+	objectName := s.keyToPath(s.namespace, key)
+	for start := time.Now(); ; {
+		if _, err := s.client.StatObject(ctx, s.config.Bucket, objectName, minio.StatObjectOptions{}); err == nil {
+			break
+		}
+		if time.Since(start) > 10*time.Second {
+			t.Fatal("data object never landed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	assert.NoError(t, w.Abort(errors.New("caller aborted")))
+
+	s.companionGrace = 0
+
+	_, _, err = s.Open(ctx, key)
+	assert.IsError(t, err, os.ErrNotExist)
+	_, err = s.client.StatObject(ctx, s.config.Bucket, objectName, minio.StatObjectOptions{})
+	assert.Error(t, err)
+}
+
+// TestS3AbortSparesConcurrentWrite verifies that an aborted
+// writer's cleanup does not delete a concurrent writer's committed data
+// object for the same key: the delete is conditional on the stored object
+// still carrying the aborting writer's tag.
+func TestS3AbortSparesConcurrentWrite(t *testing.T) {
+	s := newS3(t)
+	defer s.Close()
+
+	ctx := t.Context()
+	key := NewKey("aborted-write-interleaved")
+
+	// Writer A uploads its data object but does not commit yet.
+	wa, err := s.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = wa.Write([]byte("writer A"))
+	assert.NoError(t, err)
+	swa := wa.(*s3Writer)
+	assert.NoError(t, swa.pipe.Close())
+	objectName := s.keyToPath(s.namespace, key)
+	for start := time.Now(); ; {
+		if _, err := s.client.StatObject(ctx, s.config.Bucket, objectName, minio.StatObjectOptions{}); err == nil {
+			break
+		}
+		if time.Since(start) > 10*time.Second {
+			t.Fatal("data object never landed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Writer B replaces the object and commits before A's cleanup runs.
+	wb, err := s.Create(ctx, key, nil, time.Hour)
+	assert.NoError(t, err)
+	_, err = wb.Write([]byte("writer B"))
+	assert.NoError(t, err)
+	assert.NoError(t, wb.Close())
+
+	// A's abort must not delete B's committed object.
+	assert.NoError(t, wa.Abort(errors.New("caller aborted")))
+
+	r, _, err := s.Open(ctx, key)
+	assert.NoError(t, err)
+	data, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	assert.Equal(t, "writer B", string(data))
 }
 
 // TestS3LegacyUntaggedObjectIsReadable verifies backwards compatibility: an


### PR DESCRIPTION
The S3 backend commits an object as two sequential writes: the data object, then a companion `.meta` object carrying mutable metadata (ETag, refreshed expiry). A crash or failed write between the two leaves a complete, durable data object whose companion never lands — or describes a different generation after interleaved writers — and reads reported a miss until the next regeneration rewrote the pair.

The data object is self-describing: its immutable headers (including ETag) travel in its own user metadata, and uploads are atomic and checksummed. On tag mismatch, serve it with those headers and its own expiry instead of returning a miss — but only once the object is older than a grace window, so an unfinished commit is never readable (data objects land before their companion within the same `Close`, per the `Cache.Create` contract). The expiry-refresh path then rewrites the companion with the object's tag, reconciling the pair.

Two additional guards keep the fallback from serving anything that shouldn't be readable:

- Objects whose embedded headers lack an ETag (an earlier format stored the ETag only in the companion) stay misses, since a hit without a validator would break conditional requests and ranged-download consistency checks.
- Writes that fail to commit after the data object lands — aborted, or the companion write errors — best-effort delete the data object, so only true crash orphans reach the fallback.
