### PR TITLE
fix(client): make target dirs writable before extracting

### DIFF
--- a/client/archive.go
+++ b/client/archive.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,13 +53,30 @@ func Archive(ctx context.Context, w io.Writer, baseDir string, includePaths []st
 // Extract decompresses a zstd+tar stream from r into directory, preserving
 // file permissions, ownership, and symlinks. threads controls zstd
 // parallelism; 0 uses all CPU cores.
-func Extract(ctx context.Context, r io.Reader, directory string, threads int) error {
+//
+// Existing read-only directories are made owner-writable so tar can replace
+// their contents. tar re-applies archived modes, and a failed extract
+// restores the originals; read-only directories absent from the archive are
+// left owner-writable.
+func Extract(ctx context.Context, r io.Reader, directory string, threads int) (rerr error) {
 	if threads <= 0 {
 		threads = runtime.GOMAXPROCS(0)
 	}
 
 	if err := os.MkdirAll(directory, 0o750); err != nil {
 		return errors.Wrap(err, "failed to create target directory")
+	}
+
+	// Relax read-only dirs (e.g. Hermit package trees) so tar can overwrite
+	// their contents, restoring the original modes if anything fails.
+	relaxed, err := makeTreeWritable(directory)
+	defer func() {
+		if rerr != nil {
+			restoreDirModes(relaxed)
+		}
+	}()
+	if err != nil {
+		return errors.Wrap(err, "failed to make target directory writable")
 	}
 
 	zstdCmd := exec.CommandContext(ctx, "zstd", "-dc", fmt.Sprintf("-T%d", threads)) //nolint:gosec
@@ -101,6 +119,49 @@ func Extract(ctx context.Context, r io.Reader, directory string, threads int) er
 		errs = append(errs, errors.Errorf("tar failed: %w: %s", tarErr, tarStderr.String()))
 	}
 	return errors.Join(errs...)
+}
+
+// dirMode is a directory path and its pre-relaxation mode.
+type dirMode struct {
+	path string
+	mode fs.FileMode
+}
+
+// makeTreeWritable adds owner-write to root and every directory beneath it,
+// returning the changed directories with their original modes. tar overwrites
+// a file by unlinking it, which requires a writable parent directory.
+func makeTreeWritable(root string) ([]dirMode, error) {
+	var changed []dirMode
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		switch {
+		case walkErr != nil:
+			return walkErr
+		case !d.IsDir():
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return errors.Wrapf(err, "failed to stat %s", path)
+		}
+		// Keep setuid/setgid/sticky so relaxing and restoring don't strip them.
+		mode := info.Mode() & (fs.ModePerm | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky)
+		if mode&0o200 == 0 {
+			if err := os.Chmod(path, mode|0o200); err != nil {
+				return errors.Wrapf(err, "failed to make %s writable", path)
+			}
+			changed = append(changed, dirMode{path: path, mode: mode})
+		}
+		return nil
+	})
+	return changed, errors.Wrap(err, "failed to walk target directory")
+}
+
+// restoreDirModes best-effort restores modes relaxed by makeTreeWritable;
+// failures are ignored so the extraction error stays the one reported.
+func restoreDirModes(dirs []dirMode) {
+	for _, d := range dirs {
+		os.Chmod(d.path, d.mode) //nolint:errcheck,gosec
+	}
 }
 
 // runTarZstdPipeline runs tar piped through pzstd, writing compressed output

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -387,6 +387,69 @@ func TestArchiveExtract(t *testing.T) {
 	assert.False(t, slices.Contains(names, "y.log"))
 }
 
