### PR TITLE
feat(git): skip snapshot upload when HEAD is unchanged

### DIFF
--- a/internal/cache/tiered.go
+++ b/internal/cache/tiered.go
@@ -208,6 +208,33 @@ func (t Tiered) Stat(ctx context.Context, key Key, opts ...Option) (http.Header,
 	return nil, errors.Join(errs...)
 }
 
+// AuthoritativeStater reports object existence in authoritative shared
+// storage, bypassing local tiers whose copies can outlive a lost shared
+// object.
+type AuthoritativeStater interface {
+	AuthoritativeStat(ctx context.Context, key Key, opts ...Option) (http.Header, error)
+}
+
+var _ AuthoritativeStater = (*Tiered)(nil)
+
+// AuthoritativeStat stats the final tier, which is authoritative by
+// construction.
+func (t Tiered) AuthoritativeStat(ctx context.Context, key Key, opts ...Option) (http.Header, error) {
+	headers, err := t.caches[len(t.caches)-1].Stat(ctx, key, opts...)
+	return headers, errors.WithStack(err)
+}
+
+// StatAuthoritative stats the authoritative tier when the cache is tiered,
+// and falls back to a plain Stat for single-tier caches.
+func StatAuthoritative(ctx context.Context, c Cache, key Key, opts ...Option) (http.Header, error) {
+	if as, ok := c.(AuthoritativeStater); ok {
+		headers, err := as.AuthoritativeStat(ctx, key, opts...)
+		return headers, errors.WithStack(err)
+	}
+	headers, err := c.Stat(ctx, key, opts...)
+	return headers, errors.WithStack(err)
+}
+
 // Open returns a reader from the first cache that succeeds.
 // When a higher tier hits but lower tiers missed, the returned reader
 // transparently backfills the lowest tier as the caller reads, so that

--- a/internal/cache/tiered_test.go
+++ b/internal/cache/tiered_test.go
@@ -364,6 +364,37 @@ func TestTieredRequiresMetadataStore(t *testing.T) {
 	})
 }
 
