### PR TITLE
fix(cache): only commit tier 0 backfill entries on complete streams

### DIFF
--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -490,10 +490,10 @@ func (t Tiered) backfillTier0FromSource(ctx context.Context, key Key, source Cac
 
 // backfillReadCloser tees reads from src into dst asynchronously. Chunks are
 // sent to a background goroutine via a buffered channel so the Read path is
-// never blocked by disk I/O (up to ~32 MB of buffer). If the full stream is
-// consumed and Close completes without error, dst is closed normally
-// (committing the cached entry). On any write failure the backfill is
-// abandoned but reads continue unaffected.
+// never blocked by disk I/O (up to ~32 MB of buffer). Only a stream consumed
+// through to io.EOF commits the dst entry; a mid-stream read error or a Close
+// before EOF cancels the write context so the partial entry is discarded. On
+// any write failure the backfill is abandoned but reads continue unaffected.
 type backfillReadCloser struct {
 	src     io.ReadCloser
 	ch      chan []byte
@@ -501,6 +501,7 @@ type backfillReadCloser struct {
 	cancel  context.CancelFunc
 	done    chan error
 	closed  bool
+	eof     bool
 	closeMu sync.Mutex
 }
 
@@ -565,6 +566,15 @@ func (b *backfillReadCloser) Read(p []byte) (int, error) {
 		b.closeMu.Unlock()
 	}
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			b.closeMu.Lock()
+			b.eof = true
+			b.closeMu.Unlock()
+		} else {
+			// Mid-stream failure: cancel so the writer discards the partial
+			// entry instead of committing a truncated object.
+			b.cancel()
+		}
 		b.closeChan()
 	}
 	return n, err //nolint:wrapcheck // must return unwrapped io.EOF per io.Reader contract
@@ -572,6 +582,14 @@ func (b *backfillReadCloser) Read(p []byte) (int, error) {
 
 func (b *backfillReadCloser) Close() error {
 	srcErr := b.src.Close()
+	b.closeMu.Lock()
+	complete := b.eof
+	b.closeMu.Unlock()
+	if !complete {
+		// Closed before EOF: the stream was abandoned or failed, so the
+		// partial entry must be discarded, not committed.
+		b.cancel()
+	}
 	b.closeChan()
 	// Wait for the background writer to finish.
 	bgErr := <-b.done

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -1,6 +1,7 @@
 package cache_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -242,6 +243,92 @@ func TestTieredBackfillPermutations(t *testing.T) {
 			assert.Equal(t, etag, lowerHeaders.Get(cache.ETagKey))
 		})
 	}
+}
+
+func TestTieredBackfillDiscardsIncompleteStreams(t *testing.T) {
+	errMidStream := errors.New("mid-stream failure")
+	newTieredWithFailingUpper := func(t *testing.T, key cache.Key, content []byte, failAfter int) (tiered, lower cache.Cache) {
+		t.Helper()
+		_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+		lower, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+		assert.NoError(t, err)
+		upper, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+		assert.NoError(t, err)
+		seedTier(ctx, t, upper, key, content, "backfill-etag")
+		tiered = newTiered(ctx, lower, midStreamFailingCache{Cache: upper, failAfter: failAfter, err: errMidStream})
+		t.Cleanup(func() { _ = tiered.Close() })
+		return tiered, lower
+	}
+
+	key := cache.NewKey("backfill-truncated")
+	content := bytes.Repeat([]byte("0123456789abcdef"), 64)
+
+	t.Run("MidStreamReadError", func(t *testing.T) {
+		_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+		tiered, lower := newTieredWithFailingUpper(t, key, content, len(content)/2)
+
+		r, _, err := tiered.Open(ctx, key)
+		assert.NoError(t, err)
+		_, err = io.ReadAll(r)
+		assert.IsError(t, err, errMidStream)
+		assert.NoError(t, r.Close())
+
+		_, _, err = lower.Open(ctx, key)
+		assert.IsError(t, err, os.ErrNotExist)
+	})
+
+	t.Run("CloseBeforeEOF", func(t *testing.T) {
+		_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+		tiered, lower := newTieredWithFailingUpper(t, key, content, len(content))
+
+		r, _, err := tiered.Open(ctx, key)
+		assert.NoError(t, err)
+		buf := make([]byte, len(content)/2)
+		_, err = io.ReadFull(r, buf)
+		assert.NoError(t, err)
+		assert.NoError(t, r.Close())
+
+		_, _, err = lower.Open(ctx, key)
+		assert.IsError(t, err, os.ErrNotExist)
+	})
+}
+
+// midStreamFailingCache serves failAfter bytes of each opened object and then
+// fails the read with err, simulating an upstream stream dying mid-transfer.
+type midStreamFailingCache struct {
+	cache.Cache
+	failAfter int
+	err       error
+}
+
+func (c midStreamFailingCache) Open(ctx context.Context, key cache.Key, opts ...cache.Option) (io.ReadCloser, http.Header, error) {
+	r, h, err := c.Cache.Open(ctx, key, opts...)
+	if err != nil {
+		return nil, nil, err //nolint:wrapcheck
+	}
+	return &midStreamFailingReader{r: r, remaining: c.failAfter, err: c.err}, h, nil
+}
+
+type midStreamFailingReader struct {
+	r         io.ReadCloser
+	remaining int
+	err       error
+}
+
+func (r *midStreamFailingReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, r.err
+	}
+	if len(p) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.r.Read(p)
+	r.remaining -= n
+	return n, err //nolint:wrapcheck
+}
+
+func (r *midStreamFailingReader) Close() error {
+	return r.r.Close() //nolint:wrapcheck
 }
 
 func TestTieredCreateUsesSameETagInEveryTier(t *testing.T) {


### PR DESCRIPTION
backfillReadCloser committed the tier 0 entry whenever the background writer finished cleanly, even when the source stream failed mid-read or the reader was closed before EOF. That cached a truncated object into tier 0, which was then served as a hit until the entry was replaced.

Track whether the stream reached EOF and cancel the backfill write otherwise, so partial entries are discarded instead of committed.