+func TestExtractOverReadOnlyTree(t *testing.T) {
+	src := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(src, "pkg", "conf"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(src, "pkg", "conf", "cacerts"), []byte("v2"), 0o444))
+	assert.NoError(t, os.Chmod(filepath.Join(src, "pkg", "conf"), 0o555))
+	assert.NoError(t, os.Chmod(filepath.Join(src, "pkg"), 0o555))
+	t.Cleanup(func() { makeWritable(t, src) })
+
+	var buf bytes.Buffer
+	assert.NoError(t, client.Archive(t.Context(), &buf, src, []string{"pkg"}, nil, 0))
+
+	dst := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(dst, "pkg", "conf"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(dst, "pkg", "conf", "cacerts"), []byte("v1"), 0o444))
+	assert.NoError(t, os.Chmod(filepath.Join(dst, "pkg", "conf"), 0o555))
+	assert.NoError(t, os.Chmod(filepath.Join(dst, "pkg"), 0o555))
+	t.Cleanup(func() { makeWritable(t, dst) })
+
+	assert.NoError(t, client.Extract(t.Context(), &buf, dst, 0))
+
+	got, err := os.ReadFile(filepath.Join(dst, "pkg", "conf", "cacerts"))
+	assert.NoError(t, err)
+	assert.Equal(t, "v2", string(got))
+
+	assertReadOnlyDir(t, filepath.Join(dst, "pkg"))
+	assertReadOnlyDir(t, filepath.Join(dst, "pkg", "conf"))
+}
+
+func TestExtractFailureRestoresDirModes(t *testing.T) {
+	dst := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(dst, "pkg", "conf"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(dst, "pkg", "conf", "cacerts"), []byte("v1"), 0o444))
+	assert.NoError(t, os.Chmod(filepath.Join(dst, "pkg", "conf"), 0o555))
+	assert.NoError(t, os.Chmod(filepath.Join(dst, "pkg"), 0o555|os.ModeSetgid))
+	t.Cleanup(func() { makeWritable(t, dst) })
+
+	err := client.Extract(t.Context(), bytes.NewReader([]byte("not a zstd stream")), dst, 0)
+	assert.Error(t, err)
+
+	info, err := os.Stat(filepath.Join(dst, "pkg"))
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o555)|os.ModeSetgid, info.Mode()&(os.ModePerm|os.ModeSetgid))
+	assertReadOnlyDir(t, filepath.Join(dst, "pkg", "conf"))
+}
+
+func assertReadOnlyDir(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o555), info.Mode().Perm())
+}
+
+// makeWritable re-adds owner-write under root so t.TempDir cleanup can remove it.
+func makeWritable(t *testing.T, root string) {
+	t.Helper()
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err == nil && d.IsDir() {
+			_ = os.Chmod(path, 0o755)
+		}
+		return nil
+	})
+}
+
 func TestOpenIfNoneMatch(t *testing.T) {
 	srv := newFakeServer(nil)
 	defer srv.Close()


### PR DESCRIPTION
## Problem

`Extract` restores a snapshot over the directory a consumer previously extracted into. When that existing tree contains read-only directories — e.g. Hermit marks unpacked package trees `0555` — GNU tar can't replace the existing files: tar replaces a file by unlinking and recreating it, and unlinking requires write permission on the *parent directory*. The whole extract fails with:

```
tar: <path>: Cannot open: File exists
```

Callers then see the restore fail and fall back to a full reinstall, defeating the cache.

`tar --overwrite` doesn't help: it avoids the unlink but then fails on the read-only files themselves with `Cannot open: Permission denied`.

## Fix

Add owner-write to every directory under the target before launching tar. tar re-applies each archived directory's mode as it unpacks, so directories present in the incoming archive get their original permissions back.

If extraction fails — including a partial failure of the relaxing walk itself — the original directory modes are restored (best-effort) so a failed restore doesn't leave a previously read-only tree writable. Stat/walk/chmod errors during the relax step are wrapped and returned rather than swallowed, keeping the existing "restore failed, fall back to install" behavior.

### Known limitation: partial archives

After a *successful* extract, pre-existing read-only directories that are absent from the incoming archive are left owner-writable. This is deliberate and documented on `Extract`; the alternatives are worse:

- Restoring all relaxed dirs on success would clobber modes tar just applied — a dir the archive intentionally changed from `0555` to `0755` would be re-locked, causing visible downstream failures. Leaving a dir owner-writable fails in the benign direction (owner-write is not a privilege boundary; the owner can chmod at any time).
- Knowing exactly which dirs the archive contains requires a second read of a one-shot stream (buffering it, or teeing the decompressed stream into a concurrent `tar -t` and parsing its quoted listing), which adds significant plumbing and new failure modes to a hot path.

If precise mode fidelity for partial archives is wanted, happy to explore the tee/`tar -t` approach in a follow-up.

## Verification

- `TestExtractOverReadOnlyTree` does a real `Archive`/`Extract` round trip: read-only (`0555`) source directories are archived, extracted over a destination containing a stale read-only file under `0555` directories, and the test asserts both that the file contents are replaced and that tar re-applies the archived `0555` directory modes.
- `TestExtractFailureRestoresDirModes` feeds `Extract` a corrupt stream over a read-only tree and asserts the error is returned and the original `0555` modes are restored.
- Confirmed the main test detects the old behavior: with the `archive.go` change stashed, it fails with the exact `tar failed: exit status 2: tar: pkg/conf/cacerts: Cannot open: File exists` error from the report.
- Full `go test ./client/` passes; `gofmt` and `golangci-lint run ./client/...` are clean.