+func TestStatAuthoritativeBypassesLocalTiers(t *testing.T) {
+	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
+	local, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	shared, err := cache.NewMemory(ctx, cache.MemoryConfig{LimitMB: 1024, MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	tiered := newTiered(ctx, local, shared)
+
+	key := cache.NewKey("stat-authoritative")
+	w, err := tiered.Create(ctx, key, nil, time.Minute)
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("content"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	_, err = cache.StatAuthoritative(ctx, tiered, key)
+	assert.NoError(t, err)
+
+	// A lost shared object must be reported missing even while a local tier
+	// still holds a copy.
+	assert.NoError(t, shared.Delete(ctx, key))
+	_, err = tiered.Stat(ctx, key)
+	assert.NoError(t, err)
+	_, err = cache.StatAuthoritative(ctx, tiered, key)
+	assert.IsError(t, err, os.ErrNotExist)
+
+	// Single-tier caches fall back to a plain Stat.
+	_, err = cache.StatAuthoritative(ctx, local, key)
+	assert.NoError(t, err)
+}
+
 func TestTieredCreateDoesNotPublishMetadataETagForNewKey(t *testing.T) {
 	_, ctx := logging.Configure(t.Context(), logging.Config{Level: slog.LevelDebug})
 	store := newMetadataStore(ctx)

--- a/internal/strategy/git/export_test.go
+++ b/internal/strategy/git/export_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/gitclone"
@@ -13,11 +14,20 @@ import (
 func IsGitRequest(pathValue string) bool { return isGitRequest(pathValue) }
 
 func (s *Strategy) GenerateAndUploadSnapshot(ctx context.Context, repo *gitclone.Repository) error {
-	return s.generateAndUploadSnapshot(ctx, repo)
+	_, err := s.generateAndUploadSnapshot(ctx, repo)
+	return err
 }
 
 func (s *Strategy) GenerateAndUploadMirrorSnapshot(ctx context.Context, repo *gitclone.Repository) error {
-	return s.generateAndUploadMirrorSnapshot(ctx, repo)
+	_, err := s.generateAndUploadMirrorSnapshot(ctx, repo)
+	return err
+}
+
+// RunCoordinatedSnapshot exports the coordinated base-snapshot job for tests.
+func (s *Strategy) RunCoordinatedSnapshot(ctx context.Context, repo *gitclone.Repository, interval time.Duration) error {
+	return s.coordinatedSnapshotJob(snapshotJobBase, repo, interval, func(ctx context.Context) (string, error) {
+		return s.generateAndUploadSnapshot(ctx, repo)
+	})(ctx)
 }
 
 // CacheBundle exports cacheBundle for testing.

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -45,6 +45,7 @@ func Register(r *strategy.Registry, scheduler jobscheduler.Provider, cloneManage
 
 type Config struct {
 	SnapshotInterval       time.Duration `hcl:"snapshot-interval,optional" help:"How often to generate tar.zstd workstation snapshots. 0 disables snapshots." default:"0"`
+	SnapshotMaxAge         time.Duration `hcl:"snapshot-max-age,optional" help:"How long an unchanged snapshot (same HEAD commit) may be served before regeneration. Requires shared metadata; keep well below the cache max-ttl. 0 regenerates every interval." default:"24h"`
 	MirrorSnapshotInterval time.Duration `hcl:"mirror-snapshot-interval,optional" help:"How often to generate mirror snapshots for pod bootstrap. 0 uses snapshot-interval. Defaults to 2h." default:"2h"`
 	RepackInterval         time.Duration `hcl:"repack-interval,optional" help:"How often to run full repack. 0 disables." default:"0"`
 	ZstdThreads            int           `hcl:"zstd-threads,optional" help:"Threads for zstd compression/decompression. 0 = all CPU cores; useful for short-lived CLI invocations but risky on a long-running server where multiple snapshot/restore operations can run concurrently." default:"4"`

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -110,7 +110,7 @@ func (s *Strategy) withSnapshotClone(ctx context.Context, repo *gitclone.Reposit
 	return fn(workDir)
 }
 
-func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone.Repository) (returnErr error) {
+func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone.Repository) (commit string, returnErr error) {
 	upstream := repo.UpstreamURL()
 	ctx, span := tracer.Start(ctx, "git.snapshot.generate",
 		trace.WithAttributes(
@@ -136,6 +136,11 @@ func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone
 	defer mu.Unlock()
 
 	cacheKey := snapshotCacheKey(upstream)
+	if head := s.getMirrorHead(ctx, repo); s.snapshotUnchanged(ctx, snapshotJobBase, cacheKey, upstream, head) {
+		s.metrics.recordOperation(ctx, "snapshot", "unchanged", time.Since(start))
+		logger.InfoContext(ctx, "Snapshot unchanged, skipping generation", "upstream", upstream, "commit", head)
+		return "", nil
+	}
 	if err := s.withSnapshotClone(ctx, repo, "base", func(workDir string) error {
 		// Capture the snapshot's HEAD so we can later build a delta bundle between
 		// the cached snapshot and the current mirror state.
@@ -143,17 +148,18 @@ func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone
 		if err != nil {
 			return errors.Wrap(err, "rev-parse HEAD for snapshot")
 		}
+		commit = headSHA
 		extraHeaders := http.Header{}
 		extraHeaders.Set("X-Cachew-Snapshot-Commit", headSHA)
 
 		return snapshot.Create(ctx, s.cache, cacheKey, workDir, 0, nil, s.config.ZstdThreads, extraHeaders)
 	}); err != nil {
-		return errors.Wrap(err, "create snapshot")
+		return "", errors.Wrap(err, "create snapshot")
 	}
 
 	s.metrics.recordOperation(ctx, "snapshot", "success", time.Since(start))
 	logger.InfoContext(ctx, "Snapshot generation completed", "upstream", upstream)
-	return nil
+	return commit, nil
 }
 
 // generateAndUploadMirrorSnapshot creates a snapshot of the bare mirror
@@ -161,7 +167,7 @@ func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone
 // restored directly as a mirror without any conversion. This is used for
 // pod-to-pod bootstrap: a new cachew pod restores the mirror snapshot and
 // is immediately ready to serve, with background fetch handling freshening.
-func (s *Strategy) generateAndUploadMirrorSnapshot(ctx context.Context, repo *gitclone.Repository) (returnErr error) {
+func (s *Strategy) generateAndUploadMirrorSnapshot(ctx context.Context, repo *gitclone.Repository) (commit string, returnErr error) {
 	upstream := repo.UpstreamURL()
 	ctx, span := tracer.Start(ctx, "git.snapshot.generate_mirror",
 		trace.WithAttributes(
@@ -190,17 +196,56 @@ func (s *Strategy) generateAndUploadMirrorSnapshot(ctx context.Context, repo *gi
 
 	// Hold the fetch semaphore while tar-ing the bare mirror directory.
 	// Without this, a concurrent git fetch can replace packed-refs mid-read,
-	// causing tar to capture a truncated file.
+	// causing tar to capture a truncated file. HEAD is read and the
+	// unchanged check runs under the same exclusion so an in-flight fetch
+	// can't advance the mirror between the check and the tar.
+	var skipped bool
 	if err := repo.WithFetchExclusion(ctx, func() error {
 		return repo.WithReadLock(func() error {
+			// HEAD is a proxy for the whole mirror: branch refs can move
+			// while HEAD is stable, so a skipped mirror snapshot may miss
+			// ref updates for up to snapshot-max-age. Restored pods
+			// immediately fetch to freshen, which covers that drift.
+			commit = s.getMirrorHead(ctx, repo)
+			if s.snapshotUnchanged(ctx, snapshotJobMirror, cacheKey, upstream, commit) {
+				skipped = true
+				return nil
+			}
 			return snapshot.Create(ctx, s.cache, cacheKey, repo.Path(), 0, excludePatterns, s.config.ZstdThreads)
 		})
 	}); err != nil {
-		return errors.Wrap(err, "create mirror snapshot")
+		return "", errors.Wrap(err, "create mirror snapshot")
+	}
+	if skipped {
+		logger.InfoContext(ctx, "Mirror snapshot unchanged, skipping generation", "upstream", upstream, "commit", commit)
+		return "", nil
 	}
 
 	logger.InfoContext(ctx, "Mirror snapshot generation completed", "upstream", upstream)
-	return nil
+	return commit, nil
+}
+
+// Coordinated snapshot job names, shared between scheduling and the
+// per-generator unchanged-skip checks.
+const (
+	snapshotJobBase   = "snapshot"
+	snapshotJobLFS    = "lfs-snapshot"
+	snapshotJobMirror = "mirror-snapshot"
+)
+
+// snapshotUnchanged reports whether generation can be skipped: the last
+// completed generation captured the same commit recently enough that its
+// cache entry cannot have expired, and the entry still exists in
+// authoritative shared storage. The existence check keeps a lost entry
+// (crash, manual delete) from going unrepaired until the record ages out; it
+// must probe the authoritative tier because a local tier's copy can outlive
+// a lost shared object and would otherwise mask the loss from every replica.
+func (s *Strategy) snapshotUnchanged(ctx context.Context, job string, key cache.Key, upstream, head string) bool {
+	if !s.snapshotCoord.Unchanged(job, upstream, head, s.config.SnapshotMaxAge) {
+		return false
+	}
+	_, err := cache.StatAuthoritative(ctx, s.cache, key)
+	return err == nil
 }
 
 // snapshotStartupSpread staggers each replica's first coordinated snapshot
@@ -211,7 +256,7 @@ const snapshotStartupSpread = 5 * time.Minute
 
 func (s *Strategy) scheduleSnapshotJobs(repo *gitclone.Repository) {
 	upstream := repo.UpstreamURL()
-	submit := func(job string, interval time.Duration, generate func(ctx context.Context) error) {
+	submit := func(job string, interval time.Duration, generate func(ctx context.Context) (string, error)) {
 		run := s.coordinatedSnapshotJob(job, repo, interval, generate)
 		delay, interval := s.snapshotSchedule(interval)
 		if delay == 0 {
@@ -224,20 +269,20 @@ func (s *Strategy) scheduleSnapshotJobs(repo *gitclone.Repository) {
 			s.scheduler.SubmitPeriodicJob(upstream, job+"-periodic", interval, run)
 		})
 	}
-	submit("snapshot", s.config.SnapshotInterval, func(ctx context.Context) error {
+	submit(snapshotJobBase, s.config.SnapshotInterval, func(ctx context.Context) (string, error) {
 		if err := s.doFetch(ctx, repo); err != nil {
 			logging.FromContext(ctx).WarnContext(ctx, "Pre-snapshot fetch failed", "upstream", upstream, "error", err)
 		}
 		return s.generateAndUploadSnapshot(ctx, repo)
 	})
-	submit("lfs-snapshot", s.config.SnapshotInterval, func(ctx context.Context) error {
+	submit(snapshotJobLFS, s.config.SnapshotInterval, func(ctx context.Context) (string, error) {
 		return s.generateAndUploadLFSSnapshot(ctx, repo)
 	})
 	mirrorInterval := s.config.MirrorSnapshotInterval
 	if mirrorInterval == 0 {
 		mirrorInterval = s.config.SnapshotInterval
 	}
-	submit("mirror-snapshot", mirrorInterval, func(ctx context.Context) error {
+	submit(snapshotJobMirror, mirrorInterval, func(ctx context.Context) (string, error) {
 		return s.generateAndUploadMirrorSnapshot(ctx, repo)
 	})
 }
@@ -259,8 +304,11 @@ func (s *Strategy) snapshotSchedule(interval time.Duration) (delay, jittered tim
 // coordinatedSnapshotJob wraps a snapshot generation job with cross-replica
 // coordination: the job is skipped when another replica generated the
 // artifact recently or is generating it now. Coordination failures fail open
-// so a broken metadata store never stops snapshot generation.
-func (s *Strategy) coordinatedSnapshotJob(job string, repo *gitclone.Repository, interval time.Duration, generate func(ctx context.Context) error) func(ctx context.Context) error {
+// so a broken metadata store never stops snapshot generation. generate
+// returns the commit it captured; empty means nothing was uploaded (skipped
+// as unchanged, or nothing to snapshot), which must not count as a completion
+// or the unchanged-skip's max-age bound would drift from the last upload.
+func (s *Strategy) coordinatedSnapshotJob(job string, repo *gitclone.Repository, interval time.Duration, generate func(ctx context.Context) (string, error)) func(ctx context.Context) error {
 	upstream := repo.UpstreamURL()
 	return func(ctx context.Context) error {
 		logger := logging.FromContext(ctx)
@@ -271,10 +319,21 @@ func (s *Strategy) coordinatedSnapshotJob(job string, repo *gitclone.Repository,
 			logger.DebugContext(ctx, "Skipping snapshot generation, fresh or in progress on another replica", "job", job, "upstream", upstream)
 			return nil
 		}
-		if err := generate(ctx); err != nil {
+		commit, err := generate(ctx)
+		if err != nil {
 			return err
 		}
-		if err := s.snapshotCoord.Complete(job, upstream); err != nil {
+		if commit == "" {
+			// Nothing was uploaded, so record a skip rather than a
+			// completion: CompletedAt must keep tracking the last actual
+			// upload, while the skip's CheckedAt keeps peers from re-fetching
+			// an unchanged repo every interval.
+			if err := s.snapshotCoord.Skip(job, upstream); err != nil {
+				logger.WarnContext(ctx, "Failed to record snapshot skip", "job", job, "upstream", upstream, "error", err)
+			}
+			return nil
+		}
+		if err := s.snapshotCoord.Complete(job, upstream, commit); err != nil {
 			logger.WarnContext(ctx, "Failed to record snapshot completion", "job", job, "upstream", upstream, "error", err)
 		}
 		return nil
@@ -946,7 +1005,7 @@ func (s *Strategy) writeSnapshotSpool(w http.ResponseWriter, r *http.Request, re
 		}
 		mu.Unlock()
 		bgCtx := context.WithoutCancel(ctx)
-		if err := s.generateAndUploadSnapshot(bgCtx, repo); err != nil {
+		if _, err := s.generateAndUploadSnapshot(bgCtx, repo); err != nil {
 			logger.ErrorContext(bgCtx, "Background cache upload failed", "upstream", upstreamURL, "error", err)
 		}
 	}()
@@ -1051,7 +1110,7 @@ func snapshotSpoolDirForURL(mirrorRoot, upstreamURL string) (string, error) {
 //
 // The archive stores paths relative to .git/ (e.g. ./lfs/objects/xx/yy/sha256) so that
 // the client can extract it directly into the repo's .git/ directory.
-func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitclone.Repository) (returnErr error) {
+func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitclone.Repository) (commit string, returnErr error) {
 	upstream := repo.UpstreamURL()
 	ctx, span := tracer.Start(ctx, "git.snapshot.generate_lfs",
 		trace.WithAttributes(
@@ -1069,6 +1128,15 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 
 	logger := logging.FromContext(ctx)
 
+	// LFS objects are derived from HEAD, so an unchanged HEAD means the
+	// snapshot content is unchanged. Repos without an LFS entry never pass
+	// the existence check and simply re-run the cheap discovery grep below.
+	head := s.getMirrorHead(ctx, repo)
+	if s.snapshotUnchanged(ctx, snapshotJobLFS, lfsSnapshotCacheKey(upstream), upstream, head) {
+		logger.InfoContext(ctx, "LFS snapshot unchanged, skipping generation", "upstream", upstream, "commit", head)
+		return "", nil
+	}
+
 	// Check if any .gitattributes file at HEAD declares filter=lfs. This searches
 	// the root and all nested .gitattributes, avoiding false negatives for repos
 	// that only configure LFS in subdirectories.
@@ -1083,10 +1151,10 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && exitErr.ExitCode() == 1 {
 			s.metrics.recordLFSPhase(ctx, upstream, "discover", "skipped", time.Since(discoverStart))
 			logger.DebugContext(ctx, "No LFS filter in any .gitattributes, skipping LFS snapshot", "upstream", upstream)
-			return nil
+			return head, nil
 		}
 		s.metrics.recordLFSPhase(ctx, upstream, "discover", "error", time.Since(discoverStart))
-		return errors.Wrap(err, "git grep for LFS filter")
+		return "", errors.Wrap(err, "git grep for LFS filter")
 	}
 	s.metrics.recordLFSPhase(ctx, upstream, "discover", "success", time.Since(discoverStart))
 
@@ -1104,6 +1172,15 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 	if err := s.withSnapshotClone(ctx, repo, "lfs", func(workDir string) error {
 		s.metrics.recordLFSPhase(ctx, upstream, "clone", "success", time.Since(cloneStart))
 		cloneRecorded = true
+
+		// Record the clone's actual HEAD: a concurrent fetch can advance the
+		// mirror between the earlier unchanged check and this clone, and the
+		// coordination record must match the archived content.
+		headSHA, err := revParse(ctx, workDir, "HEAD")
+		if err != nil {
+			return errors.Wrap(err, "rev-parse HEAD for LFS snapshot")
+		}
+		commit = headSHA
 
 		// Set up LFS in the snapshot clone. cloneForSnapshot already restores
 		// remote.origin.url to the upstream URL, so LFS will fetch from GitHub.
@@ -1166,12 +1243,12 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 			s.metrics.recordLFSPhase(ctx, upstream, "clone", "error", time.Since(cloneStart))
 		}
 		s.metrics.recordOperation(ctx, "lfs-snapshot", "error", time.Since(start))
-		return errors.Wrap(err, "create LFS snapshot")
+		return "", errors.Wrap(err, "create LFS snapshot")
 	}
 
 	s.metrics.recordOperation(ctx, "lfs-snapshot", "success", time.Since(start))
 	logger.InfoContext(ctx, "LFS snapshot generation completed", "upstream", upstream)
-	return nil
+	return commit, nil
 }
 
 // dirSizeBytes returns the total size in bytes of regular files under root.

--- a/internal/strategy/git/snapshot_test.go
+++ b/internal/strategy/git/snapshot_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/githubapp"
 	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/metadatadb"
 	"github.com/block/cachew/internal/snapshot"
 	"github.com/block/cachew/internal/strategy/git"
 )
@@ -174,6 +175,81 @@ func createTestMirrorRepoWithFiles(t *testing.T, mirrorPath string, files map[st
 		output, err := cmd.CombinedOutput()
 		assert.NoError(t, err, string(output))
 	}
+}
+
+// addCommitToMirror pushes a new empty commit to the bare mirror so its HEAD
+// moves.
+func addCommitToMirror(t *testing.T, mirrorPath string) {
+	t.Helper()
+	tmpWork := t.TempDir()
+	for _, args := range [][]string{
+		{"clone", mirrorPath, tmpWork},
+		{"-C", tmpWork, "config", "user.email", "test@test.com"},
+		{"-C", tmpWork, "config", "user.name", "Test"},
+		{"-C", tmpWork, "commit", "--allow-empty", "-m", "update"},
+		{"-C", tmpWork, "push", "origin", "HEAD"},
+	} {
+		cmd := exec.Command("git", args...)
+		output, err := cmd.CombinedOutput()
+		assert.NoError(t, err, string(output))
+	}
+}
+
+func TestSnapshotUnchangedSkipsRegeneration(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamURL := "https://github.com/org/repo"
+	mirrorPath := filepath.Join(mirrorRoot, "github.com", "org", "repo")
+	createTestMirrorRepo(t, mirrorPath)
+
+	memCache, err := cache.NewMemory(ctx, cache.MemoryConfig{MaxTTL: time.Hour})
+	assert.NoError(t, err)
+	mux := newTestMux()
+
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{MirrorRoot: mirrorRoot}, nil)
+	s, err := git.New(ctx, git.Config{SnapshotMaxAge: time.Hour}, newTestScheduler(ctx, t), memCache, mux, cm, func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+	s.SetMetadataStore(metadatadb.New(ctx, metadatadb.NewMemoryBackend()))
+
+	manager, err := cm()
+	assert.NoError(t, err)
+	repo, err := manager.GetOrCreate(ctx, upstreamURL)
+	assert.NoError(t, err)
+	waitForReady(t, s)
+
+	// Interval 0 lets every run claim; freshness is enforced by max-age.
+	const interval = time.Duration(0)
+	cacheKey := cache.NewKey(upstreamURL + ".snapshot")
+	etagAt := func() string {
+		headers, err := memCache.Stat(ctx, cacheKey)
+		assert.NoError(t, err)
+		etag := headers.Get(cache.ETagKey)
+		assert.NotZero(t, etag)
+		return etag
+	}
+
+	assert.NoError(t, s.RunCoordinatedSnapshot(ctx, repo, interval))
+	etag1 := etagAt()
+
+	// Unchanged HEAD: the upload is skipped and the ETag stays stable.
+	assert.NoError(t, s.RunCoordinatedSnapshot(ctx, repo, interval))
+	assert.Equal(t, etag1, etagAt())
+
+	// A lost cache entry regenerates despite matching coordination metadata.
+	assert.NoError(t, memCache.Delete(ctx, cacheKey))
+	assert.NoError(t, s.RunCoordinatedSnapshot(ctx, repo, interval))
+	etag2 := etagAt()
+	assert.NotEqual(t, etag1, etag2)
+
+	// A moved HEAD regenerates.
+	addCommitToMirror(t, mirrorPath)
+	assert.NoError(t, s.RunCoordinatedSnapshot(ctx, repo, interval))
+	assert.NotEqual(t, etag2, etagAt())
 }
 
 func TestSnapshotGenerationViaLocalClone(t *testing.T) {

--- a/internal/strategy/git/snapshotcoord.go
+++ b/internal/strategy/git/snapshotcoord.go
@@ -23,10 +23,14 @@ const (
 )
 
 // snapshotGenRecord is the shared per-artifact generation state. StartedAt is
-// the most recent claim; CompletedAt is the most recent successful generation.
+// the most recent claim; CompletedAt is the most recent successful generation;
+// CheckedAt is the most recent claim that ended in a skip (nothing uploaded);
+// Commit is the mirror HEAD that generation captured.
 type snapshotGenRecord struct {
 	StartedAt   time.Time `json:"started_at"`
 	CompletedAt time.Time `json:"completed_at,omitzero"`
+	CheckedAt   time.Time `json:"checked_at,omitzero"`
+	Commit      string    `json:"commit,omitempty"`
 }
 
 // SnapshotCoordinator shares per-artifact generation state across replicas so
@@ -69,8 +73,8 @@ func (c *SnapshotCoordinator) Prime(ctx context.Context) error {
 
 // Claim reports whether this replica should generate the artifact now, and
 // records the claim when it should. It declines when another replica
-// completed a generation within the interval, or holds an unexpired
-// in-progress claim.
+// completed a generation or checked-and-skipped within the interval, or
+// holds an unexpired in-progress claim.
 func (c *SnapshotCoordinator) Claim(job, upstreamURL string, interval time.Duration) (bool, error) {
 	if c == nil {
 		return true, nil
@@ -86,6 +90,13 @@ func (c *SnapshotCoordinator) Claim(job, upstreamURL string, interval time.Durat
 		if !rec.CompletedAt.IsZero() && now.Sub(rec.CompletedAt) < interval {
 			return false, nil
 		}
+		// A checked-and-skipped decision is as fresh as a completion for
+		// claiming purposes: without it, once the last upload ages past the
+		// interval every replica would re-fetch an unchanged repo each
+		// interval instead of one.
+		if !rec.CheckedAt.IsZero() && now.Sub(rec.CheckedAt) < interval {
+			return false, nil
+		}
 		inProgress := rec.CompletedAt.Before(rec.StartedAt)
 		if inProgress && now.Sub(rec.StartedAt) < snapshotClaimTTL {
 			return false, nil
@@ -98,16 +109,48 @@ func (c *SnapshotCoordinator) Claim(job, upstreamURL string, interval time.Durat
 	return true, nil
 }
 
-// Complete records a successful generation so other replicas skip the
-// artifact until it goes stale again.
-func (c *SnapshotCoordinator) Complete(job, upstreamURL string) error {
+// Complete records a successful generation and the commit it captured so
+// other replicas skip the artifact until it goes stale again.
+func (c *SnapshotCoordinator) Complete(job, upstreamURL, commit string) error {
 	if c == nil {
 		return nil
 	}
 	key := snapshotGenKey(job, upstreamURL)
 	rec, _ := c.gens.Get(key)
 	rec.CompletedAt = c.now()
+	rec.Commit = commit
 	return errors.Wrap(c.gens.Set(key, rec), "record snapshot completion")
+}
+
+// Skip records a claim that ended without an upload (unchanged artifact or
+// nothing to snapshot). It clears the in-progress claim and stamps CheckedAt
+// so peers stay suppressed for the freshness interval rather than the claim
+// TTL, without counting as a completion: CompletedAt must keep tracking the
+// last actual upload so Unchanged's maxAge bound holds.
+func (c *SnapshotCoordinator) Skip(job, upstreamURL string) error {
+	if c == nil {
+		return nil
+	}
+	key := snapshotGenKey(job, upstreamURL)
+	rec, _ := c.gens.Get(key)
+	rec.CheckedAt = c.now()
+	if rec.CompletedAt.Before(rec.StartedAt) {
+		rec.StartedAt = rec.CompletedAt
+	}
+	return errors.Wrap(c.gens.Set(key, rec), "record snapshot skip")
+}
+
+// Unchanged reports whether the last completed generation captured the same
+// commit and is recent enough (within maxAge) that its cache entry cannot
+// have expired. Callers skipping on this must not call Complete, so
+// CompletedAt keeps tracking the last actual upload and maxAge bounds both
+// cache-entry age and drift of non-HEAD refs captured in the artifact.
+func (c *SnapshotCoordinator) Unchanged(job, upstreamURL, commit string, maxAge time.Duration) bool {
+	if c == nil || commit == "" || maxAge <= 0 {
+		return false
+	}
+	rec, ok := c.gens.Get(snapshotGenKey(job, upstreamURL))
+	return ok && rec.Commit == commit && !rec.CompletedAt.IsZero() && c.now().Sub(rec.CompletedAt) < maxAge
 }
 
 func snapshotGenKey(job, upstreamURL string) string {

--- a/internal/strategy/git/snapshotcoord_test.go
+++ b/internal/strategy/git/snapshotcoord_test.go
@@ -30,9 +30,46 @@ func TestSnapshotCoordinatorNilSafe(t *testing.T) {
 	claimed, err := c.Claim("snapshot", "https://github.com/foo/bar", time.Hour)
 	assert.NoError(t, err)
 	assert.True(t, claimed)
-	assert.NoError(t, c.Complete("snapshot", "https://github.com/foo/bar"))
+	assert.NoError(t, c.Complete("snapshot", "https://github.com/foo/bar", "abc123"))
+	assert.NoError(t, c.Skip("snapshot", "https://github.com/foo/bar"))
+	assert.False(t, c.Unchanged("snapshot", "https://github.com/foo/bar", "abc123", time.Hour))
 	assert.NoError(t, c.Prime(context.Background()))
 	assert.Zero(t, NewSnapshotCoordinator(nil))
+}
+
+func TestSnapshotCoordinatorUnchanged(t *testing.T) {
+	clock := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	coords := newTestSnapshotCoordinators(t, func() time.Time { return clock }, 2)
+	const upstream = "https://github.com/foo/bar"
+	const maxAge = 24 * time.Hour
+
+	// No completion recorded yet.
+	assert.False(t, coords[0].Unchanged("snapshot", upstream, "abc123", maxAge))
+
+	assert.NoError(t, coords[0].Complete("snapshot", upstream, "abc123"))
+
+	// Peers share the record: same commit within maxAge skips, everything
+	// else regenerates.
+	clock = clock.Add(12 * time.Hour)
+	assert.True(t, coords[1].Unchanged("snapshot", upstream, "abc123", maxAge))
+	assert.False(t, coords[1].Unchanged("snapshot", upstream, "def456", maxAge))
+	assert.False(t, coords[1].Unchanged("snapshot", upstream, "", maxAge))
+	assert.False(t, coords[1].Unchanged("snapshot", upstream, "abc123", 0))
+	assert.False(t, coords[1].Unchanged("lfs-snapshot", upstream, "abc123", maxAge))
+
+	clock = clock.Add(12 * time.Hour)
+	assert.False(t, coords[1].Unchanged("snapshot", upstream, "abc123", maxAge))
+}
+
+func TestSnapshotCoordinatorClaimWithoutCompleteIsNotUnchanged(t *testing.T) {
+	clock := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	coords := newTestSnapshotCoordinators(t, func() time.Time { return clock }, 1)
+	const upstream = "https://github.com/foo/bar"
+
+	claimed, err := coords[0].Claim("snapshot", upstream, time.Hour)
+	assert.NoError(t, err)
+	assert.True(t, claimed)
+	assert.False(t, coords[0].Unchanged("snapshot", upstream, "abc123", 24*time.Hour))
 }
 
 func TestSnapshotCoordinatorFreshArtifactSkips(t *testing.T) {
@@ -44,7 +81,7 @@ func TestSnapshotCoordinatorFreshArtifactSkips(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, claimed)
 	clock = clock.Add(2 * time.Minute)
-	assert.NoError(t, coords[0].Complete("snapshot", upstream))
+	assert.NoError(t, coords[0].Complete("snapshot", upstream, "abc123"))
 
 	clock = clock.Add(10 * time.Minute)
 	claimed, err = coords[1].Claim("snapshot", upstream, time.Hour)
@@ -65,7 +102,7 @@ func TestSnapshotCoordinatorFreshUntilFullInterval(t *testing.T) {
 	claimed, err := coords[0].Claim("snapshot", upstream, time.Hour)
 	assert.NoError(t, err)
 	assert.True(t, claimed)
-	assert.NoError(t, coords[0].Complete("snapshot", upstream))
+	assert.NoError(t, coords[0].Complete("snapshot", upstream, "abc123"))
 
 	// A completion just shy of the full interval still suppresses peers.
 	clock = clock.Add(time.Hour - time.Minute)
@@ -87,7 +124,7 @@ func TestSnapshotCoordinatorShortIntervalStillSuppresses(t *testing.T) {
 	claimed, err := coords[0].Claim("snapshot", upstream, 5*time.Minute)
 	assert.NoError(t, err)
 	assert.True(t, claimed)
-	assert.NoError(t, coords[0].Complete("snapshot", upstream))
+	assert.NoError(t, coords[0].Complete("snapshot", upstream, "abc123"))
 
 	clock = clock.Add(2 * time.Minute)
 	claimed, err = coords[1].Claim("snapshot", upstream, 5*time.Minute)
@@ -116,6 +153,34 @@ func TestSnapshotCoordinatorInProgressClaimSuppressesPeers(t *testing.T) {
 	assert.True(t, claimed)
 }
 
+func TestSnapshotCoordinatorSkipSuppressesPeersForInterval(t *testing.T) {
+	clock := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	coords := newTestSnapshotCoordinators(t, func() time.Time { return clock }, 2)
+	const upstream = "https://github.com/foo/bar"
+
+	claimed, err := coords[0].Claim("snapshot", upstream, time.Hour)
+	assert.NoError(t, err)
+	assert.True(t, claimed)
+	assert.NoError(t, coords[0].Skip("snapshot", upstream))
+
+	// A skip is not a completion, so it never validates an unchanged check.
+	assert.False(t, coords[1].Unchanged("snapshot", upstream, "abc123", 24*time.Hour))
+
+	// But it counts as freshness for claiming: unchanged repos get one
+	// fetch-and-check per interval, not one per replica.
+	clock = clock.Add(time.Minute)
+	claimed, err = coords[1].Claim("snapshot", upstream, time.Hour)
+	assert.NoError(t, err)
+	assert.False(t, claimed)
+
+	// Once the interval elapses a peer claims again, well before the claim
+	// TTL would have allowed had the claim lingered.
+	clock = clock.Add(time.Hour)
+	claimed, err = coords[1].Claim("snapshot", upstream, time.Hour)
+	assert.NoError(t, err)
+	assert.True(t, claimed)
+}
+
 func TestSnapshotCoordinatorFailedGenerationDoesNotMarkFresh(t *testing.T) {
 	clock := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
 	coords := newTestSnapshotCoordinators(t, func() time.Time { return clock }, 2)
@@ -140,7 +205,7 @@ func TestSnapshotCoordinatorKeysAreIndependent(t *testing.T) {
 	claimed, err := c.Claim("snapshot", "https://github.com/foo/bar", time.Hour)
 	assert.NoError(t, err)
 	assert.True(t, claimed)
-	assert.NoError(t, c.Complete("snapshot", "https://github.com/foo/bar"))
+	assert.NoError(t, c.Complete("snapshot", "https://github.com/foo/bar", "abc123"))
 
 	for _, job := range []string{"lfs-snapshot", "mirror-snapshot"} {
 		claimed, err = c.Claim(job, "https://github.com/foo/bar", time.Hour)


### PR DESCRIPTION
When the last completed generation captured the same mirror HEAD recently enough (`snapshot-max-age`, default 24h) and the cache entry still exists, snapshot generation skips the tar/zstd/upload entirely. The cached bytes and ETag stay stable, so in-flight snapshot streams and `If-Match` chunk reads remain valid across generation intervals when nothing changed — overnight ETag collisions drop to ~zero.

The captured commit is recorded on the shared coordination record at completion. A skip releases its claim instead of recording a completion, so the max-age bound keeps tracking the last actual upload and peers aren't suppressed for the full claim TTL. A lost cache entry (crash, expiry, manual delete) fails the existence check and regenerates immediately.

Applies to base, LFS, and mirror snapshots. Mirror snapshots use HEAD as a proxy for the whole mirror: non-HEAD ref drift can be omitted for up to `snapshot-max-age`, which restored pods cover by fetching immediately on startup.
