### PR TITLE
feat: Add incremental git pull-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Cachew (pronounced "cashew") is a tiered, protocol-aware, caching HTTP proxy for
 
 ### Git
 
-Caches Git repositories with two complementary techniques:
+Caches Git repositories with three complementary techniques:
 
 1. **Snapshots** — periodic `.tar.zst` archives that restore 4–5x faster than `git clone`.
 2. **Pack caching** — passthrough caching of packs from `git-upload-pack` for incremental pulls.
+3. **Incremental pull-through**: when the mirror lacks a wanted object, fetches only the missing delta from upstream and serves the pack locally instead of forwarding the whole request. On by default; set `incremental-pullthrough = false` to disable.
 
 Redirect Git traffic through cachew:
 
@@ -26,8 +27,10 @@ cachew git restore https://github.com/org/repo ./repo
 
 ```hcl
 git {
-  snapshot-interval = "1h"
-  repack-interval   = "1h"
+  snapshot-interval         = "1h"
+  repack-interval           = "1h"
+  incremental-pullthrough   = true    # default; false disables incremental pull-through
+  incremental-fetch-timeout = "2m"    # default
 }
 ```
 

--- a/hack/cachew-incremental-report.sh
+++ b/hack/cachew-incremental-report.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# cachew-incremental-report.sh: effectiveness report for cachew's git
+# incremental pull-through feature, read from Prometheus.
+#
+# Metrics used (see cachew git strategy metrics.go):
+#   cachew_git_incremental_serves_total{outcome, repository}          counter
+#   cachew_git_incremental_fetch_duration_seconds{outcome, repository} histogram
+#   cachew_git_incremental_eligible_total{engaged, repository}         counter
+#
+# Usage:
+#   ./cachew-incremental-report.sh [-u prometheus-url] [-n namespace] [-r range] [-t top-n] [--no-color]
+#
+# Prometheus URL can also come from $PROMETHEUS_URL / $PROM_URL.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults / argument parsing
+# ---------------------------------------------------------------------------
+
+PROM_URL="${PROMETHEUS_URL:-${PROM_URL:-}}"
+NAMESPACE="cachew"
+RANGE="24h"
+TOP_N=5
+USE_COLOR=1
+
+# Canonical outcome order (matches internal/strategy/git/incremental.go).
+OUTCOME_ORDER=(
+  local_hit
+  fetched
+  fallback_fetch_failed
+  fallback_missing
+  fallback_local_error
+  client_gone
+  client_gone_after_fetch
+  fallback_not_our_ref
+)
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  -u, --url URL         Prometheus base URL (e.g. https://prometheus.ci.tenstorrent.net)
+                         Defaults to \$PROMETHEUS_URL or \$PROM_URL.
+  -n, --namespace NS     Namespace label to filter on (default: cachew; use '' to omit)
+  -r, --range RANGE      Window to report counter growth over (default: 24h)
+  -t, --top N            Number of top fallback repos to show (default: 5)
+      --no-color         Disable ANSI color output
+  -h, --help             Show this help
+
+Examples:
+  $(basename "$0") -u https://prometheus.ci.tenstorrent.net
+  PROMETHEUS_URL=https://prometheus.ci.tenstorrent.net $(basename "$0") -r 7d
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -u|--url)
+      [[ $# -lt 2 ]] && { echo "error: -u/--url requires a URL argument" >&2; usage >&2; exit 1; }
+      PROM_URL="$2"; shift 2 ;;
+    -n|--namespace)
+      [[ $# -lt 2 ]] && { echo "error: -n/--namespace requires a value" >&2; usage >&2; exit 1; }
+      NAMESPACE="$2"; shift 2 ;;
+    -r|--range)
+      [[ $# -lt 2 ]] && { echo "error: -r/--range requires a duration" >&2; usage >&2; exit 1; }
+      RANGE="$2"; shift 2 ;;
+    -t|--top)
+      [[ $# -lt 2 ]] && { echo "error: -t/--top requires a number" >&2; usage >&2; exit 1; }
+      TOP_N="$2"; shift 2 ;;
+    --no-color) USE_COLOR=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$PROM_URL" ]]; then
+  echo "error: no Prometheus URL given. Use -u/--url or set \$PROMETHEUS_URL." >&2
+  exit 1
+fi
+PROM_URL="${PROM_URL%/}"
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  echo "error: bash >= 4 is required (on macOS: brew install bash)" >&2
+  exit 1
+fi
+
+for bin in curl jq awk seq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "error: '$bin' is required but not found in PATH." >&2; exit 1; }
+done
+
+QUERY_HAD_ERROR=0
+TMP_FILES=()
+
+cleanup() {
+  local f
+  for f in "${TMP_FILES[@]}"; do
+    rm -f "$f"
+  done
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Colors (disabled if not a tty or --no-color)
+# ---------------------------------------------------------------------------
+
+if [[ $USE_COLOR -eq 1 && -t 1 ]]; then
+  BOLD=$'\e[1m'; DIM=$'\e[2m'; RED=$'\e[31m'; GREEN=$'\e[32m'; YELLOW=$'\e[33m'; CYAN=$'\e[36m'; RESET=$'\e[0m'
+else
+  BOLD=""; DIM=""; RED=""; GREEN=""; YELLOW=""; CYAN=""; RESET=""
+fi
+
+# ---------------------------------------------------------------------------
+# Prometheus query helper
+# ---------------------------------------------------------------------------
+
+# ns_label_prefix returns "namespace=\"foo\"," when filtering, or empty when -n ''.
+ns_label_prefix() {
+  if [[ -n "$NAMESPACE" ]]; then
+    printf 'namespace="%s",' "$NAMESPACE"
+  fi
+}
+
+# counter_window <metric> [extra-selector]: PromQL for how much a counter grew
+# within RANGE.
+#
+# increase() alone undercounts here: it baselines on the first sample inside the
+# window, so a series that first appears mid-window or ticks once and stays flat
+# reports 0 - and rare outcomes like fetched and fallback_* are exactly the
+# sparse series this report exists to surface. Differencing the counter across
+# the window edges instead (falling back to the raw value, which already counts
+# from zero at process start, when there is no earlier sample) is exact for
+# those, but loses whatever was counted before a restart. Neither is right on
+# its own, so take whichever is larger, and keep the difference for series
+# increase() drops entirely for want of a second sample.
+counter_window() {
+  local metric="$1" sel="${2:-}" cur prev diff win
+  cur="last_over_time(${metric}{${NSPF}${sel}}[${RANGE}])"
+  prev="last_over_time(${metric}{${NSPF}${sel}}[${RANGE}] offset ${RANGE})"
+  diff="(((${cur}) - (${prev}) >= 0) or (${cur}))"
+  win="increase(${metric}{${NSPF}${sel}}[${RANGE}])"
+  printf '((%s >= %s) or %s or %s)' "$diff" "$win" "$win" "$diff"
+}
+
+# prom_query <promql>: prints the raw JSON `data.result` array on success,
+# prints nothing and returns 1 on any error or non-"success" status.
+prom_query() {
+  local query="$1" resp curl_err status
+  local err_file
+  err_file="$(mktemp -t cachew-report-curl-err.XXXXXX)"
+  TMP_FILES+=("$err_file")
+  if ! resp="$(curl -sS -G --max-time 15 --data-urlencode "query=${query}" "${PROM_URL}/api/v1/query" 2>"${err_file}")"; then
+    curl_err="$(cat "${err_file}" 2>/dev/null)"
+    echo "warning: could not reach Prometheus at ${PROM_URL}: ${curl_err}" >&2
+    return 1
+  fi
+  status="$(jq -r '.status // "error"' <<<"$resp" 2>/dev/null)" || status="error"
+  if [[ "$status" != "success" ]]; then
+    echo "warning: query failed: ${query}" >&2
+    echo "  $(jq -r '.error // "unrecognized response"' <<<"$resp" 2>/dev/null)" >&2
+    return 1
+  fi
+  local result
+  result="$(jq -c '.data.result // []' <<<"$resp" 2>/dev/null)" || result='[]'
+  if [[ "$result" == "null" ]]; then
+    result='[]'
+  fi
+  echo "$result"
+}
+
+# ---------------------------------------------------------------------------
+# Small formatting helpers
+# ---------------------------------------------------------------------------
+
+pct() { # pct <numerator> <denominator> -> "12.3"
+  awk -v a="$1" -v b="$2" 'BEGIN { if (b+0 == 0) { print "0.0" } else { printf "%.1f", (a/b)*100 } }'
+}
+
+fnum() { # fnum <float> -> human count, thousands-separated, no decimals
+  awk -v v="$1" 'BEGIN {
+    n = sprintf("%.0f", v)
+    neg = ""
+    if (n ~ /^-/) { neg = "-"; n = substr(n, 2) }
+    out = ""; len = length(n)
+    for (i = 1; i <= len; i++) {
+      out = out substr(n, i, 1)
+      rem = len - i
+      if (rem > 0 && rem % 3 == 0) out = out ","
+    }
+    print neg out
+  }'
+}
+
+fdur() { # fdur <seconds> -> "1.234s" or "12.3ms"
+  awk -v s="$1" 'BEGIN {
+    if (s+0 < 1) printf "%.1fms", s*1000
+    else printf "%.3fs", s
+  }'
+}
+
+bar() { # bar <pct 0-100> <width> -> a simple ASCII bar
+  local p="$1" width="${2:-30}" filled empty i
+  filled=$(awk -v p="$p" -v w="$width" 'BEGIN { n=int(p/100*w+0.5); if (n<0) n=0; if (n>w) n=w; print n }')
+  empty=$((width - filled))
+  if (( filled > 0 )); then
+    for ((i = 1; i <= filled; i++)); do printf '#'; done
+  fi
+  if (( empty > 0 )); then
+    for ((i = 1; i <= empty; i++)); do printf '.'; done
+  fi
+}
+
+hr() { printf '%s\n' "${DIM}$(printf '─%.0s' $(seq 1 72))${RESET}"; }
+
+# ---------------------------------------------------------------------------
+# Namespace pre-flight
+# ---------------------------------------------------------------------------
+
+# The check spans every incremental instrument, not just serves_total: a
+# deployment where incremental is enabled but has not engaged yet exports
+# eligible_total with engaged="false" and no serves_total at all, and that is a
+# result worth reporting rather than an error worth aborting on.
+if [[ -n "$NAMESPACE" ]]; then
+  ns_check="$(prom_query "count by (namespace) (cachew_git_incremental_serves_total or cachew_git_incremental_eligible_total or cachew_git_incremental_fetch_duration_seconds_count)")" || { QUERY_HAD_ERROR=1; ns_check='[]'; }
+  if [[ "$ns_check" == "[]" || -z "$ns_check" ]]; then
+    echo "${YELLOW}warning: no cachew incremental series found in Prometheus.${RESET}" >&2
+    echo "  Incremental pull-through may be disabled, or the metrics may not be scraped yet." >&2
+    echo "  The report below will be empty; re-run with -n '' to omit the namespace filter." >&2
+  elif ! jq -e --arg ns "$NAMESPACE" '.[] | select(.metric.namespace == $ns)' <<<"$ns_check" >/dev/null 2>&1; then
+    echo "${RED}error: no cachew incremental series with namespace=\"${NAMESPACE}\".${RESET}" >&2
+    echo "  Namespaces present:" >&2
+    jq -r '.[].metric.namespace // "<missing>"' <<<"$ns_check" | sort -u | sed 's/^/    /' >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+
+echo "${BOLD}${CYAN}Cachew Incremental Pull-Through Report${RESET}"
+echo "${DIM}Prometheus: ${PROM_URL}   namespace=${NAMESPACE:-<none>}   range=${RANGE}   $(date -u '+%Y-%m-%d %H:%M:%S UTC')${RESET}"
+hr
+
+NSPF="$(ns_label_prefix)"
+
+# ---------------------------------------------------------------------------
+# 1. Outcome breakdown (cachew_git_incremental_serves_total)
+# ---------------------------------------------------------------------------
+
+declare -A OUTCOME
+for o in "${OUTCOME_ORDER[@]}"; do OUTCOME[$o]=0; done
+
+result="$(prom_query "sum by (outcome) ($(counter_window cachew_git_incremental_serves_total))")" || { QUERY_HAD_ERROR=1; result='[]'; }
+if [[ "$result" != "[]" && -n "$result" ]]; then
+  while IFS=$'\t' read -r outcome value; do
+    [[ -n "$outcome" ]] && OUTCOME[$outcome]="$value"
+  done < <(jq -r '.[] | "\(.metric.outcome)\t\(.value[1])"' <<<"$result")
+fi
+
+TOTAL_SERVES=0
+for o in "${OUTCOME_ORDER[@]}"; do
+  TOTAL_SERVES=$(awk -v t="$TOTAL_SERVES" -v v="${OUTCOME[$o]:-0}" 'BEGIN{printf "%.4f", t+v}')
+done
+
+echo "${BOLD}1. Outcome breakdown${RESET} ${DIM}(incremental_serves_total, last ${RANGE})${RESET}"
+if awk -v t="$TOTAL_SERVES" 'BEGIN{exit !(t==0)}'; then
+  echo "  ${YELLOW}no incremental-serve events in this range. The feature may be disabled or not deployed, or there was no traffic.${RESET}"
+else
+  printf "  %-28s %10s  %6s  %s\n" "outcome" "count" "pct" ""
+  for o in "${OUTCOME_ORDER[@]}"; do
+    p="$(pct "${OUTCOME[$o]:-0}" "$TOTAL_SERVES")"
+    color="$RESET"
+    case "$o" in
+      local_hit|fetched) color="$GREEN" ;;
+      fallback_fetch_failed|fallback_local_error) color="$RED" ;;
+      fallback_missing|fallback_not_our_ref) color="$YELLOW" ;;
+      client_gone|client_gone_after_fetch) color="$DIM" ;;
+    esac
+    printf "  %-28s %10s  %5s%%  ${color}%s${RESET}\n" "$o" "$(fnum "${OUTCOME[$o]:-0}")" "$p" "$(bar "$p" 20)"
+  done
+  printf "  %-28s %10s\n" "TOTAL" "$(fnum "$TOTAL_SERVES")"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 2. Effectiveness: engaged vs pure cache miss
+# ---------------------------------------------------------------------------
+
+ENGAGED=$(awk -v a="${OUTCOME[local_hit]:-0}" -v b="${OUTCOME[fetched]:-0}" 'BEGIN{printf "%.4f", a+b}')
+PURE_MISS=$(awk -v a="${OUTCOME[fallback_fetch_failed]:-0}" -v b="${OUTCOME[fallback_missing]:-0}" -v c="${OUTCOME[fallback_local_error]:-0}" -v d="${OUTCOME[client_gone]:-0}" -v e="${OUTCOME[client_gone_after_fetch]:-0}" -v f="${OUTCOME[fallback_not_our_ref]:-0}" 'BEGIN{printf "%.4f", a+b+c+d+e+f}')
+BEHIND_TOTAL=$(awk -v a="${OUTCOME[fetched]:-0}" -v b="$PURE_MISS" 'BEGIN{printf "%.4f", a+b}')
+
+echo "${BOLD}2. Feature effectiveness${RESET}"
+if awk -v t="$TOTAL_SERVES" 'BEGIN{exit !(t==0)}'; then
+  echo "  ${DIM}n/a (no data)${RESET}"
+else
+  engaged_pct="$(pct "$ENGAGED" "$TOTAL_SERVES")"
+  miss_pct="$(pct "$PURE_MISS" "$TOTAL_SERVES")"
+  echo "  Served without a full upstream passthrough (local_hit + fetched): ${GREEN}${engaged_pct}%${RESET} of incremental traffic"
+  echo "  Fell back to a full passthrough (fallback_* + client_gone*): ${RED}${miss_pct}%${RESET} of incremental traffic  ${DIM}(same cost as pre-feature behavior)${RESET}"
+  if awk -v t="$BEHIND_TOTAL" 'BEGIN{exit !(t==0)}'; then
+    echo "  ${DIM}Mirror was never behind in this range, so there is no fetch-vs-fallback signal to report.${RESET}"
+  else
+    save_pct="$(pct "${OUTCOME[fetched]:-0}" "$BEHIND_TOTAL")"
+    echo "  When the mirror was behind, incremental avoided a full re-clone: ${GREEN}${save_pct}%${RESET} of the time"
+  fi
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 3. Traffic coverage (cachew_git_incremental_eligible_total)
+# ---------------------------------------------------------------------------
+
+declare -A ELIGIBLE
+ELIGIBLE[true]=0
+ELIGIBLE[false]=0
+result="$(prom_query "sum by (engaged) ($(counter_window cachew_git_incremental_eligible_total))")" || { QUERY_HAD_ERROR=1; result='[]'; }
+if [[ "$result" != "[]" && -n "$result" ]]; then
+  while IFS=$'\t' read -r engaged value; do
+    [[ -n "$engaged" ]] && ELIGIBLE[$engaged]="$value"
+  done < <(jq -r '.[] | "\(.metric.engaged)\t\(.value[1])"' <<<"$result")
+fi
+ELIGIBLE_TOTAL=$(awk -v a="${ELIGIBLE[true]}" -v b="${ELIGIBLE[false]}" 'BEGIN{printf "%.4f", a+b}')
+
+echo "${BOLD}3. Traffic coverage${RESET} ${DIM}(incremental_eligible_total: upload-pack POSTs against a ready mirror)${RESET}"
+if awk -v t="$ELIGIBLE_TOTAL" 'BEGIN{exit !(t==0)}'; then
+  echo "  ${DIM}n/a (no data; metric may predate this deployment)${RESET}"
+else
+  engage_rate="$(pct "${ELIGIBLE[true]}" "$ELIGIBLE_TOTAL")"
+  echo "  Engaged (had wants to check):     $(fnum "${ELIGIBLE[true]}")  (${engage_rate}%)"
+  echo "  Skipped (ls-refs/no-wants/etc.):  $(fnum "${ELIGIBLE[false]}")  ($(pct "${ELIGIBLE[false]}" "$ELIGIBLE_TOTAL")%)"
+  if ! awk -v t="$TOTAL_SERVES" 'BEGIN{exit !(t==0)}'; then
+    drift="$(pct "$(awk -v a="${ELIGIBLE[true]}" -v b="$TOTAL_SERVES" 'BEGIN{printf "%.4f", (a>b)?a-b:b-a}')" "$TOTAL_SERVES")"
+    if awk -v d="$drift" 'BEGIN{exit !(d>5)}'; then
+      echo "  ${YELLOW}note: engaged count differs from incremental_serves_total by ${drift}%. Check for a scrape gap, a restart, incremental-pullthrough disabled in this range, or bodies mixing want and want-ref.${RESET}"
+    fi
+  fi
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 4. Latency (cachew_git_incremental_fetch_duration_seconds)
+# ---------------------------------------------------------------------------
+
+echo "${BOLD}4. Latency by outcome${RESET} ${DIM}(incremental_fetch_duration_seconds)${RESET}"
+declare -A AVG_SUM AVG_COUNT P50 P95 P99
+
+result="$(prom_query "sum by (outcome) ($(counter_window cachew_git_incremental_fetch_duration_seconds_sum))")" || { QUERY_HAD_ERROR=1; result='[]'; }
+[[ "$result" != "[]" && -n "$result" ]] && while IFS=$'\t' read -r o v; do [[ -n "$o" ]] && AVG_SUM[$o]="$v"; done < <(jq -r '.[] | "\(.metric.outcome)\t\(.value[1])"' <<<"$result")
+
+result="$(prom_query "sum by (outcome) ($(counter_window cachew_git_incremental_fetch_duration_seconds_count))")" || { QUERY_HAD_ERROR=1; result='[]'; }
+[[ "$result" != "[]" && -n "$result" ]] && while IFS=$'\t' read -r o v; do [[ -n "$o" ]] && AVG_COUNT[$o]="$v"; done < <(jq -r '.[] | "\(.metric.outcome)\t\(.value[1])"' <<<"$result")
+
+for q in 50 95 99; do
+  result="$(prom_query "histogram_quantile(0.${q}, sum by (le, outcome) ($(counter_window cachew_git_incremental_fetch_duration_seconds_bucket)))")" || { QUERY_HAD_ERROR=1; result='[]'; }
+  if [[ "$result" != "[]" && -n "$result" ]]; then
+    while IFS=$'\t' read -r o v; do
+      [[ -n "$o" ]] || continue
+      case "$q" in
+        50) P50[$o]="$v" ;;
+        95) P95[$o]="$v" ;;
+        99) P99[$o]="$v" ;;
+      esac
+    done < <(jq -r '.[] | "\(.metric.outcome)\t\(.value[1])"' <<<"$result")
+  fi
+done
+
+any_duration=0
+for o in "${OUTCOME_ORDER[@]}"; do
+  [[ -n "${AVG_COUNT[$o]:-}" && "${AVG_COUNT[$o]:-0}" != "0" ]] && any_duration=1
+done
+
+if [[ $any_duration -eq 0 ]]; then
+  echo "  ${DIM}n/a (no data)${RESET}"
+else
+  printf "  %-28s %10s %10s %10s %10s\n" "outcome" "avg" "p50" "p95" "p99"
+  for o in "${OUTCOME_ORDER[@]}"; do
+    cnt="${AVG_COUNT[$o]:-0}"
+    if awk -v c="$cnt" 'BEGIN{exit !(c==0)}'; then
+      printf "  %-28s %10s\n" "$o" "no data"
+      continue
+    fi
+    avg=$(awk -v s="${AVG_SUM[$o]:-0}" -v c="$cnt" 'BEGIN{printf "%.6f", s/c}')
+    printf "  %-28s %10s %10s %10s %10s\n" "$o" "$(fdur "$avg")" "$(fdur "${P50[$o]:-0}")" "$(fdur "${P95[$o]:-0}")" "$(fdur "${P99[$o]:-0}")"
+  done
+  echo "  ${DIM}local_hit's near-zero cost is the baseline; fetched/fallback_* show the network cost.${RESET}"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 5. Top repos falling back
+# ---------------------------------------------------------------------------
+
+echo "${BOLD}5. Top ${TOP_N} repos falling back to full passthrough${RESET} ${DIM}(fallback_* + client_gone*)${RESET}"
+result="$(prom_query "topk(${TOP_N}, sum by (repository) ($(counter_window cachew_git_incremental_serves_total 'outcome=~"fallback_.*|client_gone.*"')))")" || { QUERY_HAD_ERROR=1; result='[]'; }
+if [[ "$result" == "[]" || -z "$result" || "$(jq 'length' <<<"$result")" == "0" ]]; then
+  echo "  ${GREEN}none (no fallbacks in this range)${RESET}"
+else
+  i=1
+  while IFS=$'\t' read -r repo value; do
+    printf "  %2d. %-50s %8s\n" "$i" "$repo" "$(fnum "$value")"
+    i=$((i + 1))
+  done < <(jq -r 'sort_by(-(.value[1]|tonumber)) | .[] | "\(.metric.repository)\t\(.value[1])"' <<<"$result")
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 6. Other cachew git traffic, for context
+# ---------------------------------------------------------------------------
+
+echo "${BOLD}6. Other git request volume${RESET} ${DIM}(cachew_git_requests_total: snapshot/bundle/lfs-snapshot/ensure-refs/receive-pack/forward; upload-pack is not in this counter)${RESET}"
+result="$(prom_query "sum by (type) ($(counter_window cachew_git_requests_total))")" || { QUERY_HAD_ERROR=1; result='[]'; }
+if [[ "$result" == "[]" || -z "$result" || "$(jq 'length' <<<"$result")" == "0" ]]; then
+  echo "  ${DIM}n/a (no data)${RESET}"
+else
+  while IFS=$'\t' read -r type value; do
+    printf "  %-24s %10s\n" "$type" "$(fnum "$value")"
+  done < <(jq -r '.[] | "\(.metric.type)\t\(.value[1])"' <<<"$result")
+fi
+
+hr
+if [[ $QUERY_HAD_ERROR -eq 1 ]]; then
+  echo "${RED}${BOLD}One or more queries above failed (see warnings on stderr). The \"n/a\" and zero sections may reflect that rather than genuinely empty data.${RESET}"
+fi
+echo "${DIM}Queries are plain PromQL against ${PROM_URL}/api/v1/query. See the script source for the exact expressions.${RESET}"

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -87,10 +88,16 @@ type Repository struct {
 	path               string
 	upstreamURL        string
 	lastFetch          time.Time
+	lastFetchAttempt   time.Time // set when a git fetch starts, including failures; gates NeedsFetch
 	lastRefCheck       time.Time
 	refCheckValid      bool
+	refCheckStale      bool
+	refCheckErr        error
+	refCheckErrAt      time.Time // set when a ref check fails; gates the failure backoff
+	refCheckInFlight   chan struct{}
 	fetchSem           chan struct{}
 	credentialProvider CredentialProvider
+	lsRemoteRuns       atomic.Int64
 }
 
 type Manager struct {
@@ -340,7 +347,11 @@ func (r *Repository) LastFetch() time.Time {
 func (r *Repository) NeedsFetch(fetchInterval time.Duration) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return time.Since(r.lastFetch) >= fetchInterval
+	last := r.lastFetch
+	if r.lastFetchAttempt.After(last) {
+		last = r.lastFetchAttempt
+	}
+	return time.Since(last) >= fetchInterval
 }
 
 func (r *Repository) WithReadLock(fn func() error) error {
@@ -364,6 +375,7 @@ func (r *Repository) ResetToEmpty() {
 	defer r.mu.Unlock()
 	r.state = StateEmpty
 	r.lastFetch = time.Time{}
+	r.lastFetchAttempt = time.Time{}
 }
 
 // TryStartCloning atomically transitions the repository from StateEmpty to
@@ -671,6 +683,13 @@ func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, e
 
 // executeFetch runs git fetch against upstream. The caller must hold fetchSem.
 func (r *Repository) executeFetch(ctx context.Context, enforceSpeedLimit bool) error {
+	// Record the attempt before the network call so a failure or timeout still
+	// trips NeedsFetch's cooldown and serial requests do not each pay a full
+	// IncrementalFetchTimeout / FetchTimeout during an upstream outage.
+	r.mu.Lock()
+	r.lastFetchAttempt = time.Now()
+	r.mu.Unlock()
+
 	config := DefaultGitTuningConfig()
 
 	args := []string{
@@ -703,6 +722,10 @@ func (r *Repository) executeFetch(ctx context.Context, enforceSpeedLimit bool) e
 
 	r.mu.Lock()
 	r.lastFetch = time.Now()
+	// Drop any cached ref-staleness verdict so the next check reopens instead of
+	// serving a stale "behind" result for the rest of the interval. This also
+	// clears a cached failure, since upstream is now known reachable.
+	r.invalidateRefCheckLocked()
 	r.mu.Unlock()
 	return nil
 }
@@ -711,30 +734,124 @@ func (r *Repository) executeFetch(ctx context.Context, enforceSpeedLimit bool) e
 // If refs are stale it returns NeedsFetch=true so the caller can schedule a
 // background fetch via the job scheduler, rather than fetching synchronously
 // on the request path (which would acquire a write lock and block all serving).
+//
+// Concurrent callers share one check: the first runs the ls-remote while later
+// callers wait on refCheckInFlight and reuse its outcome. Without this, a burst
+// of requests landing in the same window would each issue their own ls-remote
+// against upstream.
 func (r *Repository) EnsureRefsUpToDate(ctx context.Context) (needsFetch bool, err error) {
 	r.mu.Lock()
 	if r.refCheckValid && time.Since(r.lastRefCheck) < r.config.RefCheckInterval {
+		stale, checkErr := r.refCheckStale, r.refCheckErr
 		r.mu.Unlock()
-		return false, nil
+		return stale, checkErr
 	}
+	// A failed check is cached for a short backoff window so that during an
+	// upstream outage serial requests do not each run their own ls-remote and wait
+	// out LsRemoteTimeout. The window is a fraction of RefCheckInterval so
+	// recovery is still noticed promptly, and it is keyed off the failure
+	// timestamp rather than refCheckValid so a check in flight is never mistaken
+	// for a completed one.
+	if r.refCheckErr != nil && time.Since(r.refCheckErrAt) < r.refCheckFailureBackoff() {
+		checkErr := r.refCheckErr
+		r.mu.Unlock()
+		return false, checkErr
+	}
+	if r.refCheckInFlight != nil {
+		ch := r.refCheckInFlight
+		r.mu.Unlock()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return false, errors.Wrap(ctx.Err(), "context cancelled waiting for in-flight ref check")
+		}
+		r.mu.Lock()
+		stale, checkErr := r.refCheckStale, r.refCheckErr
+		r.mu.Unlock()
+		return stale, checkErr
+	}
+	// Record the check time to rate-limit re-entry after a successful check, but
+	// do NOT set refCheckValid=true until the ls-remote succeeds. Otherwise
+	// concurrent callers read a cached "refs up to date" result while the check
+	// is still in flight and skip a fetch they needed.
 	r.lastRefCheck = time.Now()
-	r.refCheckValid = true
+	r.refCheckInFlight = make(chan struct{})
+	inFlight := r.refCheckInFlight
 	r.mu.Unlock()
+
+	defer func() {
+		r.mu.Lock()
+		close(inFlight)
+		r.refCheckInFlight = nil
+		r.mu.Unlock()
+	}()
+
+	// Detach from the caller's context so a disconnecting client cannot fail every
+	// waiter with a cancellation error. runRefCheck applies LsRemoteTimeout
+	// internally.
+	return r.runRefCheck(context.WithoutCancel(ctx))
+}
+
+// refCheckFailureBackoff is how long a failed ref check is cached before another
+// caller may retry it. It is a fraction of RefCheckInterval: long enough to
+// collapse a burst of serial requests during an upstream outage, short enough
+// that recovery is picked up quickly.
+func (r *Repository) refCheckFailureBackoff() time.Duration {
+	return r.config.RefCheckInterval / 4
+}
+
+// invalidateRefCheckLocked drops any cached ref-check verdict, including a
+// cached failure, so the next check reopens. The caller must hold r.mu.
+func (r *Repository) invalidateRefCheckLocked() {
+	r.refCheckValid = false
+	r.refCheckErr = nil
+	r.refCheckErrAt = time.Time{}
+}
+
+// runRefCheck performs the ls-remote comparison for the caller that started the
+// check and records the outcome for callers waiting on it.
+func (r *Repository) runRefCheck(ctx context.Context) (bool, error) {
+	// Bound the whole check, not just the ls-remote: GetLocalRefs holds the
+	// repository read lock across a for-each-ref subprocess, so a hang there
+	// would otherwise wedge the refCheckInFlight singleflight slot forever.
+	ctx, cancel := context.WithTimeout(ctx, r.config.LsRemoteTimeout)
+	defer cancel()
+
+	r.mu.RLock()
+	lastFetchBefore := r.lastFetch
+	r.mu.RUnlock()
+
+	record := func(valid, stale bool, err error) {
+		r.mu.Lock()
+		// A fetch that landed while this check was in flight already invalidated
+		// the cache; do not overwrite that with a pre-fetch verdict.
+		if r.lastFetch.After(lastFetchBefore) {
+			r.mu.Unlock()
+			return
+		}
+		r.refCheckValid = valid
+		r.refCheckStale = stale
+		r.refCheckErr = err
+		if err != nil {
+			r.refCheckErrAt = time.Now()
+		} else {
+			r.refCheckErrAt = time.Time{}
+		}
+		r.mu.Unlock()
+	}
 
 	localRefs, err := r.GetLocalRefs(ctx)
 	if err != nil {
-		return false, errors.Wrap(err, "get local refs")
+		err = errors.Wrap(err, "get local refs")
+		record(false, false, err)
+		return false, err
 	}
 
-	lsCtx, cancel := context.WithTimeout(ctx, r.config.LsRemoteTimeout)
-	defer cancel()
-
-	upstreamRefs, err := r.GetUpstreamRefs(lsCtx)
+	upstreamRefs, err := r.GetUpstreamRefs(ctx)
 	if err != nil {
-		r.mu.Lock()
-		r.refCheckValid = false
-		r.mu.Unlock()
-		return false, errors.Wrap(err, "get upstream refs")
+		err = errors.Wrap(err, "get upstream refs")
+		record(false, false, err)
+		return false, err
 	}
 
 	for ref, upstreamSHA := range upstreamRefs {
@@ -746,13 +863,17 @@ func (r *Repository) EnsureRefsUpToDate(ctx context.Context) (needsFetch bool, e
 		}
 		localSHA, exists := localRefs[ref]
 		if !exists || localSHA != upstreamSHA {
-			r.mu.Lock()
-			r.refCheckValid = false
-			r.mu.Unlock()
+			// Cache the stale verdict under RefCheckInterval so a behind
+			// mirror does not re-issue ls-remote on every serial request;
+			// a successful fetch clears the cache so the next check reopens.
+			record(true, true, nil)
 			return true, nil
 		}
 	}
 
+	// The check succeeded and refs match. Cache the result so subsequent calls
+	// within the interval skip the ls-remote round trip.
+	record(true, false, nil)
 	return false, nil
 }
 
@@ -791,7 +912,7 @@ func (r *Repository) EnsureRefs(
 	// Invalidate the cached ref-check so the normal transparent path also
 	// re-evaluates after our forced fetch.
 	r.mu.Lock()
-	r.refCheckValid = false
+	r.invalidateRefCheckLocked()
 	r.mu.Unlock()
 
 	localRefs, err = r.GetLocalRefs(ctx)
@@ -868,6 +989,7 @@ func (r *Repository) GetLocalRefs(ctx context.Context) (map[string]string, error
 }
 
 func (r *Repository) GetUpstreamRefs(ctx context.Context) (map[string]string, error) {
+	r.lsRemoteRuns.Add(1)
 	// #nosec G204 - r.upstreamURL is controlled by us
 	cmd, err := r.GitCommand(ctx, "ls-remote", r.upstreamURL)
 	if err != nil {

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -569,7 +569,19 @@ func (r *Repository) Fetch(ctx context.Context) error {
 // for catch-up fetches after snapshot restore where the delta may be large and
 // the default Config.FetchTimeout is too short.
 func (r *Repository) FetchWithTimeout(ctx context.Context, timeout time.Duration) error {
-	return r.fetchInternal(ctx, timeout, true, true)
+	_, err := r.fetchInternal(ctx, timeout, true, true)
+	return err
+}
+
+// FetchCoalescing fetches from upstream, coalescing with a concurrent semaphore
+// holder rather than issuing a redundant network call. The attempted flag
+// reports whether this call ran a git fetch itself (true, whether or not it
+// succeeded) or piggy-backed on another holder's work (false), so a caller can
+// tell a failed fetch from a coalesce wait that timed out without ever
+// contacting upstream. Callers that need a guaranteed fetch should fall back to
+// FetchVerified only when attempted is false.
+func (r *Repository) FetchCoalescing(ctx context.Context) (attempted bool, err error) {
+	return r.fetchInternal(ctx, r.config.FetchTimeout, true, true)
 }
 
 // FetchLenient fetches from upstream with the given timeout but without the
@@ -578,7 +590,8 @@ func (r *Repository) FetchWithTimeout(ctx context.Context, timeout time.Duration
 // stall at near-zero transfer rate for minutes — the same situation that
 // executeClone handles by omitting lowSpeedLimit.
 func (r *Repository) FetchLenient(ctx context.Context, timeout time.Duration) error {
-	return r.fetchInternal(ctx, timeout, false, true)
+	_, err := r.fetchInternal(ctx, timeout, false, true)
+	return err
 }
 
 // FetchVerified fetches from upstream, waiting for the fetch semaphore if
@@ -587,17 +600,47 @@ func (r *Repository) FetchLenient(ctx context.Context, timeout time.Duration) er
 // WithFetchExclusion) or its fetch may have failed — so a nil return
 // guarantees this call ran a successful git fetch.
 func (r *Repository) FetchVerified(ctx context.Context) error {
-	return r.fetchInternal(ctx, r.config.FetchTimeout, true, false)
+	_, err := r.fetchInternal(ctx, r.config.FetchTimeout, true, false)
+	return err
 }
 
-func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, enforceSpeedLimit, coalesce bool) error {
+// FetchVerifiedIfAbsent waits for the fetch semaphore and runs a git fetch only
+// when oids are still missing. If a concurrent fetch already brought the objects
+// in while this call waited, or the wait itself was cut short, it returns
+// attempted=false without hitting upstream.
+func (r *Repository) FetchVerifiedIfAbsent(ctx context.Context, oids []string) (attempted bool, err error) {
+	select {
+	case <-r.fetchSem:
+		defer func() { r.fetchSem <- struct{}{} }()
+	case <-ctx.Done():
+		return false, errors.Wrap(ctx.Err(), "context cancelled before acquiring fetch semaphore")
+	}
+
+	missing, err := r.MissingObjects(ctx, oids)
+	if err != nil {
+		return false, err
+	}
+	if len(missing) == 0 {
+		return false, nil
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, r.config.FetchTimeout)
+	defer cancel()
+	return true, r.executeFetch(fetchCtx, true)
+}
+
+// fetchInternal returns attempted=true when this call ran the git fetch itself,
+// whether or not the fetch succeeded, and attempted=false when it never reached
+// upstream: a coalescing caller piggy-backed on another semaphore holder, or the
+// context ended while waiting for the semaphore.
+func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, enforceSpeedLimit, coalesce bool) (attempted bool, err error) {
 	select {
 	case <-r.fetchSem:
 		defer func() {
 			r.fetchSem <- struct{}{}
 		}()
 	case <-ctx.Done():
-		return errors.Wrap(ctx.Err(), "context cancelled before acquiring fetch semaphore")
+		return false, errors.Wrap(ctx.Err(), "context cancelled before acquiring fetch semaphore")
 	default:
 		// The semaphore is held. Coalescing callers treat the holder's work as
 		// their fetch; verified callers wait their turn and fetch themselves.
@@ -605,9 +648,9 @@ func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, e
 			select {
 			case <-r.fetchSem:
 				r.fetchSem <- struct{}{}
-				return nil
+				return false, nil
 			case <-ctx.Done():
-				return errors.Wrap(ctx.Err(), "context cancelled while waiting for fetch")
+				return false, errors.Wrap(ctx.Err(), "context cancelled while waiting for fetch")
 			}
 		}
 		select {
@@ -616,13 +659,18 @@ func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, e
 				r.fetchSem <- struct{}{}
 			}()
 		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "context cancelled before acquiring fetch semaphore")
+			return false, errors.Wrap(ctx.Err(), "context cancelled before acquiring fetch semaphore")
 		}
 	}
 
 	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	return true, r.executeFetch(fetchCtx, enforceSpeedLimit)
+}
+
+// executeFetch runs git fetch against upstream. The caller must hold fetchSem.
+func (r *Repository) executeFetch(ctx context.Context, enforceSpeedLimit bool) error {
 	config := DefaultGitTuningConfig()
 
 	args := []string{
@@ -637,7 +685,7 @@ func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, e
 	}
 	args = append(args, "fetch", "--prune", "--prune-tags")
 
-	cmd, err := r.GitCommand(fetchCtx, args...)
+	cmd, err := r.GitCommand(ctx, args...)
 	if err != nil {
 		return errors.Wrap(err, "create git command")
 	}

--- a/internal/gitclone/manager.go
+++ b/internal/gitclone/manager.go
@@ -98,6 +98,7 @@ type Repository struct {
 	fetchSem           chan struct{}
 	credentialProvider CredentialProvider
 	lsRemoteRuns       atomic.Int64
+	fetchActive        atomic.Bool // true while an executeFetch call is running
 }
 
 type Manager struct {
@@ -352,6 +353,19 @@ func (r *Repository) NeedsFetch(fetchInterval time.Duration) bool {
 		last = r.lastFetchAttempt
 	}
 	return time.Since(last) >= fetchInterval
+}
+
+// FetchInFlight reports whether executeFetch is currently running.
+//
+// Why: lastFetchAttempt is stamped on entry, not completion, so NeedsFetch
+// cannot tell an in-progress fetch from one that just finished. Check this
+// before treating the cooldown as a reason to skip a coalescing wait. A
+// caller that waits may still block up to the in-flight fetch's timeout.
+//
+// Not based on fetchSem: that lock is also held by non-fetch operations
+// (e.g. WithFetchExclusion's snapshot tar).
+func (r *Repository) FetchInFlight() bool {
+	return r.fetchActive.Load()
 }
 
 func (r *Repository) WithReadLock(fn func() error) error {
@@ -683,6 +697,11 @@ func (r *Repository) fetchInternal(ctx context.Context, timeout time.Duration, e
 
 // executeFetch runs git fetch against upstream. The caller must hold fetchSem.
 func (r *Repository) executeFetch(ctx context.Context, enforceSpeedLimit bool) error {
+	// Marks the whole call, not just the subprocess. Kept separate from
+	// fetchSem, which non-fetch operations also hold.
+	r.fetchActive.Store(true)
+	defer r.fetchActive.Store(false)
+
 	// Record the attempt before the network call so a failure or timeout still
 	// trips NeedsFetch's cooldown and serial requests do not each pay a full
 	// IncrementalFetchTimeout / FetchTimeout during an upstream outage.

--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -353,6 +353,53 @@ func TestRepository_FetchVerifiedDoesNotCoalesce(t *testing.T) {
 	assert.True(t, repo.HasCommit(ctx, newSHA))
 }
 
+func TestRepository_FetchCoalescingReportsWhetherItFetched(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	upstreamPath := createBareRepo(t, tmpDir)
+
+	clonePath := filepath.Join(tmpDir, "clone")
+	repo := &Repository{
+		state:       StateEmpty,
+		config:      testRepoConfig(),
+		path:        clonePath,
+		upstreamURL: upstreamPath,
+		fetchSem:    make(chan struct{}, 1),
+	}
+	repo.fetchSem <- struct{}{}
+	assert.NoError(t, repo.Clone(ctx))
+
+	// Coalescing onto a non-fetch semaphore holder reports fetched=false.
+	release := make(chan struct{})
+	acquired := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- repo.WithFetchExclusion(ctx, func() error {
+			close(acquired)
+			<-release
+			return nil
+		})
+	}()
+	<-acquired
+	fetchedDone := make(chan bool, 1)
+	errDone := make(chan error, 1)
+	go func() {
+		fetched, err := repo.FetchCoalescing(ctx)
+		fetchedDone <- fetched
+		errDone <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	assert.NoError(t, <-holderDone)
+	assert.NoError(t, <-errDone)
+	assert.False(t, <-fetchedDone)
+
+	// With the semaphore free, it runs the fetch itself and reports fetched=true.
+	fetched, err := repo.FetchCoalescing(ctx)
+	assert.NoError(t, err)
+	assert.True(t, fetched)
+}
+
 func TestParseGitRefs(t *testing.T) {
 	output := []byte(`
 abc123 refs/heads/main
@@ -684,6 +731,78 @@ func TestRepository_EnsureRefs(t *testing.T) {
 	assert.False(t, fetched)
 	assert.Equal(t, 0, len(missing))
 	assert.Equal(t, newSHA, resolved[head])
+}
+
+func TestRepository_FetchVerifiedIfAbsentPeerDelivered(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	upstreamPath := createBareRepo(t, tmpDir)
+
+	clonePath := filepath.Join(tmpDir, "clone")
+	repo := &Repository{
+		state:       StateEmpty,
+		config:      testRepoConfig(),
+		path:        clonePath,
+		upstreamURL: upstreamPath,
+		fetchSem:    make(chan struct{}, 1),
+	}
+	repo.fetchSem <- struct{}{}
+	assert.NoError(t, repo.Clone(ctx))
+
+	workPath := filepath.Join(tmpDir, "work")
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "f.txt"), []byte("peer"), 0o600))
+	// #nosec G204 - workPath is a t.TempDir() path created by this test
+	branchOut, err := exec.Command("git", "-C", workPath, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	assert.NoError(t, err)
+	branch := strings.TrimSpace(string(branchOut))
+	for _, args := range [][]string{
+		{"git", "-C", workPath, "add", "."},
+		{"git", "-C", workPath, "commit", "-m", "peer"},
+		{"git", "-C", workPath, "push", upstreamPath, "HEAD:" + branch},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+	// #nosec G204 - workPath is a t.TempDir() path created by this test
+	newSHAOut, err := exec.Command("git", "-C", workPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	newSHA := strings.TrimSpace(string(newSHAOut))
+
+	before := repo.LastFetch()
+	release := make(chan struct{})
+	acquired := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- repo.WithFetchExclusion(ctx, func() error {
+			close(acquired)
+			// #nosec G204 - clonePath is a t.TempDir() path created by this test
+			out, fetchErr := exec.Command("git", "-C", clonePath, "fetch", "--prune", "--prune-tags").CombinedOutput()
+			if fetchErr != nil {
+				return fetchErr
+			}
+			_ = out
+			<-release
+			return nil
+		})
+	}()
+	<-acquired
+
+	type result struct {
+		fetched bool
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		fetched, err := repo.FetchVerifiedIfAbsent(ctx, []string{newSHA})
+		done <- result{fetched, err}
+	}()
+	close(release)
+	assert.NoError(t, <-holderDone)
+	res := <-done
+	assert.NoError(t, res.err)
+	assert.False(t, res.fetched, "peer fetch should satisfy wants without this call fetching")
+	assert.Equal(t, before, repo.LastFetch(), "LastFetch must not advance when no fetch ran in this call")
+	assert.True(t, repo.HasCommit(ctx, newSHA))
 }
 
 // TestMirrorConfigAllowsUnreachableSHA verifies that the mirror config lets

--- a/internal/gitclone/manager_test.go
+++ b/internal/gitclone/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
 
 	"github.com/block/cachew/internal/logging"
 )
@@ -293,6 +294,19 @@ func TestRepository_NeedsFetch(t *testing.T) {
 	repo.mu.Unlock()
 
 	assert.False(t, repo.NeedsFetch(15*time.Minute))
+
+	// A recent failed attempt must also suppress NeedsFetch, even when the
+	// last successful fetch is older than the interval.
+	repo.mu.Lock()
+	repo.lastFetch = time.Now().Add(-time.Hour)
+	repo.lastFetchAttempt = time.Now()
+	repo.mu.Unlock()
+	assert.False(t, repo.NeedsFetch(15*time.Minute))
+
+	repo.mu.Lock()
+	repo.lastFetchAttempt = time.Now().Add(-20 * time.Minute)
+	repo.mu.Unlock()
+	assert.True(t, repo.NeedsFetch(15*time.Minute))
 }
 
 func TestRepository_FetchVerifiedDoesNotCoalesce(t *testing.T) {
@@ -398,6 +412,265 @@ func TestRepository_FetchCoalescingReportsWhetherItFetched(t *testing.T) {
 	fetched, err := repo.FetchCoalescing(ctx)
 	assert.NoError(t, err)
 	assert.True(t, fetched)
+}
+
+// testRefCheckConfig returns a Config with a long RefCheckInterval so tests
+// control precisely when the cached ref check expires.
+func testRefCheckConfig() Config {
+	cfg := testRepoConfig()
+	cfg.RefCheckInterval = time.Minute
+	return cfg
+}
+
+// newClonedTestRepo creates an upstream and a mirror clone of it, returning
+// the ready Repository and the upstream path for advancing refs.
+func newClonedTestRepo(t *testing.T, cfg Config) (*Repository, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	upstreamPath := createBareRepo(t, tmpDir)
+	clonePath := filepath.Join(tmpDir, "clone")
+	repo := &Repository{
+		state:       StateEmpty,
+		config:      cfg,
+		path:        clonePath,
+		upstreamURL: upstreamPath,
+		fetchSem:    make(chan struct{}, 1),
+	}
+	repo.fetchSem <- struct{}{}
+	assert.NoError(t, repo.Clone(context.Background()))
+	return repo, upstreamPath
+}
+
+// advanceBareUpstream adds a commit to the work repo that barePath was cloned
+// from and pushes it, moving the upstream ref ahead of any mirror.
+func advanceBareUpstream(t *testing.T, barePath string) {
+	t.Helper()
+	workPath := filepath.Join(filepath.Dir(barePath), "work")
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "f.txt"), []byte("advanced"), 0o600))
+	// #nosec G204 - workPath is derived from barePath, a t.TempDir() path created by this test
+	branchOut, err := exec.Command("git", "-C", workPath, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	assert.NoError(t, err)
+	branch := strings.TrimSpace(string(branchOut))
+	for _, args := range [][]string{
+		{"git", "-C", workPath, "add", "."},
+		{"git", "-C", workPath, "commit", "-m", "advance"},
+		{"git", "-C", workPath, "push", barePath, "HEAD:" + branch},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+}
+
+func TestRepository_EnsureRefsUpToDate_CachesSuccessfulCheck(t *testing.T) {
+	repo, _ := newClonedTestRepo(t, testRefCheckConfig())
+	ctx := context.Background()
+
+	needsFetch, err := repo.EnsureRefsUpToDate(ctx)
+	assert.NoError(t, err)
+	assert.False(t, needsFetch)
+	runs := repo.lsRemoteRuns.Load()
+	assert.Equal(t, int64(1), runs)
+
+	needsFetch, err = repo.EnsureRefsUpToDate(ctx)
+	assert.NoError(t, err)
+	assert.False(t, needsFetch)
+	assert.Equal(t, runs, repo.lsRemoteRuns.Load(), "second check within RefCheckInterval must reuse the cached result")
+}
+
+func TestRepository_EnsureRefsUpToDate_CachesFailureForBackoff(t *testing.T) {
+	repo, _ := newClonedTestRepo(t, testRefCheckConfig())
+	ctx := context.Background()
+
+	// Unreachable upstream: ls-remote fails fast with connection-refused.
+	repo.upstreamURL = "https://127.0.0.1:1/nonexistent/repo"
+
+	_, err := repo.EnsureRefsUpToDate(ctx)
+	assert.Error(t, err)
+	runs := repo.lsRemoteRuns.Load()
+
+	// During an upstream outage the cached failure is replayed, so serial requests
+	// do not each run their own ls-remote and wait out LsRemoteTimeout.
+	_, err = repo.EnsureRefsUpToDate(ctx)
+	assert.Error(t, err)
+	assert.Equal(t, runs, repo.lsRemoteRuns.Load(), "failed check must be cached for the backoff window")
+
+	// A successful fetch proves upstream is reachable again, so it must drop the
+	// cached failure rather than leaving callers to wait out the backoff. (The
+	// fetch uses the clone's origin remote, which still points at the real
+	// upstream, so it succeeds while ls-remote keeps failing.)
+	assert.NoError(t, repo.Fetch(ctx))
+	_, err = repo.EnsureRefsUpToDate(ctx)
+	assert.Error(t, err)
+	assert.Equal(t, runs+1, repo.lsRemoteRuns.Load(), "fetch must invalidate the cached failure")
+	runs = repo.lsRemoteRuns.Load()
+
+	// The failure is cached only for a fraction of RefCheckInterval, so recovery
+	// is picked up long before a successful verdict would expire.
+	repo.mu.Lock()
+	repo.refCheckErrAt = time.Now().Add(-2 * repo.refCheckFailureBackoff())
+	repo.mu.Unlock()
+
+	_, err = repo.EnsureRefsUpToDate(ctx)
+	assert.Error(t, err)
+	assert.Equal(t, runs+1, repo.lsRemoteRuns.Load(), "check must reopen once the failure backoff expires")
+}
+
+func TestRepository_EnsureRefsUpToDate_CachesStaleVerdict(t *testing.T) {
+	repo, upstreamPath := newClonedTestRepo(t, testRefCheckConfig())
+	ctx := context.Background()
+
+	needsFetch, err := repo.EnsureRefsUpToDate(ctx)
+	assert.NoError(t, err)
+	assert.False(t, needsFetch)
+
+	// Expire the fresh cache entry and advance upstream so the next check
+	// observes staleness.
+	repo.mu.Lock()
+	repo.lastRefCheck = time.Now().Add(-2 * time.Minute)
+	repo.mu.Unlock()
+	advanceBareUpstream(t, upstreamPath)
+
+	needsFetch, err = repo.EnsureRefsUpToDate(ctx)
+	assert.NoError(t, err)
+	assert.True(t, needsFetch, "mirror should be detected stale after upstream advanced")
+	runs := repo.lsRemoteRuns.Load()
+
+	// A stale verdict is cached under RefCheckInterval so serial requests
+	// against a behind mirror do not each re-issue ls-remote.
+	needsFetch, err = repo.EnsureRefsUpToDate(ctx)
+	assert.NoError(t, err)
+	assert.True(t, needsFetch)
+	assert.Equal(t, runs, repo.lsRemoteRuns.Load(), "stale results must be cached within RefCheckInterval")
+}
+
+func TestRepository_EnsureRefsUpToDate_FetchInvalidatesStaleCache(t *testing.T) {
+	repo, upstreamPath := newClonedTestRepo(t, testRefCheckConfig())
+	ctx := context.Background()
+
+	// Clear any cached verdict and advance upstream so the check reports stale.
+	repo.mu.Lock()
+	repo.lastRefCheck = time.Now().Add(-2 * time.Minute)
+	repo.refCheckValid = false
+	repo.mu.Unlock()
+	advanceBareUpstream(t, upstreamPath)
+
+	needsFetch, err := repo.EnsureRefsUpToDate(ctx)
+	assert.NoError(t, err)
+	assert.True(t, needsFetch)
+
+	// A successful fetch must clear the cached stale verdict so the next
+	// check reopens rather than serving "behind" for the rest of the interval.
+	assert.NoError(t, repo.Fetch(ctx))
+	assert.False(t, repo.refCheckValid, "fetch must invalidate the cached ref check")
+
+	needsFetch, err = repo.EnsureRefsUpToDate(ctx)
+	assert.NoError(t, err)
+	assert.False(t, needsFetch, "after fetch the mirror should match upstream")
+}
+
+func TestRepository_EnsureRefsUpToDate_LeaderCancelDoesNotPoisonWaiter(t *testing.T) {
+	repo, _ := newClonedTestRepo(t, testRefCheckConfig())
+
+	leaderCtx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled; without WithoutCancel the leader would fail
+
+	type result struct {
+		stale bool
+		err   error
+	}
+	leaderDone := make(chan result, 1)
+	waiterDone := make(chan result, 1)
+
+	go func() {
+		stale, err := repo.EnsureRefsUpToDate(leaderCtx)
+		leaderDone <- result{stale, err}
+	}()
+	time.Sleep(5 * time.Millisecond)
+	go func() {
+		stale, err := repo.EnsureRefsUpToDate(context.Background())
+		waiterDone <- result{stale, err}
+	}()
+
+	leader := <-leaderDone
+	waiter := <-waiterDone
+	assert.NoError(t, leader.err, "cancelled leader must still complete the check")
+	assert.NoError(t, waiter.err, "waiter must not inherit the leader's cancellation")
+	assert.Equal(t, leader.stale, waiter.stale)
+}
+
+func TestRepository_EnsureRefsUpToDate_SingleflightWaiter(t *testing.T) {
+	repo := &Repository{
+		config:           testRepoConfig(),
+		fetchSem:         make(chan struct{}, 1),
+		refCheckInFlight: make(chan struct{}),
+		refCheckStale:    true,
+	}
+	repo.fetchSem <- struct{}{}
+
+	type result struct {
+		stale bool
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		stale, err := repo.EnsureRefsUpToDate(context.Background())
+		done <- result{stale, err}
+	}()
+
+	// The waiter must block until the simulated in-flight check completes.
+	select {
+	case <-done:
+		t.Fatal("waiter returned before the in-flight check completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(repo.refCheckInFlight)
+	res := <-done
+	assert.NoError(t, res.err)
+	assert.True(t, res.stale)
+	assert.Equal(t, int64(0), repo.lsRemoteRuns.Load(), "waiter must reuse the in-flight check, not issue its own ls-remote")
+}
+
+func TestRepository_EnsureRefsUpToDate_SingleflightWaiterError(t *testing.T) {
+	repo := &Repository{
+		config:           testRepoConfig(),
+		fetchSem:         make(chan struct{}, 1),
+		refCheckInFlight: make(chan struct{}),
+		refCheckErr:      errors.New("ls-remote exploded"),
+	}
+	repo.fetchSem <- struct{}{}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := repo.EnsureRefsUpToDate(context.Background())
+		done <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	close(repo.refCheckInFlight)
+	err := <-done
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ls-remote exploded")
+}
+
+func TestRepository_EnsureRefsUpToDate_SingleflightWaiterCancel(t *testing.T) {
+	repo := &Repository{
+		config:           testRepoConfig(),
+		fetchSem:         make(chan struct{}, 1),
+		refCheckInFlight: make(chan struct{}),
+	}
+	repo.fetchSem <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := repo.EnsureRefsUpToDate(ctx)
+		done <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	err := <-done
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context cancelled")
 }
 
 func TestParseGitRefs(t *testing.T) {

--- a/internal/gitclone/objects.go
+++ b/internal/gitclone/objects.go
@@ -1,0 +1,74 @@
+package gitclone
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/alecthomas/errors"
+)
+
+// MissingObjects reports which of the given object IDs are absent from the
+// repository's local object database, using a single `git cat-file
+// --batch-check` invocation. Object IDs must be 40- or 64-character lower-case
+// hex; anything else returns an error. The returned slice preserves the input
+// order of missing IDs (deduplicated). It takes the repository read lock only
+// to serialize against operations that hold the write lock; git fetch runs
+// without that lock (see fetchInternal), so the result is a point-in-time
+// snapshot that a concurrent fetch may invalidate by adding objects.
+func (r *Repository) MissingObjects(ctx context.Context, oids []string) ([]string, error) {
+	// Validate and deduplicate preserving order.
+	seen := make(map[string]bool, len(oids))
+	deduped := make([]string, 0, len(oids))
+	for _, oid := range oids {
+		if err := ValidateOID(oid); err != nil {
+			return nil, err
+		}
+		if !seen[oid] {
+			seen[oid] = true
+			deduped = append(deduped, oid)
+		}
+	}
+	if len(deduped) == 0 {
+		return nil, nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// #nosec G204 - r.path is controlled by us
+	cmd := exec.CommandContext(ctx, "git", "-C", r.path, "cat-file", "--batch-check", "--no-buffer")
+	cmd.Stdin = strings.NewReader(strings.Join(deduped, "\n") + "\n")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, errors.Wrapf(err, "git cat-file --batch-check: %s", stderr.String())
+	}
+
+	var missing []string
+	for line := range strings.SplitSeq(strings.TrimRight(stdout.String(), "\n"), "\n") {
+		if strings.HasSuffix(line, " missing") {
+			// Output format is "<oid> missing"; extract the oid.
+			oid, _, _ := strings.Cut(line, " ")
+			missing = append(missing, oid)
+		}
+	}
+	return missing, nil
+}
+
+// ValidateOID returns an error if oid is not a 40- or 64-character lower-case hex string.
+func ValidateOID(oid string) error {
+	if len(oid) != 40 && len(oid) != 64 {
+		return errors.Errorf("invalid object ID %q: must be 40 or 64 hex characters", oid)
+	}
+	for _, c := range oid {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return errors.Errorf("invalid object ID %q: must be lower-case hex", oid)
+		}
+	}
+	return nil
+}

--- a/internal/gitclone/objects_test.go
+++ b/internal/gitclone/objects_test.go
@@ -1,0 +1,141 @@
+package gitclone //nolint:testpackage // white-box testing required for unexported fields
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+// newTestRepo creates a bare mirror-style git repository with one commit and
+// returns a Repository pointing at it, along with the HEAD commit SHA.
+func newTestRepo(t *testing.T) (*Repository, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	workPath := filepath.Join(tmpDir, "work")
+	repoPath := filepath.Join(tmpDir, "mirror.git")
+
+	assert.NoError(t, os.MkdirAll(workPath, 0o755))
+
+	for _, args := range [][]string{
+		{"git", "-c", "init.defaultBranch=main", "-C", workPath, "init"},
+		{"git", "-C", workPath, "config", "user.email", "test@example.com"},
+		{"git", "-C", workPath, "config", "user.name", "Test"},
+	} {
+		assert.NoError(t, exec.Command(args[0], args[1:]...).Run())
+	}
+
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "f.txt"), []byte("hello"), 0o600))
+
+	for _, args := range [][]string{
+		{"git", "-C", workPath, "add", "."},
+		{"git", "-C", workPath, "commit", "-m", "init"},
+		{"git", "clone", "--mirror", workPath, repoPath},
+	} {
+		assert.NoError(t, exec.Command(args[0], args[1:]...).Run())
+	}
+
+	// #nosec G204 - workPath is a t.TempDir() path created by this test
+	out, err := exec.Command("git", "-C", workPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	headSHA := strings.TrimSpace(string(out))
+
+	repo := &Repository{
+		state:       StateReady,
+		config:      testRepoConfig(),
+		path:        repoPath,
+		upstreamURL: workPath,
+		fetchSem:    make(chan struct{}, 1),
+	}
+	repo.fetchSem <- struct{}{}
+
+	return repo, headSHA
+}
+
+func TestMissingObjects(t *testing.T) {
+	// A fabricated valid-hex SHA that does not exist in any real repo.
+	const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	tests := []struct {
+		name        string
+		inputFn     func(presentSHA string) []string
+		wantMissing func(presentSHA string) []string
+	}{
+		{
+			name:        "EmptyInput",
+			inputFn:     func(_ string) []string { return nil },
+			wantMissing: func(_ string) []string { return nil },
+		},
+		{
+			name:        "AllPresent",
+			inputFn:     func(sha string) []string { return []string{sha} },
+			wantMissing: func(_ string) []string { return nil },
+		},
+		{
+			name:        "AllMissing",
+			inputFn:     func(_ string) []string { return []string{absentSHA} },
+			wantMissing: func(_ string) []string { return []string{absentSHA} },
+		},
+		{
+			name:        "SomeMissing",
+			inputFn:     func(sha string) []string { return []string{sha, absentSHA} },
+			wantMissing: func(_ string) []string { return []string{absentSHA} },
+		},
+		{
+			name:        "DuplicatesDeduped",
+			inputFn:     func(_ string) []string { return []string{absentSHA, absentSHA} },
+			wantMissing: func(_ string) []string { return []string{absentSHA} },
+		},
+		{
+			name:        "OrderPreserved",
+			inputFn:     func(_ string) []string { return []string{absentSHA, "deadbeef00deadbeef00deadbeef00deadbeef00"} },
+			wantMissing: func(_ string) []string { return []string{absentSHA, "deadbeef00deadbeef00deadbeef00deadbeef00"} },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, headSHA := newTestRepo(t)
+			input := tc.inputFn(headSHA)
+			got, err := repo.MissingObjects(context.Background(), input)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantMissing(headSHA), got)
+		})
+	}
+}
+
+func TestMissingObjects_InvalidOID(t *testing.T) {
+	tests := []struct {
+		name string
+		oid  string
+	}{
+		{
+			name: "TooShort",
+			oid:  "deadbeef",
+		},
+		{
+			name: "TooLong",
+			oid:  strings.Repeat("a", 41),
+		},
+		{
+			name: "UpperCaseHex",
+			oid:  "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+		},
+		{
+			name: "NonHexChars",
+			oid:  "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, _ := newTestRepo(t)
+			_, err := repo.MissingObjects(context.Background(), []string{tc.oid})
+			assert.Error(t, err)
+		})
+	}
+}

--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -171,7 +171,7 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 	if stderrBuf.Len() > 0 {
 		stderr := stderrBuf.String()
 		logger.ErrorContext(r.Context(), "git http-backend error", "stderr", stderr, "path", backendPath)
-		if !bw.committed && strings.Contains(stderr, "not our ref") {
+		if !bw.committed && (strings.Contains(stderr, "not our ref") || strings.Contains(stderr, "unknown ref")) {
 			return true
 		}
 	}
@@ -183,10 +183,17 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 // checkRefsStale checks whether the local mirror's refs are behind upstream.
 // Returns true if a fetch is needed. The caller decides whether to fetch
 // synchronously or fall back to upstream.
-func (s *Strategy) checkRefsStale(ctx context.Context, repo *gitclone.Repository) (bool, error) {
+//
+// A failed check reports "not stale" so a flaky ls-remote cannot take the mirror
+// out of service. The failure is logged at debug level only: this runs on every
+// info/refs request, so an unreachable upstream would otherwise emit a warning
+// per request.
+func (s *Strategy) checkRefsStale(ctx context.Context, repo *gitclone.Repository) bool {
 	needsFetch, err := repo.EnsureRefsUpToDate(ctx)
 	if err != nil {
-		return false, errors.Wrap(err, "check upstream refs")
+		logging.FromContext(ctx).DebugContext(ctx, "Ref staleness check failed, treating mirror as fresh",
+			"upstream", repo.UpstreamURL(), "error", errors.Wrap(err, "check upstream refs"))
+		return false
 	}
-	return needsFetch, nil
+	return needsFetch
 }

--- a/internal/strategy/git/backend.go
+++ b/internal/strategy/git/backend.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/alecthomas/errors"
-
 	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/httputil"
 	"github.com/block/cachew/internal/logging"
@@ -183,17 +181,6 @@ func (s *Strategy) serveFromBackend(w http.ResponseWriter, r *http.Request, repo
 // checkRefsStale checks whether the local mirror's refs are behind upstream.
 // Returns true if a fetch is needed. The caller decides whether to fetch
 // synchronously or fall back to upstream.
-//
-// A failed check reports "not stale" so a flaky ls-remote cannot take the mirror
-// out of service. The failure is logged at debug level only: this runs on every
-// info/refs request, so an unreachable upstream would otherwise emit a warning
-// per request.
-func (s *Strategy) checkRefsStale(ctx context.Context, repo *gitclone.Repository) bool {
-	needsFetch, err := repo.EnsureRefsUpToDate(ctx)
-	if err != nil {
-		logging.FromContext(ctx).DebugContext(ctx, "Ref staleness check failed, treating mirror as fresh",
-			"upstream", repo.UpstreamURL(), "error", errors.Wrap(err, "check upstream refs"))
-		return false
-	}
-	return needsFetch
+func (s *Strategy) checkRefsStale(ctx context.Context, repo *gitclone.Repository) (bool, error) {
+	return repo.EnsureRefsUpToDate(ctx)
 }

--- a/internal/strategy/git/export_test.go
+++ b/internal/strategy/git/export_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/block/cachew/internal/cache"
@@ -35,5 +36,31 @@ func (s *Strategy) CacheBundle(ctx context.Context, key cache.Key, r io.Reader) 
 	return s.cacheBundle(ctx, key, r)
 }
 
+// IsUploadPackPost exports isUploadPackPost for testing.
+func IsUploadPackPost(r *http.Request, pathValue string) bool {
+	return isUploadPackPost(r, pathValue)
+}
+
+// IncrementalParse exports incrementalParse for testing.
+func IncrementalParse(r *http.Request, pathValue string, body []byte) ([]string, bool) {
+	return incrementalParse(r, pathValue, body)
+}
+
 // UploadPackParseLimit exports uploadPackParseLimit for testing.
 const UploadPackParseLimit = uploadPackParseLimit
+
+// SubmitFetch exports submitFetch for testing.
+func SubmitFetch(s *Strategy, repo *gitclone.Repository) { s.submitFetch(repo) }
+
+// SubmitFetchForce exports submitFetchForce for testing.
+func SubmitFetchForce(s *Strategy, repo *gitclone.Repository) { s.submitFetchForce(repo) }
+
+// EnsureWantsAvailable exports ensureWantsAvailable for testing.
+func EnsureWantsAvailable(ctx context.Context, s *Strategy, repo *gitclone.Repository, wants []string) (string, error) {
+	return s.ensureWantsAvailable(ctx, repo, wants)
+}
+
+// IncrementalOutcomeAfterNotOurRef exports incrementalOutcomeAfterNotOurRef for testing.
+func IncrementalOutcomeAfterNotOurRef(outcome string) string {
+	return incrementalOutcomeAfterNotOurRef(outcome)
+}

--- a/internal/strategy/git/export_test.go
+++ b/internal/strategy/git/export_test.go
@@ -34,3 +34,6 @@ func (s *Strategy) RunCoordinatedSnapshot(ctx context.Context, repo *gitclone.Re
 func (s *Strategy) CacheBundle(ctx context.Context, key cache.Key, r io.Reader) error {
 	return s.cacheBundle(ctx, key, r)
 }
+
+// UploadPackParseLimit exports uploadPackParseLimit for testing.
+const UploadPackParseLimit = uploadPackParseLimit

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -27,6 +27,7 @@ import (
 	"github.com/block/cachew/internal/cache"
 	"github.com/block/cachew/internal/gitclone"
 	"github.com/block/cachew/internal/githubapp"
+	cachewhttputil "github.com/block/cachew/internal/httputil"
 	"github.com/block/cachew/internal/jobscheduler"
 	"github.com/block/cachew/internal/logging"
 	"github.com/block/cachew/internal/metadatadb"
@@ -52,7 +53,7 @@ type Config struct {
 	BundleCacheTTL         time.Duration `hcl:"bundle-cache-ttl,optional" help:"TTL of cached server-side git bundles." default:"2h"`
 
 	SnapshotFilters         map[string]string `hcl:"snapshot-filters,optional" help:"Per-repository git partial-clone filter applied to workstation snapshots, keyed by host/org/repo (e.g. {\"github.com/org/repo\": \"blob:none\"}). Filtered snapshots contain full history metadata but only the blobs needed for the HEAD checkout; clients lazily fetch historical blobs through cachew on demand."`
-	IncrementalPullthrough  bool              `hcl:"incremental-pullthrough,optional" help:"Serve partially-cached upload-pack requests by fetching only missing objects into the local mirror instead of proxying the full response from upstream." default:"true"`
+	IncrementalPullthrough  bool              `hcl:"incremental-pullthrough,optional" help:"Serve partially-cached upload-pack requests by fetching only missing objects into the local mirror instead of proxying the full response from upstream. When enabled, upload-pack bodies are capped at 8 MiB (2× the parse limit); larger bodies receive 413." default:"true"`
 	IncrementalFetchTimeout time.Duration     `hcl:"incremental-fetch-timeout,optional" help:"Upper bound on the synchronous request-path fetch performed by incremental pull-through. The coalescing and verified attempts share this budget, and the coalescing attempt is capped at half so a verified retry still has room. On timeout the request falls back to upstream. Each underlying git fetch also honors fetch-timeout, and the preceding ref-staleness check is bounded separately by ls-remote-timeout." default:"2m"`
 }
 
@@ -382,6 +383,15 @@ func (s *Strategy) handleGitRequest(w http.ResponseWriter, r *http.Request, host
 		return
 	}
 
+	// Only incremental pull-through buffers and parses upload-pack bodies, so the
+	// body cap belongs behind the same kill switch: with incremental disabled the
+	// body streams straight through and a legitimately large one must not start
+	// failing with 413.
+	if s.config.IncrementalPullthrough && isUploadPackPost(r, pathValue) &&
+		r.Body != nil && r.Body != http.NoBody {
+		r.Body = http.MaxBytesReader(w, r.Body, 2*uploadPackParseLimit)
+	}
+
 	// Increment after GetOrCreate so unvalidated URLs can't bloat the keyspace.
 	if isClone, cerr := RequestIsClone(pathValue, r); cerr != nil {
 		logger.WarnContext(ctx, "Failed to inspect upload-pack body for clone counting", "error", cerr)
@@ -409,6 +419,11 @@ func (s *Strategy) handleGitRequest(w http.ResponseWriter, r *http.Request, host
 			})
 		}
 		if err := s.serveWithSpool(w, r, host, pathValue, upstreamURL); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				cachewhttputil.ErrorResponse(w, r, http.StatusRequestEntityTooLarge, "request body too large")
+				return
+			}
 			logger.WarnContext(ctx, "Spool failed, forwarding to upstream", "error", err)
 			s.forwardToUpstream(w, r, host, pathValue)
 		}
@@ -438,6 +453,11 @@ func (s *Strategy) serveReadyRepo(w http.ResponseWriter, r *http.Request, repo *
 		var readErr error
 		bodyBytes, readErr = io.ReadAll(r.Body)
 		if readErr != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(readErr, &maxErr) {
+				cachewhttputil.ErrorResponse(w, r, http.StatusRequestEntityTooLarge, "request body too large")
+				return nil
+			}
 			return errors.Wrap(readErr, "read request body")
 		}
 		replayRequestBody(r, bodyBytes)

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -675,12 +675,12 @@ func (s *Strategy) startClone(ctx context.Context, repo *gitclone.Repository) (r
 	}
 
 	if err != nil {
-		s.metrics.recordOperation(ctx, "clone", "error", time.Since(cloneStart))
+		s.metrics.recordOperation(ctx, "clone", "error", "background", time.Since(cloneStart))
 		repo.ResetToEmpty()
 		return errors.Wrapf(err, "clone %s", upstream)
 	}
 
-	s.metrics.recordOperation(ctx, "clone", "success", time.Since(cloneStart))
+	s.metrics.recordOperation(ctx, "clone", "success", "background", time.Since(cloneStart))
 	logger.InfoContext(ctx, "Clone completed", "upstream", upstream, "path", repo.Path())
 
 	if s.config.SnapshotInterval > 0 {
@@ -770,20 +770,21 @@ func (s *Strategy) freshenMirror(ctx context.Context, repo *gitclone.Repository)
 }
 
 func (s *Strategy) doFetch(ctx context.Context, repo *gitclone.Repository) error {
-	return s.fetchMirror(ctx, repo, repo.Fetch)
+	return s.fetchMirror(ctx, repo, repo.Fetch, "background")
 }
 
 // doFetchVerified is doFetch minus fetch coalescing: nil guarantees this call
 // ran a successful git fetch, so the caller can assert upstream state.
-func (s *Strategy) doFetchVerified(ctx context.Context, repo *gitclone.Repository) error {
-	return s.fetchMirror(ctx, repo, repo.FetchVerified)
+func (s *Strategy) doFetchVerified(ctx context.Context, repo *gitclone.Repository, trigger string) error {
+	return s.fetchMirror(ctx, repo, repo.FetchVerified, trigger)
 }
 
-func (s *Strategy) fetchMirror(ctx context.Context, repo *gitclone.Repository, fetch func(context.Context) error) (returnErr error) {
+func (s *Strategy) fetchMirror(ctx context.Context, repo *gitclone.Repository, fetch func(context.Context) error, trigger string) (returnErr error) {
 	ctx, span := tracer.Start(ctx, "git.fetch",
 		trace.WithAttributes(
 			attribute.String("cachew.operation", "fetch"),
 			attribute.String("cachew.upstream", repo.UpstreamURL()),
+			attribute.String("cachew.trigger", trigger),
 		),
 	)
 	defer func() {
@@ -799,10 +800,10 @@ func (s *Strategy) fetchMirror(ctx context.Context, repo *gitclone.Repository, f
 
 	start := time.Now()
 	if err := fetch(ctx); err != nil {
-		s.metrics.recordOperation(ctx, "fetch", "error", time.Since(start))
+		s.metrics.recordOperation(ctx, "fetch", "error", trigger, time.Since(start))
 		return errors.Errorf("fetch failed: %w", err)
 	}
-	s.metrics.recordOperation(ctx, "fetch", "success", time.Since(start))
+	s.metrics.recordOperation(ctx, "fetch", "success", trigger, time.Since(start))
 	logger.InfoContext(ctx, "Fetch completed", "upstream", repo.UpstreamURL(), "duration", time.Since(start))
 	return nil
 }

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -51,7 +51,9 @@ type Config struct {
 	ZstdThreads            int           `hcl:"zstd-threads,optional" help:"Threads for zstd compression/decompression. 0 = all CPU cores; useful for short-lived CLI invocations but risky on a long-running server where multiple snapshot/restore operations can run concurrently." default:"4"`
 	BundleCacheTTL         time.Duration `hcl:"bundle-cache-ttl,optional" help:"TTL of cached server-side git bundles." default:"2h"`
 
-	SnapshotFilters map[string]string `hcl:"snapshot-filters,optional" help:"Per-repository git partial-clone filter applied to workstation snapshots, keyed by host/org/repo (e.g. {\"github.com/org/repo\": \"blob:none\"}). Filtered snapshots contain full history metadata but only the blobs needed for the HEAD checkout; clients lazily fetch historical blobs through cachew on demand."`
+	SnapshotFilters         map[string]string `hcl:"snapshot-filters,optional" help:"Per-repository git partial-clone filter applied to workstation snapshots, keyed by host/org/repo (e.g. {\"github.com/org/repo\": \"blob:none\"}). Filtered snapshots contain full history metadata but only the blobs needed for the HEAD checkout; clients lazily fetch historical blobs through cachew on demand."`
+	IncrementalPullthrough  bool              `hcl:"incremental-pullthrough,optional" help:"Serve partially-cached upload-pack requests by fetching only missing objects into the local mirror instead of proxying the full response from upstream." default:"true"`
+	IncrementalFetchTimeout time.Duration     `hcl:"incremental-fetch-timeout,optional" help:"Upper bound on the synchronous request-path fetch performed by incremental pull-through. The coalescing and verified attempts share this budget, and the coalescing attempt is capped at half so a verified retry still has room. On timeout the request falls back to upstream. Each underlying git fetch also honors fetch-timeout, and the preceding ref-staleness check is bounded separately by ls-remote-timeout." default:"2m"`
 }
 
 type Strategy struct {
@@ -69,6 +71,7 @@ type Strategy struct {
 	snapshotSpools      sync.Map // keyed by upstream URL, values are *snapshotSpoolEntry
 	coldSnapshotMu      sync.Map // keyed by upstream URL, values are *coldSnapshotEntry
 	deferredRestoreOnce sync.Map // keyed by upstream URL, ensures at most one deferred restore per repo
+	forcedFetches       sync.Map // keyed by upstream URL, ensures at most one cooldown-bypassing fetch is queued per repo
 	metrics             *gitMetrics
 	repoCounts          *RepoCounts
 	snapshotCoord       *SnapshotCoordinator
@@ -91,6 +94,12 @@ func New(
 	}
 	if config.BundleCacheTTL == 0 {
 		config.BundleCacheTTL = 2 * time.Hour
+	}
+	if config.IncrementalFetchTimeout == 0 {
+		config.IncrementalFetchTimeout = 2 * time.Minute
+	}
+	if config.IncrementalFetchTimeout < 0 {
+		return nil, errors.Errorf("incremental-fetch-timeout must be positive, got %v", config.IncrementalFetchTimeout)
 	}
 	if config.SnapshotInterval > 0 {
 		for _, bin := range []string{"tar", "pzstd"} {
@@ -212,7 +221,9 @@ func New(
 	mux.Handle("GET /git/{host}/{path...}", http.HandlerFunc(s.handleRequest))
 	mux.Handle("POST /git/{host}/{path...}", http.HandlerFunc(s.handleRequest))
 
-	logger.InfoContext(ctx, "Git strategy initialized", "snapshot_interval", config.SnapshotInterval)
+	logger.InfoContext(ctx, "Git strategy initialized", "snapshot_interval", config.SnapshotInterval,
+		"incremental_pullthrough", config.IncrementalPullthrough,
+		"incremental_fetch_timeout", config.IncrementalFetchTimeout)
 
 	return s, nil
 }
@@ -406,6 +417,9 @@ func (s *Strategy) handleGitRequest(w http.ResponseWriter, r *http.Request, host
 
 func (s *Strategy) serveReadyRepo(w http.ResponseWriter, r *http.Request, repo *gitclone.Repository, host, pathValue string, isInfoRefs bool) error {
 	ctx := r.Context()
+	// Started at handler entry so the incremental duration metric covers the whole
+	// latency this handler adds on the request path.
+	incrementalStart := time.Now()
 
 	if isInfoRefs && s.checkRefsStale(ctx, repo) {
 		// Mirror is behind upstream. Forward to upstream so the client gets
@@ -426,24 +440,99 @@ func (s *Strategy) serveReadyRepo(w http.ResponseWriter, r *http.Request, repo *
 		if readErr != nil {
 			return errors.Wrap(readErr, "read request body")
 		}
-		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-		r.ContentLength = int64(len(bodyBytes))
-		r.TransferEncoding = nil
+		replayRequestBody(r, bodyBytes)
+	}
+
+	// incrementalParse has no side effects, so wants are computed even when the
+	// feature is off. That lets the eligibility metric below cover
+	// config-disabled traffic.
+	wants, wantRefs := incrementalParse(r, pathValue, bodyBytes)
+	// Use host/repoPath (matching sibling git metrics) rather than the full
+	// upstream URL so the repository attribute joins across metrics.
+	incrementalRepo := host + "/" + ExtractRepoPath(pathValue)
+	if isUploadPackPost(r, pathValue) {
+		s.metrics.recordIncrementalEligible(ctx, len(wants) > 0, incrementalRepo)
+	}
+	// Outcome metrics are recorded only once the serve outcome is known: a request
+	// the incremental path cleared can still end as a full upstream passthrough on
+	// "not our ref", which must not count as a local_hit or fetched success.
+	// incrementalOutcome stays empty when incremental did not run.
+	var (
+		incrementalOutcome  string
+		incrementalDuration time.Duration
+	)
+	recordIncremental := func(outcome string) {
+		s.metrics.recordIncrementalServe(ctx, outcome, incrementalRepo)
+		s.metrics.recordIncrementalFetchDuration(ctx, outcome, incrementalRepo, incrementalDuration)
+	}
+
+	// A want-ref body asks the mirror to resolve ref names locally. Mirrors do not
+	// advertise ref-in-want, so their upload-pack cannot serve such a body at all.
+	// Forwarding is also safer: local ref-name resolution can serve a stale tip and
+	// regress the client's FETCH_HEAD, and nothing on this path proves the mirror's
+	// refs are current.
+	//
+	// Not gated on IncrementalPullthrough: what the mirror advertises comes from
+	// its on-disk config, not the flag.
+	if wantRefs {
+		logging.FromContext(ctx).InfoContext(ctx, "Forwarding want-ref request: mirror does not serve ref-in-want", "path", pathValue)
+		s.forwardWithBody(w, r, host, pathValue, bodyBytes)
+		return nil
+	}
+
+	if s.config.IncrementalPullthrough && len(wants) > 0 {
+		outcome, herr := s.ensureWantsAvailable(ctx, repo, wants)
+		// The incremental latency ends with the fetch, so capture the duration here
+		// even though the outcome is recorded after the local serve.
+		incrementalOutcome, incrementalDuration = outcome, time.Since(incrementalStart)
+		if herr != nil || outcome == incrementalFallbackMissing {
+			logging.FromContext(ctx).InfoContext(ctx, "Incremental pull-through falling back to upstream",
+				"outcome", outcome, "error", herr, "path", pathValue)
+			// A fetch failure (or a client disconnect before the verified retry)
+			// leaves the mirror cold; kick a background catch-up so subsequent
+			// requests do not each pay the synchronous timeout. The forced
+			// variant is required because the failed attempt itself satisfies
+			// NeedsFetch's cooldown.
+			if outcome == incrementalFallbackFetchFailed || outcome == incrementalClientGone {
+				s.submitFetchForce(repo)
+			}
+			recordIncremental(outcome)
+			s.forwardWithBody(w, r, host, pathValue, bodyBytes)
+			return nil
+		}
 	}
 
 	if s.serveFromBackend(w, r, repo) {
 		// The mirror is missing the requested object — most likely a commit
 		// that was advertised before a concurrent force-push fetch orphaned
 		// it. Fall back to upstream so the client is not left with an error.
-		logging.FromContext(ctx).InfoContext(ctx, "Falling back to upstream due to 'not our ref'", "path", pathValue)
-		if bodyBytes != nil {
-			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			r.ContentLength = int64(len(bodyBytes))
-			r.TransferEncoding = nil
+		if incrementalOutcome != "" {
+			incrementalOutcome = incrementalOutcomeAfterNotOurRef(incrementalOutcome)
 		}
-		s.forwardToUpstream(w, r, host, pathValue)
+		logging.FromContext(ctx).InfoContext(ctx, "Falling back to upstream due to 'not our ref'", "path", pathValue)
+		s.forwardWithBody(w, r, host, pathValue, bodyBytes)
+	}
+	if incrementalOutcome != "" {
+		recordIncremental(incrementalOutcome)
 	}
 	return nil
+}
+
+// replayRequestBody replaces r.Body with a fresh reader over bodyBytes so the
+// request can be re-served (local backend or upstream forward) after buffering
+// consumed the body.
+func replayRequestBody(r *http.Request, bodyBytes []byte) {
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	r.ContentLength = int64(len(bodyBytes))
+	r.TransferEncoding = nil
+}
+
+// forwardWithBody replays bodyBytes onto r (when non-nil) and forwards to upstream.
+func (s *Strategy) forwardWithBody(w http.ResponseWriter, r *http.Request, host, pathValue string, bodyBytes []byte) {
+	if bodyBytes != nil {
+		replayRequestBody(r, bodyBytes)
+	}
+	s.forwardToUpstream(w, r, host, pathValue)
 }
 
 // SpoolKeyForRequest returns the spool key for a request, or empty string if the
@@ -747,7 +836,7 @@ func (s *Strategy) tryRestoreSnapshot(ctx context.Context, repo *gitclone.Reposi
 }
 
 // submitFetch schedules a background fetch when the mirror may be behind
-// upstream and the fetch cooldown has elapsed.
+// upstream and a fetch cooldown has expired.
 func (s *Strategy) submitFetch(repo *gitclone.Repository) {
 	if !repo.NeedsFetch(s.cloneManager.Config().RefCheckInterval) {
 		return
@@ -756,6 +845,32 @@ func (s *Strategy) submitFetch(repo *gitclone.Repository) {
 	// behind long-running jobs on the same upstream URL queue.
 	s.scheduler.Submit(repo.UpstreamURL()+"/fetch", "fetch", func(ctx context.Context) error {
 		return s.doFetch(ctx, repo)
+	})
+}
+
+// submitFetchForce schedules a background fetch even when the fetch cooldown has
+// not expired. Recovery paths need this: executeFetch stamps the attempt before
+// the network call, so a fetch that has just failed already satisfies
+// NeedsFetch's cooldown, and submitFetch would then do nothing just when the
+// mirror needs to catch up.
+//
+// The scheduler neither dedupes queued jobs nor runs two jobs from one queue
+// concurrently, so the fetch semaphore cannot collapse duplicates that are only
+// queued. forcedFetches keeps at most one forced fetch pending per repository,
+// bounding a burst of failing requests to a single catch-up.
+//
+// The job fetches verified rather than coalescing: a coalescing fetch that
+// merely waits on a non-fetching semaphore holder, such as a snapshot tar,
+// returns success without contacting upstream, which would clear forcedFetches
+// and leave the mirror exactly as cold as the failure that queued the job.
+func (s *Strategy) submitFetchForce(repo *gitclone.Repository) {
+	key := repo.UpstreamURL()
+	if _, pending := s.forcedFetches.LoadOrStore(key, struct{}{}); pending {
+		return
+	}
+	s.scheduler.Submit(key+"/fetch", "fetch", func(ctx context.Context) error {
+		defer s.forcedFetches.Delete(key)
+		return s.doFetchVerified(ctx, repo, "background")
 	})
 }
 
@@ -773,8 +888,88 @@ func (s *Strategy) doFetch(ctx context.Context, repo *gitclone.Repository) error
 	return s.fetchMirror(ctx, repo, repo.Fetch, "background")
 }
 
+// doFetchReporting is doFetch plus a flag reporting whether this call ran a git
+// fetch (true) or coalesced onto another semaphore holder (false), so the
+// incremental path can skip a redundant verified fetch after a real one.
+// Operation metrics and the success log are recorded only for a real fetch; a
+// coalesce wait must not inflate the request-path fetch SLO, and that holds for
+// failures too: a coalesce wait can end in error without ever contacting
+// upstream, so only an attempted fetch records an error.
+func (s *Strategy) doFetchReporting(ctx context.Context, repo *gitclone.Repository) (fetched bool, returnErr error) {
+	ctx, span := tracer.Start(ctx, "git.fetch",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "fetch"),
+			attribute.String("cachew.upstream", repo.UpstreamURL()),
+			attribute.String("cachew.trigger", "incremental"),
+		),
+	)
+	defer func() {
+		if returnErr != nil {
+			span.RecordError(returnErr)
+			span.SetStatus(codes.Error, returnErr.Error())
+		}
+		span.End()
+	}()
+
+	logger := logging.FromContext(ctx)
+	start := time.Now()
+	attempted, err := repo.FetchCoalescing(ctx)
+	if err != nil {
+		if attempted {
+			s.metrics.recordOperation(ctx, "fetch", "error", "incremental", time.Since(start))
+		}
+		return false, errors.Errorf("fetch failed: %w", err)
+	}
+	if !attempted {
+		span.SetAttributes(attribute.Bool("cachew.coalesced", true))
+		return false, nil
+	}
+	s.metrics.recordOperation(ctx, "fetch", "success", "incremental", time.Since(start))
+	logger.InfoContext(ctx, "Fetch completed", "upstream", repo.UpstreamURL(), "duration", time.Since(start))
+	return true, nil
+}
+
+// doFetchVerifiedIfAbsent waits for the fetch semaphore and runs a git fetch only
+// when wants are still missing after the coalescing attempt. As with
+// doFetchReporting, only a call that actually ran a fetch records an operation
+// metric; giving up while waiting for the semaphore never contacted upstream.
+func (s *Strategy) doFetchVerifiedIfAbsent(ctx context.Context, repo *gitclone.Repository, wants []string) (returnErr error) {
+	ctx, span := tracer.Start(ctx, "git.fetch",
+		trace.WithAttributes(
+			attribute.String("cachew.operation", "fetch"),
+			attribute.String("cachew.upstream", repo.UpstreamURL()),
+			attribute.String("cachew.trigger", "incremental"),
+		),
+	)
+	defer func() {
+		if returnErr != nil {
+			span.RecordError(returnErr)
+			span.SetStatus(codes.Error, returnErr.Error())
+		}
+		span.End()
+	}()
+
+	logger := logging.FromContext(ctx)
+	start := time.Now()
+	attempted, err := repo.FetchVerifiedIfAbsent(ctx, wants)
+	if err != nil {
+		if attempted {
+			s.metrics.recordOperation(ctx, "fetch", "error", "incremental", time.Since(start))
+		}
+		return errors.Errorf("fetch failed: %w", err)
+	}
+	if !attempted {
+		span.SetAttributes(attribute.Bool("cachew.coalesced", true))
+		return nil
+	}
+	s.metrics.recordOperation(ctx, "fetch", "success", "incremental", time.Since(start))
+	logger.InfoContext(ctx, "Fetch completed", "upstream", repo.UpstreamURL(), "duration", time.Since(start))
+	return nil
+}
+
 // doFetchVerified is doFetch minus fetch coalescing: nil guarantees this call
-// ran a successful git fetch, so the caller can assert upstream state.
+// ran a successful git fetch, so the caller can assert upstream state. trigger
+// is "incremental" when invoked from the request path and "background" otherwise.
 func (s *Strategy) doFetchVerified(ctx context.Context, repo *gitclone.Repository, trigger string) error {
 	return s.fetchMirror(ctx, repo, repo.FetchVerified, trigger)
 }

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -407,8 +407,7 @@ func (s *Strategy) handleGitRequest(w http.ResponseWriter, r *http.Request, host
 func (s *Strategy) serveReadyRepo(w http.ResponseWriter, r *http.Request, repo *gitclone.Repository, host, pathValue string, isInfoRefs bool) error {
 	ctx := r.Context()
 
-	stale, _ := s.checkRefsStale(ctx, repo) //nolint:errcheck // best-effort; treat as non-stale on failure
-	if isInfoRefs && stale {
+	if isInfoRefs && s.checkRefsStale(ctx, repo) {
 		// Mirror is behind upstream. Forward to upstream so the client gets
 		// fresh refs immediately, and kick off a background fetch so the
 		// mirror catches up for subsequent requests.
@@ -747,9 +746,12 @@ func (s *Strategy) tryRestoreSnapshot(ctx context.Context, repo *gitclone.Reposi
 	return nil
 }
 
-// submitFetch schedules a fetch unconditionally. Use this when ls-remote has
-// already confirmed the mirror is behind upstream.
+// submitFetch schedules a background fetch when the mirror may be behind
+// upstream and the fetch cooldown has elapsed.
 func (s *Strategy) submitFetch(repo *gitclone.Repository) {
+	if !repo.NeedsFetch(s.cloneManager.Config().RefCheckInterval) {
+		return
+	}
 	// Use a separate queue from snapshot/repack so fetches are not serialized
 	// behind long-running jobs on the same upstream URL queue.
 	s.scheduler.Submit(repo.UpstreamURL()+"/fetch", "fetch", func(ctx context.Context) error {

--- a/internal/strategy/git/git.go
+++ b/internal/strategy/git/git.go
@@ -436,14 +436,24 @@ func (s *Strategy) serveReadyRepo(w http.ResponseWriter, r *http.Request, repo *
 	// latency this handler adds on the request path.
 	incrementalStart := time.Now()
 
-	if isInfoRefs && s.checkRefsStale(ctx, repo) {
-		// Mirror is behind upstream. Forward to upstream so the client gets
-		// fresh refs immediately, and kick off a background fetch so the
-		// mirror catches up for subsequent requests.
-		logging.FromContext(ctx).InfoContext(ctx, "Refs stale, forwarding to upstream and fetching in background", "upstream", repo.UpstreamURL())
-		s.submitFetch(repo)
-		s.forwardToUpstream(w, r, host, pathValue)
-		return nil
+	if isInfoRefs {
+		stale, err := s.checkRefsStale(ctx, repo)
+		if err != nil {
+			// A failed check is treated as "not stale" so a flaky ls-remote cannot
+			// take the mirror out of service. Logged at debug only: this runs on
+			// every info/refs request, so an unreachable upstream would otherwise
+			// emit a warning per request.
+			logging.FromContext(ctx).DebugContext(ctx, "Ref staleness check failed, treating mirror as fresh",
+				"upstream", repo.UpstreamURL(), "error", errors.Wrap(err, "check upstream refs"))
+		} else if stale {
+			// Mirror is behind upstream. Forward to upstream so the client gets
+			// fresh refs immediately, and kick off a background fetch so the
+			// mirror catches up for subsequent requests.
+			logging.FromContext(ctx).InfoContext(ctx, "Refs stale, forwarding to upstream and fetching in background", "upstream", repo.UpstreamURL())
+			s.submitFetch(repo)
+			s.forwardToUpstream(w, r, host, pathValue)
+			return nil
+		}
 	}
 
 	// Buffer the request body so it can be replayed if serveFromBackend

--- a/internal/strategy/git/incremental.go
+++ b/internal/strategy/git/incremental.go
@@ -112,9 +112,10 @@ func (s *Strategy) ensureWantsAvailable(ctx context.Context, repo *gitclone.Repo
 	if len(missing) == 0 {
 		return incrementalLocalHit, nil
 	}
-	// A fetch this recent already had its chance to bring the want in. Retrying
-	// would only amplify upstream traffic.
-	if !repo.NeedsFetch(s.cloneManager.Config().RefCheckInterval) {
+	// Cooldown alone is not enough. A recently-completed fetch means retrying
+	// would amplify traffic, but an in-flight fetch should be coalesced onto
+	// below, not skipped past.
+	if !repo.NeedsFetch(s.cloneManager.Config().RefCheckInterval) && !repo.FetchInFlight() {
 		return incrementalFallbackMissing, nil
 	}
 

--- a/internal/strategy/git/incremental.go
+++ b/internal/strategy/git/incremental.go
@@ -1,0 +1,221 @@
+package git
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/alecthomas/errors"
+
+	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/internal/logging"
+)
+
+// Incremental pull-through outcome values, recorded on the
+// incrementalServeTotal counter. local_hit means all wants were already in the
+// mirror and fetched means a git fetch brought them in. Every other outcome
+// forwards the request upstream.
+const (
+	incrementalLocalHit            = "local_hit"
+	incrementalFetched             = "fetched"
+	incrementalFallbackFetchFailed = "fallback_fetch_failed"
+	incrementalFallbackMissing     = "fallback_missing"
+	// fallback_local_error covers failures of the local missing-object check
+	// itself (cat-file errors, dead contexts) so they are not mistaken for
+	// upstream fetch failures in metrics.
+	incrementalFallbackLocalError = "fallback_local_error"
+	// client_gone means the request context was cancelled before the incremental
+	// fetch path could complete; it is not an upstream fetch failure.
+	incrementalClientGone = "client_gone"
+	// client_gone_after_fetch means the client disconnected after the coalescing
+	// fetch attempt, which may have succeeded and left the mirror up to date.
+	incrementalClientGoneAfterFetch = "client_gone_after_fetch"
+	// fallback_not_our_ref means incremental cleared the wants but the local
+	// backend still reported "not our ref"/"unknown ref", so the request needed a
+	// full upstream passthrough. A separate outcome keeps those passthroughs out
+	// of the local_hit/fetched success counts.
+	incrementalFallbackNotOurRef = "fallback_not_our_ref"
+)
+
+// classifyMissingErr maps a MissingObjects failure to an incremental outcome: a
+// dead request context is client_gone, anything else is a local check failure.
+func classifyMissingErr(ctx context.Context, err error, wrapMsg string) (string, error) {
+	if ctx.Err() != nil {
+		return incrementalClientGone, errors.Wrap(ctx.Err(), wrapMsg)
+	}
+	return incrementalFallbackLocalError, errors.Wrap(err, wrapMsg)
+}
+
+// isUploadPackPost reports whether the request is an upload-pack POST, the only
+// request shape the incremental path considers, so it is also the denominator
+// for the incrementalEligibleTotal counter.
+func isUploadPackPost(r *http.Request, pathValue string) bool {
+	return r.Method == http.MethodPost && strings.HasSuffix(pathValue, "/git-upload-pack")
+}
+
+// incrementalParse extracts the want OIDs from a buffered upload-pack POST body,
+// plus whether the body carries protocol v2 want-ref lines. Empty wants means
+// the request skips the incremental path (not a fetch, v2 ls-refs, no wants,
+// parse failure), because the existing serve path is the safe default. wantRefs
+// is reported separately because a want-ref body asks the mirror to resolve ref
+// names, which the caller must not trust unless the mirror's refs are known
+// fresh.
+func incrementalParse(r *http.Request, pathValue string, body []byte) (wants []string, wantRefs bool) {
+	if !isUploadPackPost(r, pathValue) {
+		return nil, false
+	}
+	gzipEncoded := strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip")
+	req, err := ParseUploadPackRequest(body, gzipEncoded)
+	if err != nil {
+		logger := logging.FromContext(r.Context())
+		if errors.Is(err, errBodyTooLarge) {
+			// This is a well-formed fetch we declined, not a malformed body, so
+			// log it loudly enough to notice if real clients trip the limit.
+			logger.WarnContext(r.Context(), "Skipping incremental path: upload-pack body exceeds parse limit",
+				"parse_limit", uploadPackParseLimit, "body_bytes", len(body), "path", pathValue)
+			return nil, false
+		}
+		logger.DebugContext(r.Context(), "Skipping incremental path: upload-pack parse failed", "error", err)
+		return nil, false
+	}
+	if req.LsRefs {
+		return nil, false
+	}
+	return req.Wants, req.WantRefs
+}
+
+// ensureWantsAvailable makes sure the mirror contains every wanted object,
+// fetching from upstream if needed. Git negotiation means only the missing delta
+// crosses the network.
+//
+// Fetch amplification is bounded by the same RefCheckInterval cooldown that
+// freshenMirror uses, not by reasoning about ref namespaces: the staleness check
+// compares only refs/heads/*, so a "fresh" result says nothing about a want
+// reachable solely from refs/pull/* or refs/tags/*.
+//
+// The fetch is detached from the request context with WithoutCancel so a client
+// disconnect cannot kill an in-flight delta transfer; the mirror still converges
+// under IncrementalFetchTimeout. The request context is checked after each fetch
+// attempt so a disconnect reports client_gone_after_fetch rather than a fetch or
+// local-check failure. MissingObjects re-checks use the request context while it
+// is still live, since they are local and fast.
+//
+// The caller must forward to upstream on any non-nil error or on
+// incrementalFallbackMissing, which means the want is still absent: either
+// upstream does not have it or the fetch cooldown blocked the attempt. Any other
+// outcome may be served locally.
+func (s *Strategy) ensureWantsAvailable(ctx context.Context, repo *gitclone.Repository, wants []string) (string, error) {
+	missing, err := repo.MissingObjects(ctx, wants)
+	if err != nil {
+		return classifyMissingErr(ctx, err, "check missing objects")
+	}
+	if len(missing) == 0 {
+		return incrementalLocalHit, nil
+	}
+	// A fetch this recent already had its chance to bring the want in. Retrying
+	// would only amplify upstream traffic.
+	if !repo.NeedsFetch(s.cloneManager.Config().RefCheckInterval) {
+		return incrementalFallbackMissing, nil
+	}
+
+	// Detach from the request context so a client disconnect leaves the delta
+	// fetch running to completion under IncrementalFetchTimeout.
+	base := context.WithoutCancel(ctx)
+	hctx, cancel := context.WithTimeout(base, s.config.IncrementalFetchTimeout)
+	defer cancel()
+	// Give the coalescing attempt half the budget so the verified attempt still
+	// has room if the first call only waited on a holder that did not fetch.
+	fctx, fcancel := context.WithTimeout(hctx, s.config.IncrementalFetchTimeout/2)
+	defer fcancel()
+
+	// First attempt: coalesces with any in-flight background fetch, so concurrent
+	// requests do not each issue a network call for the same delta. The coalesce
+	// wait spans the whole fctx budget on purpose: the semaphore serializes
+	// fetches anyway, so giving up early cannot start the verified fetch sooner,
+	// it would only turn would-be local serves into upstream fallbacks.
+	//
+	// lastFetchBefore lets a caller that only coalesced (fetched=false) still
+	// recognize a real fetch that finished while it waited: fetchSem has capacity
+	// 1, so one holder runs at a time, and LastFetch advances only on a
+	// successful fetch. Without it, every coalescing waiter on an unresolvable
+	// want ran its own guaranteed fetch below, amplifying upstream traffic
+	// instead of trusting the fetch it just waited on.
+	lastFetchBefore := repo.LastFetch()
+	fetched, err := s.doFetchReporting(fctx, repo)
+	if err != nil {
+		return incrementalFallbackFetchFailed, errors.Wrap(err, "fetch for incremental pull-through")
+	}
+	if !fetched && repo.LastFetch().After(lastFetchBefore) {
+		fetched = true
+	}
+
+	// The coalesce wait runs under WithoutCancel, so a client disconnect does not
+	// abort it. Classify that case before MissingObjects, which would otherwise
+	// report fallback_local_error for a dead request context.
+	if err := ctx.Err(); err != nil {
+		return incrementalClientGoneAfterFetch, errors.Wrap(err, "client gone after incremental fetch")
+	}
+
+	// The re-check runs under the request context, not fctx: a coalesce wait may
+	// have consumed most of the fetch budget, and cat-file is local and fast, so
+	// a near-dead fctx would only produce spurious failures.
+	missing, err = repo.MissingObjects(ctx, wants)
+	if err != nil {
+		return classifyMissingErr(ctx, err, "re-check missing objects after fetch")
+	}
+	if len(missing) == 0 {
+		return incrementalFetched, nil
+	}
+
+	// The want is still missing. If this call ran a git fetch, upstream does not
+	// have the object (force-pushed away, say), so a verified retry would only
+	// amplify upstream traffic. A guaranteed fetch is worth it only when we
+	// coalesced onto another semaphore holder that may not have fetched at all,
+	// such as a snapshot tar operation.
+	if fetched {
+		return incrementalFallbackMissing, nil
+	}
+
+	// Second attempt: wait for the semaphore and fetch only if wants are still
+	// missing. A peer may have delivered them while this call waited.
+	//
+	// Re-check the cooldown first. Coalescing onto a fetch that failed also
+	// reports fetched=false, so during an upstream outage every waiter would
+	// otherwise fall through to its own full fetch attempt, serializing them all
+	// behind the semaphore instead of honouring the cooldown the failed attempt
+	// just stamped.
+	if !repo.NeedsFetch(s.cloneManager.Config().RefCheckInterval) {
+		return incrementalFallbackMissing, nil
+	}
+	if err := s.doFetchVerifiedIfAbsent(hctx, repo, wants); err != nil {
+		return incrementalFallbackFetchFailed, errors.Wrap(err, "verified fetch for incremental pull-through")
+	}
+
+	// The verified attempt is detached too, so classify a disconnect here rather
+	// than letting the re-check below report client_gone and queue a forced fetch
+	// the mirror does not need.
+	if err := ctx.Err(); err != nil {
+		return incrementalClientGoneAfterFetch, errors.Wrap(err, "client gone after verified incremental fetch")
+	}
+
+	// Same rationale as the first re-check: use the request context, not the
+	// possibly-exhausted fetch budget.
+	missing, err = repo.MissingObjects(ctx, wants)
+	if err != nil {
+		return classifyMissingErr(ctx, err, "re-check missing objects after verified fetch")
+	}
+	if len(missing) > 0 {
+		// The want is not reachable from any upstream ref (e.g. force-pushed away).
+		return incrementalFallbackMissing, nil
+	}
+	return incrementalFetched, nil
+}
+
+// incrementalOutcomeAfterNotOurRef reclassifies a successful incremental outcome
+// when the local backend still reports "not our ref"/"unknown ref".
+func incrementalOutcomeAfterNotOurRef(incrementalOutcome string) string {
+	if incrementalOutcome != "" {
+		return incrementalFallbackNotOurRef
+	}
+	return ""
+}

--- a/internal/strategy/git/incremental_test.go
+++ b/internal/strategy/git/incremental_test.go
@@ -2072,6 +2072,79 @@ func TestIncrementalStaleInfoRefsForwardedThenBackgroundFetch(t *testing.T) {
 	assertIncrementalServeMetrics(ctx, t, reader, "local_hit", hostPort+"/org/stale-repo", false)
 }
 
+func TestIncrementalUploadPackRejectsOversizedBody(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/bigbodyrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	oversized := make([]byte, 2*git.UploadPackParseLimit+1)
+	url := fmt.Sprintf("%s/git/%s/%s/git-upload-pack", cachewSrv.URL, e2eUpstreamHost, repoPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(oversized))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	client := &http.Client{Transport: http.DefaultTransport}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
+func TestUploadPackOversizedBodyAcceptedWhenIncrementalDisabled(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/bigbodydisabledrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  false, // the body cap must not apply
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	oversized := make([]byte, 2*git.UploadPackParseLimit+1)
+	url := fmt.Sprintf("%s/git/%s/%s/git-upload-pack", cachewSrv.URL, e2eUpstreamHost, repoPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(oversized))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	client := &http.Client{Transport: http.DefaultTransport}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	// The body is garbage, so the local backend's verdict is git's business; the
+	// contract under test is only that cachew itself does not reject the size.
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, resp.StatusCode,
+		"the body cap must be gated on IncrementalPullthrough")
+}
+
 func TestWantRefForwardedIncrementalDisabled(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found in PATH")

--- a/internal/strategy/git/incremental_test.go
+++ b/internal/strategy/git/incremental_test.go
@@ -1,0 +1,2309 @@
+package git_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cgi"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/block/cachew/internal/gitclone"
+	"github.com/block/cachew/internal/githubapp"
+	"github.com/block/cachew/internal/logging"
+	"github.com/block/cachew/internal/strategy/git"
+)
+
+// fakeUpstreamMarker is the distinctive body returned by the fake upstream server
+// in E2E fallback scenarios so we can assert the client received it.
+const fakeUpstreamMarker = "FAKE-UPSTREAM-RESPONSE"
+
+// countingFakeUpstream returns a fake upstream httptest.Server that counts every
+// request and responds with fakeUpstreamMarker, plus its hit counter.
+func countingFakeUpstream(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fakeUpstreamMarker))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// redirectToFakeTransport is an http.RoundTripper that redirects every request
+// to fakeBaseURL (scheme+host), counting each redirect. It is used in E2E
+// tests to intercept calls that serveReadyRepo would forward to upstream.
+type redirectToFakeTransport struct {
+	fakeBaseURL string
+	inner       http.RoundTripper
+	hits        *atomic.Int32
+}
+
+func (rt *redirectToFakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.hits.Add(1)
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(rt.fakeBaseURL, "http://")
+	req.Host = req.URL.Host
+	return rt.inner.RoundTrip(req) //nolint:wrapcheck
+}
+
+// buildCompleteUploadPackBody produces a complete v0 upload-pack negotiation
+// body: want lines, flush packet, then a "done" line. Without the trailing
+// done, git upload-pack waits for more negotiation and the request hangs.
+func buildCompleteUploadPackBody(oids ...string) []byte {
+	var b strings.Builder
+	for _, oid := range oids {
+		b.WriteString(pkt("want " + oid + "\n"))
+	}
+	b.WriteString(flushPkt)
+	b.WriteString(pkt("done\n"))
+	return []byte(b.String())
+}
+
+// buildV0UploadPackBodyWithNULCaps produces a real protocol-v0 first-want line
+// (capabilities after a NUL) plus done, matching gitprotocol-pack(5).
+func buildV0UploadPackBodyWithNULCaps(oid string) []byte {
+	first := "want " + oid + "\x00multi_ack side-band-64k agent=git/2.45\n"
+	return []byte(pkt(first) + flushPkt + pkt("done\n"))
+}
+
+// newLoggingServer wraps handler in a middleware that injects the ctx logger
+// into each request context before dispatching. This is required because
+// handleRequest calls logging.FromContext which panics if no logger is present.
+func newLoggingServer(ctx context.Context, handler http.Handler) *httptest.Server {
+	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(logging.ContextWithLogger(r.Context(), logging.FromContext(ctx)))
+		handler.ServeHTTP(w, r)
+	})
+	return httptest.NewServer(wrapper)
+}
+
+// e2eUpstreamHost keeps checkRefsStale hermetic: git ls-remote against
+// 127.0.0.1 fails instantly with connection-refused instead of real I/O.
+const e2eUpstreamHost = "127.0.0.1"
+
+// setupE2EStrategy creates a git strategy wired to a real http.ServeMux and
+// returns the strategy plus its test server. mirrorRoot must already contain the
+// mirror directory tree that RepoPathFromURL resolves the upstream URL to, built
+// under e2eUpstreamHost.
+func setupE2EStrategy(ctx context.Context, t *testing.T, mirrorRoot string, cfg git.Config) (*git.Strategy, *httptest.Server) {
+	t.Helper()
+	mux := http.NewServeMux()
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+		MirrorRoot:       mirrorRoot,
+		FetchInterval:    24 * time.Hour, // prevent background auto-fetch during tests
+		FetchTimeout:     30 * time.Second,
+		RefCheckInterval: time.Nanosecond, // expire cooldown immediately so incremental can fetch
+	}, nil)
+	s, err := git.New(ctx, cfg, newTestScheduler(ctx, t), nil, mux, cm,
+		func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+	t.Cleanup(func() { waitForReady(t, s) })
+	srv := newLoggingServer(ctx, mux)
+	t.Cleanup(srv.Close)
+	return s, srv
+}
+
+func postUploadPack(ctx context.Context, serverURL, repoPath string, body []byte) (*http.Response, error) {
+	url := fmt.Sprintf("%s/git/%s/%s/git-upload-pack", serverURL, e2eUpstreamHost, repoPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	client := &http.Client{Transport: http.DefaultTransport}
+	return client.Do(req)
+}
+
+// buildUploadPackBody produces a minimal v0 upload-pack body with the given
+// want OIDs.
+func buildUploadPackBody(oids ...string) []byte {
+	var b strings.Builder
+	for _, oid := range oids {
+		b.WriteString(pkt("want " + oid + "\n"))
+	}
+	b.WriteString(flushPkt)
+	return []byte(b.String())
+}
+
+// buildLsRefsBody produces a v2 ls-refs body: a ref advertisement request that
+// carries no wants, so it reaches the incremental decision point without engaging it.
+func buildLsRefsBody() []byte {
+	return []byte(pkt("command=ls-refs\n") + delimPkt + pkt("peel\n") + flushPkt)
+}
+
+// Instrument names asserted by the incremental metric helpers below.
+const (
+	incrementalServesMetric   = "cachew.git.incremental_serves_total"
+	incrementalDurationMetric = "cachew.git.incremental_fetch_duration_seconds"
+	incrementalEligibleMetric = "cachew.git.incremental_eligible_total"
+	operationsMetric          = "cachew.git.operations_total"
+)
+
+// setupMetricsReader points the global OTel meter provider at a manual reader
+// for the duration of the test, restoring the previous provider afterwards.
+// Tests in this package never run in parallel, so swapping the global is safe.
+//
+// Must be called before the strategy is constructed: newGitMetrics resolves its
+// meter once, at construction time, and a meter from the default no-op provider
+// silently discards everything recorded through it.
+func setupMetricsReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	prev := otel.GetMeterProvider()
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+	return reader
+}
+
+func collectMetrics(ctx context.Context, t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, reader.Collect(ctx, &rm))
+	return rm
+}
+
+// metricAggregation returns the aggregation exported under name, or nil when the
+// instrument recorded nothing. The SDK omits untouched instruments.
+func metricAggregation(rm metricdata.ResourceMetrics, name string) metricdata.Aggregation {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m.Data
+			}
+		}
+	}
+	return nil
+}
+
+// counterPoints returns the int64 counter points under name whose attributes
+// match want exactly.
+func counterPoints(rm metricdata.ResourceMetrics, name string, want attribute.Set) []metricdata.DataPoint[int64] {
+	sum, ok := metricAggregation(rm, name).(metricdata.Sum[int64])
+	if !ok {
+		return nil
+	}
+	var out []metricdata.DataPoint[int64]
+	for _, dp := range sum.DataPoints {
+		if dp.Attributes.Equals(&want) {
+			out = append(out, dp)
+		}
+	}
+	return out
+}
+
+// histogramPoints returns the float64 histogram points under name whose
+// attributes match want exactly.
+func histogramPoints(rm metricdata.ResourceMetrics, name string, want attribute.Set) []metricdata.HistogramDataPoint[float64] {
+	hist, ok := metricAggregation(rm, name).(metricdata.Histogram[float64])
+	if !ok {
+		return nil
+	}
+	var out []metricdata.HistogramDataPoint[float64]
+	for _, dp := range hist.DataPoints {
+		if dp.Attributes.Equals(&want) {
+			out = append(out, dp)
+		}
+	}
+	return out
+}
+
+// metricPointCount reports how many points name exported across all attribute
+// sets; zero when the instrument never recorded.
+func metricPointCount(rm metricdata.ResourceMetrics, name string) int {
+	switch d := metricAggregation(rm, name).(type) {
+	case metricdata.Sum[int64]:
+		return len(d.DataPoints)
+	case metricdata.Histogram[float64]:
+		return len(d.DataPoints)
+	default:
+		return 0
+	}
+}
+
+// assertIncrementalServeMetrics asserts that a single engaged request against repo
+// recorded one serve, one fetch duration and one engaged=true eligibility
+// point. fetched says whether real fetch work happened, in which case the
+// duration must be non-zero; a local_hit can legitimately round to zero.
+func assertIncrementalServeMetrics(ctx context.Context, t *testing.T, reader *sdkmetric.ManualReader, outcome, repo string, fetched bool) {
+	t.Helper()
+	rm := collectMetrics(ctx, t, reader)
+	serveAttrs := attribute.NewSet(
+		attribute.String("outcome", outcome),
+		attribute.String("repository", repo),
+	)
+
+	serves := counterPoints(rm, incrementalServesMetric, serveAttrs)
+	assert.Equal(t, 1, len(serves), "want one %s point for outcome %q repository %q", incrementalServesMetric, outcome, repo)
+	assert.Equal(t, int64(1), serves[0].Value)
+
+	durations := histogramPoints(rm, incrementalDurationMetric, serveAttrs)
+	assert.Equal(t, 1, len(durations), "want one %s point for outcome %q repository %q", incrementalDurationMetric, outcome, repo)
+	assert.Equal(t, uint64(1), durations[0].Count)
+	if fetched {
+		assert.True(t, durations[0].Sum > 0, "%s should time the upstream fetch, got %v", incrementalDurationMetric, durations[0].Sum)
+	}
+
+	assertIncrementalEligible(t, rm, repo, true)
+}
+
+// assertIncrementalEligible asserts exactly one eligibility point for repo with the
+// given engaged value.
+func assertIncrementalEligible(t *testing.T, rm metricdata.ResourceMetrics, repo string, engaged bool) {
+	t.Helper()
+	eligible := counterPoints(rm, incrementalEligibleMetric, attribute.NewSet(
+		attribute.Bool("engaged", engaged),
+		attribute.String("repository", repo),
+	))
+	assert.Equal(t, 1, len(eligible), "want one %s point for engaged=%v repository %q", incrementalEligibleMetric, engaged, repo)
+	assert.Equal(t, int64(1), eligible[0].Value)
+}
+
+func TestIncrementalParse(t *testing.T) {
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+
+	oid1 := sha1OID("aabbcc")
+	oid2 := sha1OID("ddeeff")
+
+	lsRefsBody := buildLsRefsBody()
+	wantRefBody := []byte(pkt("command=fetch\n") + delimPkt + pkt("want-ref refs/heads/main\n") + flushPkt)
+	mixedBody := []byte(pkt("command=fetch\n") + delimPkt + pkt("want-ref refs/heads/main\n") + pkt("want "+oid1+"\n") + flushPkt)
+	wantBody := buildUploadPackBody(oid1, oid2)
+	gzWantBody := gzipBody(wantBody)
+
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		body         []byte
+		extraHdr     map[string]string
+		wantWants    []string
+		wantWantRefs bool
+	}{
+		{
+			name:      "GETReturnsNil",
+			method:    http.MethodGet,
+			path:      "org/repo/info/refs",
+			wantWants: nil,
+		},
+		{
+			name:      "POSTNonUploadPackPath",
+			method:    http.MethodPost,
+			path:      "org/repo/info/refs",
+			body:      wantBody,
+			wantWants: nil,
+		},
+		{
+			name:      "POSTWithWants",
+			method:    http.MethodPost,
+			path:      "org/repo/git-upload-pack",
+			body:      wantBody,
+			wantWants: []string{oid1, oid2},
+		},
+		{
+			name:      "LsRefsBody",
+			method:    http.MethodPost,
+			path:      "org/repo/git-upload-pack",
+			body:      lsRefsBody,
+			wantWants: nil,
+		},
+		{
+			name:         "WantRefBody",
+			method:       http.MethodPost,
+			path:         "org/repo/git-upload-pack",
+			body:         wantRefBody,
+			wantWants:    nil,
+			wantWantRefs: true,
+		},
+		{
+			name:         "WantRefAndWantsBody",
+			method:       http.MethodPost,
+			path:         "org/repo/git-upload-pack",
+			body:         mixedBody,
+			wantWants:    []string{oid1},
+			wantWantRefs: true,
+		},
+		{
+			name:   "GzipBody",
+			method: http.MethodPost,
+			path:   "org/repo/git-upload-pack",
+			body:   gzWantBody,
+			extraHdr: map[string]string{
+				"Content-Encoding": "gzip",
+			},
+			wantWants: []string{oid1, oid2},
+		},
+		{
+			name:      "GarbageBodyReturnsNil",
+			method:    http.MethodPost,
+			path:      "org/repo/git-upload-pack",
+			body:      []byte("not a pkt-line body"),
+			wantWants: nil,
+		},
+		{
+			name:      "NilBodyReturnsNil",
+			method:    http.MethodPost,
+			path:      "org/repo/git-upload-pack",
+			body:      nil,
+			wantWants: nil,
+		},
+		{
+			name:      "EmptyBodyReturnsNil",
+			method:    http.MethodPost,
+			path:      "org/repo/git-upload-pack",
+			body:      []byte{},
+			wantWants: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/git/github.com/"+tt.path, bytes.NewReader(tt.body))
+			req = req.WithContext(ctx)
+			for k, v := range tt.extraHdr {
+				req.Header.Set(k, v)
+			}
+			wants, wantRefs := git.IncrementalParse(req, tt.path, tt.body)
+			assert.Equal(t, tt.wantWants, wants)
+			assert.Equal(t, tt.wantWantRefs, wantRefs)
+		})
+	}
+}
+
+func TestIsUploadPackPost(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		{name: "POSTUploadPack", method: http.MethodPost, path: "org/repo/git-upload-pack", want: true},
+		{name: "GETUploadPack", method: http.MethodGet, path: "org/repo/git-upload-pack", want: false},
+		{name: "POSTInfoRefs", method: http.MethodPost, path: "org/repo/info/refs", want: false},
+		{name: "GETInfoRefs", method: http.MethodGet, path: "org/repo/info/refs", want: false},
+		{name: "POSTReceivePack", method: http.MethodPost, path: "org/repo/git-receive-pack", want: false},
+		{name: "POSTRepoRoot", method: http.MethodPost, path: "org/repo", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/git/github.com/"+tt.path, nil)
+			assert.Equal(t, tt.want, git.IsUploadPackPost(req, tt.path))
+		})
+	}
+}
+
+// setupMirrorWithUpstream creates:
+//   - a non-bare upstream git repo at upstreamPath with one commit
+//   - a bare mirror clone at mirrorPath
+//
+// Returns the HEAD SHA of the initial commit.
+func setupMirrorWithUpstream(t *testing.T, upstreamPath, mirrorPath string) string {
+	t.Helper()
+	assert.NoError(t, os.MkdirAll(upstreamPath, 0o755))
+	for _, args := range [][]string{
+		{"git", "-c", "init.defaultBranch=main", "-C", upstreamPath, "init"},
+		{"git", "-C", upstreamPath, "config", "user.email", "test@example.com"},
+		{"git", "-C", upstreamPath, "config", "user.name", "Test"},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+	assert.NoError(t, os.WriteFile(filepath.Join(upstreamPath, "file.txt"), []byte("initial"), 0o600))
+	for _, args := range [][]string{
+		{"git", "-C", upstreamPath, "add", "."},
+		{"git", "-C", upstreamPath, "commit", "-m", "initial"},
+		{"git", "clone", "--mirror", upstreamPath, mirrorPath},
+		// Allow serving any SHA from the mirror (required for incremental pull-through).
+		{"git", "-C", mirrorPath, "config", "uploadpack.allowAnySHA1InWant", "true"},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+	out, err := exec.Command("git", "-C", upstreamPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
+// pushCommitToUpstream adds a new commit to upstreamPath and returns the new HEAD SHA.
+func pushCommitToUpstream(t *testing.T, upstreamPath string) string {
+	t.Helper()
+	assert.NoError(t, os.WriteFile(filepath.Join(upstreamPath, "file2.txt"), []byte("delta"), 0o600))
+	for _, args := range [][]string{
+		{"git", "-C", upstreamPath, "add", "."},
+		{"git", "-C", upstreamPath, "commit", "-m", "delta"},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+	// #nosec G204 - upstreamPath is a t.TempDir() path created by this test
+	out, err := exec.Command("git", "-C", upstreamPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
+// pushPullRefToUpstream creates a commit reachable only via refs/pull/1/head,
+// leaving refs/heads/* untouched. Returns the new commit SHA. This models the
+// GitHub Actions PR-CI case where actions/checkout fetches the merge/head ref
+// by exact SHA while branch tips are unchanged.
+func pushPullRefToUpstream(t *testing.T, upstreamPath string) string {
+	t.Helper()
+	assert.NoError(t, os.WriteFile(filepath.Join(upstreamPath, "pr.txt"), []byte("pull-ref"), 0o600))
+	for _, args := range [][]string{
+		{"git", "-C", upstreamPath, "add", "."},
+		{"git", "-C", upstreamPath, "commit", "-m", "pr commit"},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+	// #nosec G204 - upstreamPath is a t.TempDir() path created by this test
+	out, err := exec.Command("git", "-C", upstreamPath, "rev-parse", "HEAD").Output()
+	assert.NoError(t, err)
+	sha := strings.TrimSpace(string(out))
+	// Point a pull ref at the new commit, then reset main back so heads are unchanged.
+	// #nosec G204 - upstreamPath is a t.TempDir() path and sha is the rev-parse output from it
+	out, err = exec.Command("git", "-C", upstreamPath, "update-ref", "refs/pull/1/head", sha).CombinedOutput()
+	assert.NoError(t, err, string(out))
+	// #nosec G204 - upstreamPath is a t.TempDir() path created by this test
+	out, err = exec.Command("git", "-C", upstreamPath, "update-ref", "refs/heads/main", "HEAD~1").CombinedOutput()
+	assert.NoError(t, err, string(out))
+	// #nosec G204 - upstreamPath is a t.TempDir() path created by this test
+	out, err = exec.Command("git", "-C", upstreamPath, "checkout", "-q", "main").CombinedOutput()
+	assert.NoError(t, err, string(out))
+	return sha
+}
+
+// stallUpstream makes every subsequent fetch from the mirror block inside
+// upload-pack until the returned release func is called, so a test can act while
+// a fetch is genuinely in flight. Returns the path of the marker file the
+// stalled fetch creates on entry.
+func stallUpstream(t *testing.T, mirrorPath string) (started string, release func()) {
+	t.Helper()
+	dir := t.TempDir()
+	started = filepath.Join(dir, "started")
+	releasePath := filepath.Join(dir, "release")
+	script := filepath.Join(dir, "stall-upload-pack.sh")
+	body := "#!/bin/sh\ntouch " + started + "\nwhile [ ! -f " + releasePath + " ]; do sleep 0.02; done\n" +
+		"exec git upload-pack \"$@\"\n"
+	assert.NoError(t, os.WriteFile(script, []byte(body), 0o600))
+	assert.NoError(t, os.Chmod(script, 0o700))
+	// #nosec G204 - mirrorPath and script are t.TempDir() paths created by this test
+	out, err := exec.Command("git", "-C", mirrorPath, "config", "remote.origin.uploadpack", script).CombinedOutput()
+	assert.NoError(t, err, string(out))
+	return started, func() {
+		assert.NoError(t, os.WriteFile(releasePath, nil, 0o600))
+	}
+}
+
+// waitForFile blocks until path exists, failing the test if it never appears.
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// newTestStrategyForMirror creates a Strategy whose mirror root is mirrorRoot
+// and returns the underlying manager.
+func newTestStrategyForMirror(ctx context.Context, t *testing.T, mirrorRoot string, cfg git.Config) (*git.Strategy, *gitclone.Manager) {
+	t.Helper()
+	mux := newTestMux()
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+		MirrorRoot:       mirrorRoot,
+		FetchInterval:    15 * time.Minute,
+		FetchTimeout:     30 * time.Second,
+		RefCheckInterval: time.Nanosecond, // expire cooldown immediately so incremental can fetch
+	}, nil)
+	s, err := git.New(ctx, cfg, newTestScheduler(ctx, t), nil, mux, cm,
+		func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+	manager, err := cm()
+	assert.NoError(t, err)
+	return s, manager
+}
+
+// newTestStrategyForMirrorWithRefCheck is like newTestStrategyForMirror but
+// lets the caller set RefCheckInterval. Used by the cooldown test.
+func newTestStrategyForMirrorWithRefCheck(ctx context.Context, t *testing.T, mirrorRoot string, cfg git.Config, refCheckInterval time.Duration) (*git.Strategy, *gitclone.Manager) {
+	t.Helper()
+	mux := newTestMux()
+	cm := gitclone.NewManagerProvider(ctx, gitclone.Config{
+		MirrorRoot:       mirrorRoot,
+		FetchInterval:    15 * time.Minute,
+		FetchTimeout:     30 * time.Second,
+		RefCheckInterval: refCheckInterval,
+	}, nil)
+	s, err := git.New(ctx, cfg, newTestScheduler(ctx, t), nil, mux, cm,
+		func() (*githubapp.TokenManager, error) { return nil, nil }) //nolint:nilnil
+	assert.NoError(t, err)
+	manager, err := cm()
+	assert.NoError(t, err)
+	return s, manager
+}
+
+func TestEnsureWantsAvailable(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+
+	// The fake upstream URL must be one the Manager's RepoPathFromURL can parse
+	// as a host+path, which means it must be an http/https URL. We create the
+	// mirror at the expected path, then reconfigure its remote to point at the
+	// local filesystem upstream so git fetch works without network access.
+	const fakeUpstreamURL = "https://example.com/org/repo"
+	// Manager resolves this to <mirrorRoot>/example.com/org/repo.
+	relMirrorPath := filepath.Join("example.com", "org", "repo")
+
+	t.Run("LocalHit", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		headSHA := setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{headSHA})
+		assert.NoError(t, err)
+		assert.Equal(t, "local_hit", outcome)
+	})
+
+	t.Run("FetchedAfterUpstreamAdvances", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		// Set up the initial mirror with the local upstream as origin so the
+		// strategy's startup fetch (in warmExistingRepos) uses the local path and
+		// does not fail.
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		// Create the strategy and wait for warm-up. The startup fetch will
+		// pull the initial state (one commit).
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		// Advance upstream. The mirror does not know about this commit yet.
+		newSHA := pushCommitToUpstream(t, upstreamPath)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		// Mirror does not have newSHA, so ensureWantsAvailable should fetch it.
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{newSHA})
+		assert.NoError(t, err)
+		assert.Equal(t, "fetched", outcome)
+	})
+
+	t.Run("FallbackFetchFailed", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		// Set up the mirror with a valid upstream, then point its origin at a
+		// non-existent path so the incremental fetch fails. The want is absent from
+		// the mirror, so the fetch path runs and fails → fallback_fetch_failed.
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+		out, err := exec.Command("git", "-C", mirrorPath, "remote", "set-url", "origin", "/nonexistent/path").CombinedOutput()
+		assert.NoError(t, err, string(out))
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 10 * time.Second,
+		})
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+		assert.Equal(t, "fallback_fetch_failed", outcome)
+		assert.Error(t, err)
+	})
+
+	t.Run("FailureCooldownSkipsRetry", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+		out, err := exec.Command("git", "-C", mirrorPath, "remote", "set-url", "origin", "/nonexistent/path").CombinedOutput()
+		assert.NoError(t, err, string(out))
+
+		const cooldown = 500 * time.Millisecond
+		s, manager := newTestStrategyForMirrorWithRefCheck(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 10 * time.Second,
+		}, cooldown)
+		waitForReady(t, s)
+
+		// Let the warm-up fetch's success cooldown expire so the first call
+		// actually attempts a fetch (and fails against the broken origin).
+		time.Sleep(cooldown + 50*time.Millisecond)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+		assert.Equal(t, "fallback_fetch_failed", outcome)
+		assert.Error(t, err)
+
+		before := repo.LastFetch()
+		outcome, err = git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+		assert.NoError(t, err)
+		assert.Equal(t, "fallback_missing", outcome, "failed attempt must cool down synchronous retries")
+		assert.Equal(t, before, repo.LastFetch(), "cooldown must skip the fetch")
+	})
+
+	t.Run("CooldownSkipsFetch", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		// Long RefCheckInterval so the warm-up fetch puts us inside the cooldown.
+		s, manager := newTestStrategyForMirrorWithRefCheck(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		}, time.Hour)
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		// An absent want within the cooldown must return fallback_missing without
+		// issuing a git fetch, so LastFetch must be unchanged across the call. The
+		// SHA is valid hex but absent from both mirror and upstream, so even a fetch
+		// that did run could not bring it in.
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		before := repo.LastFetch()
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+		assert.NoError(t, err)
+		assert.Equal(t, "fallback_missing", outcome)
+		assert.Equal(t, before, repo.LastFetch(), "cooldown must skip the fetch")
+	})
+
+	t.Run("PullRefOnlyFetches", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		// Advance upstream under refs/pull/1/head only, leaving heads unchanged,
+		// so a heads-only staleness check would report "fresh". The cooldown path
+		// (not that check) must still fetch the PR commit.
+		pullSHA := pushPullRefToUpstream(t, upstreamPath)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{pullSHA})
+		assert.NoError(t, err)
+		assert.Equal(t, "fetched", outcome, "want reachable only via refs/pull/* must be fetched")
+		assert.True(t, repo.HasCommit(ctx, pullSHA), "mirror should contain the pull-ref commit")
+	})
+
+	t.Run("VerifiedFetchAfterCoalesce", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		// Advance upstream after warm-up so the mirror lacks newSHA.
+		newSHA := pushCommitToUpstream(t, upstreamPath)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		// Hold the fetch semaphore with a non-fetch holder so the first
+		// doFetchReporting coalesces (fetched=false). Releasing it lets the
+		// coalescing call return, and the verified-fetch second attempt then
+		// acquires the semaphore and runs a real git fetch.
+		release := make(chan struct{})
+		holderDone := make(chan error, 1)
+		go func() {
+			holderDone <- repo.WithFetchExclusion(ctx, func() error {
+				<-release
+				return nil
+			})
+		}()
+		time.Sleep(20 * time.Millisecond)
+
+		type result struct {
+			outcome string
+			err     error
+		}
+		done := make(chan result, 1)
+		go func() {
+			outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{newSHA})
+			done <- result{outcome, err}
+		}()
+
+		close(release)
+		assert.NoError(t, <-holderDone)
+		res := <-done
+		assert.NoError(t, res.err)
+		assert.Equal(t, "fetched", res.outcome, "verified fetch should bring in the missing want")
+		assert.True(t, repo.HasCommit(ctx, newSHA), "mirror should contain newSHA after verified fetch")
+	})
+
+	t.Run("ClientGonePrecancelled", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		newSHA := pushCommitToUpstream(t, upstreamPath)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		reqCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		outcome, err := git.EnsureWantsAvailable(reqCtx, s, repo, []string{newSHA})
+		assert.Equal(t, "client_gone", outcome)
+		assert.Error(t, err)
+	})
+
+	t.Run("FallbackLocalError", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		// Not a git repo, so cat-file fails with a live context.
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+		assert.Equal(t, "fallback_local_error", outcome)
+		assert.Error(t, err)
+	})
+
+	t.Run("ClientGoneAfterCoalesce", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		newSHA := pushCommitToUpstream(t, upstreamPath)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		// Hold the semaphore so attempt 1 coalesces. Cancel the request
+		// context while waiting; after release, ensureWantsAvailable must
+		// report client_gone (not fallback_fetch_failed / local_error).
+		release := make(chan struct{})
+		holderDone := make(chan error, 1)
+		go func() {
+			holderDone <- repo.WithFetchExclusion(ctx, func() error {
+				<-release
+				return nil
+			})
+		}()
+		time.Sleep(20 * time.Millisecond)
+
+		reqCtx, cancel := context.WithCancel(ctx)
+		type result struct {
+			outcome string
+			err     error
+		}
+		done := make(chan result, 1)
+		go func() {
+			outcome, err := git.EnsureWantsAvailable(reqCtx, s, repo, []string{newSHA})
+			done <- result{outcome, err}
+		}()
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+		close(release)
+		assert.NoError(t, <-holderDone)
+		res := <-done
+		assert.Equal(t, "client_gone_after_fetch", res.outcome)
+		assert.Error(t, res.err)
+	})
+
+	t.Run("VerifiedFetchFails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+		out, err := exec.Command("git", "-C", mirrorPath, "remote", "set-url", "origin", "/nonexistent/path").CombinedOutput()
+		assert.NoError(t, err, string(out))
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 10 * time.Second,
+		})
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		release := make(chan struct{})
+		acquired := make(chan struct{})
+		holderDone := make(chan error, 1)
+		go func() {
+			holderDone <- repo.WithFetchExclusion(ctx, func() error {
+				close(acquired)
+				<-release
+				return nil
+			})
+		}()
+		<-acquired
+
+		type result struct {
+			outcome string
+			err     error
+		}
+		done := make(chan result, 1)
+		go func() {
+			outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+			done <- result{outcome, err}
+		}()
+		close(release)
+		assert.NoError(t, <-holderDone)
+		res := <-done
+		assert.Equal(t, "fallback_fetch_failed", res.outcome)
+		assert.Error(t, res.err)
+	})
+
+	t.Run("VerifiedFetchStillMissing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		release := make(chan struct{})
+		acquired := make(chan struct{})
+		holderDone := make(chan error, 1)
+		go func() {
+			holderDone <- repo.WithFetchExclusion(ctx, func() error {
+				close(acquired)
+				<-release
+				return nil
+			})
+		}()
+		<-acquired
+
+		type result struct {
+			outcome string
+			err     error
+		}
+		done := make(chan result, 1)
+		go func() {
+			outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+			done <- result{outcome, err}
+		}()
+		close(release)
+		assert.NoError(t, <-holderDone)
+		res := <-done
+		assert.Equal(t, "fallback_missing", res.outcome)
+		assert.NoError(t, res.err)
+	})
+
+	t.Run("PeerFetchFailureCooldownSkipsVerifiedFetch", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+		// #nosec G204 - mirrorPath is a t.TempDir() path and the remote URL is a literal
+		out, err := exec.Command("git", "-C", mirrorPath, "remote", "set-url", "origin", "/nonexistent/path").CombinedOutput()
+		assert.NoError(t, err, string(out))
+
+		const cooldown = time.Second
+		s, manager := newTestStrategyForMirrorWithRefCheck(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 10 * time.Second,
+		}, cooldown)
+		waitForReady(t, s)
+
+		// Let the warm-up fetch's cooldown expire so the coalescing attempt runs.
+		time.Sleep(cooldown + 50*time.Millisecond)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		release := make(chan struct{})
+		acquired := make(chan struct{})
+		holderDone := make(chan error, 1)
+		go func() {
+			holderDone <- repo.WithFetchExclusion(ctx, func() error {
+				close(acquired)
+				<-release
+				return nil
+			})
+		}()
+		<-acquired
+
+		// Queued on the semaphore ahead of the coalescing callers, so its failing
+		// fetch stamps the cooldown while they are all still waiting.
+		peerDone := make(chan error, 1)
+		go func() { peerDone <- repo.FetchVerified(ctx) }()
+		time.Sleep(50 * time.Millisecond)
+
+		type result struct {
+			outcome string
+			err     error
+		}
+		const waiters = 4
+		done := make(chan result, waiters)
+		for range waiters {
+			go func() {
+				outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+				done <- result{outcome, err}
+			}()
+		}
+		time.Sleep(100 * time.Millisecond)
+		close(release)
+		assert.NoError(t, <-holderDone)
+		assert.Error(t, <-peerDone)
+
+		for range waiters {
+			res := <-done
+			assert.NoError(t, res.err)
+			assert.Equal(t, "fallback_missing", res.outcome, "peer fetch failure must cool down the verified retry")
+		}
+	})
+
+	t.Run("ClientGoneAfterVerifiedFetch", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		})
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		startedMarker, releaseFetch := stallUpstream(t, mirrorPath)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		release := make(chan struct{})
+		acquired := make(chan struct{})
+		holderDone := make(chan error, 1)
+		go func() {
+			holderDone <- repo.WithFetchExclusion(ctx, func() error {
+				close(acquired)
+				<-release
+				return nil
+			})
+		}()
+		<-acquired
+
+		reqCtx, cancel := context.WithCancel(ctx)
+		type result struct {
+			outcome string
+			err     error
+		}
+		done := make(chan result, 1)
+		go func() {
+			outcome, err := git.EnsureWantsAvailable(reqCtx, s, repo, []string{absentSHA})
+			done <- result{outcome, err}
+		}()
+		time.Sleep(50 * time.Millisecond)
+		close(release)
+		assert.NoError(t, <-holderDone)
+
+		// The coalescing attempt found no fetch to join, so the verified retry is
+		// the one now stalled upstream. Disconnect the client mid-fetch.
+		waitForFile(t, startedMarker)
+		cancel()
+		releaseFetch()
+
+		res := <-done
+		assert.Equal(t, "client_gone_after_fetch", res.outcome)
+		assert.Error(t, res.err)
+	})
+
+	t.Run("FetchTimeout", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		reader := setupMetricsReader(t)
+		s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 50 * time.Millisecond,
+		})
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		release := make(chan struct{})
+		acquired := make(chan struct{})
+		holderDone := make(chan error, 1)
+		go func() {
+			holderDone <- repo.WithFetchExclusion(ctx, func() error {
+				close(acquired)
+				<-release
+				return nil
+			})
+		}()
+		<-acquired
+		time.Sleep(100 * time.Millisecond)
+
+		outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{absentSHA})
+		close(release)
+		assert.NoError(t, <-holderDone)
+		assert.Equal(t, "fallback_fetch_failed", outcome)
+		assert.Error(t, err)
+
+		// The wait for the semaphore timed out, so this request never issued a
+		// fetch of its own; counting it as a failed fetch would blame upstream for
+		// contention and inflate the fetch error rate.
+		errored := counterPoints(collectMetrics(ctx, t, reader), operationsMetric, attribute.NewSet(
+			attribute.String("operation", "fetch"),
+			attribute.String("status", "error"),
+			attribute.String("trigger", "incremental"),
+		))
+		assert.Equal(t, 0, len(errored), "coalesce wait that never fetched must not record a fetch error")
+	})
+}
+
+func TestIncrementalOutcomeAfterNotOurRef(t *testing.T) {
+	assert.Equal(t, "", git.IncrementalOutcomeAfterNotOurRef(""))
+	assert.Equal(t, "fallback_not_our_ref", git.IncrementalOutcomeAfterNotOurRef("local_hit"))
+	assert.Equal(t, "fallback_not_our_ref", git.IncrementalOutcomeAfterNotOurRef("fetched"))
+}
+
+func TestIncrementalUploadPackServedLocally(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	// Mirror at <mirrorRoot>/127.0.0.1/org/repo matches the upstream URL
+	// https://127.0.0.1/org/repo. See e2eUpstreamHost for why the host matters.
+	const host = "127.0.0.1"
+	const repoPath = "org/localrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	headSHA := setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	body := buildCompleteUploadPackBody(headSHA)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, body)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, strings.Contains(string(respBody), "NAK"), "response body should contain NAK")
+	assert.True(t, strings.Contains(string(respBody), "PACK"), "response body should contain PACK magic bytes")
+	assert.Equal(t, int32(0), hits.Load(), "fake upstream should not be contacted when mirror is in sync")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "local_hit", host+"/"+repoPath, false)
+}
+
+func TestIncrementalUploadPackServedLocallyV0NULCaps(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/v0nulrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	headSHA := setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// Real v0 first-want carries capabilities after a NUL. Before the parser
+	// fix this body was treated as a malformed want and incremental was skipped.
+	body := buildV0UploadPackBodyWithNULCaps(headSHA)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, body)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, strings.Contains(string(respBody), "NAK"), "response body should contain NAK")
+	assert.True(t, strings.Contains(string(respBody), "PACK"), "response body should contain PACK magic bytes")
+	assert.Equal(t, int32(0), hits.Load(), "fake upstream should not be contacted for a v0 NUL-cap local hit")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "local_hit", host+"/"+repoPath, false)
+}
+
+func TestIncrementalUploadPackFetchesMissingDelta(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/deltarepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// Advance upstream after warm-up, so the mirror does not yet have newSHA.
+	newSHA := pushCommitToUpstream(t, upstreamPath)
+
+	// Sanity check: mirror does not have the new commit yet.
+	// #nosec G204 - mirrorPath is a t.TempDir() path and newSHA is rev-parse output from the local upstream
+	catFile := exec.Command("git", "-C", mirrorPath, "cat-file", "-e", newSHA)
+	assert.Error(t, catFile.Run(), "mirror should not have newSHA before the request")
+
+	body := buildCompleteUploadPackBody(newSHA)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, body)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, strings.Contains(string(respBody), "NAK"), "response body should contain NAK")
+	assert.True(t, strings.Contains(string(respBody), "PACK"), "response body should contain PACK magic bytes")
+
+	// The proxy transport (hits) is only used by forwardToUpstream. The incremental
+	// delta fetch goes through the mirror's origin remote (local filesystem),
+	// so hits must remain zero.
+	assert.Equal(t, int32(0), hits.Load(), "fake upstream proxy should not be contacted; delta fetch uses mirror's origin remote")
+
+	// Confirm the mirror now contains the new commit, proving the delta fetch ran.
+	// #nosec G204 - mirrorPath is a t.TempDir() path and newSHA is rev-parse output from the local upstream
+	catFileAfter := exec.Command("git", "-C", mirrorPath, "cat-file", "-e", newSHA)
+	assert.NoError(t, catFileAfter.Run(), "mirror should contain newSHA after the incremental delta fetch")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "fetched", host+"/"+repoPath, true)
+}
+
+func TestIncrementalUploadPackFallsBackOnMissingWant(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/fallbackrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	body := buildCompleteUploadPackBody(absentSHA)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, body)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.True(t, hits.Load() >= 1, "fake upstream should receive the forwarded POST")
+	assert.True(t, strings.Contains(string(respBody), fakeUpstreamMarker),
+		"client should receive the fake upstream marker body")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "fallback_missing", host+"/"+repoPath, true)
+}
+
+func TestIncrementalUploadPackFallsBackOnFetchFailed(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/fetchfailedrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 10 * time.Second,
+	})
+	waitForReady(t, s)
+
+	// Point the mirror's origin at an unreachable path so the incremental fetch
+	// fails. checkRefsStale uses the upstream URL (https://127.0.0.1/...) and
+	// fails fast on connection-refused; RefCheckInterval is 1ns in the E2E
+	// setup so the cooldown has expired and the fetch path runs.
+	// #nosec G204 - mirrorPath is a t.TempDir() path and the remote URL is a literal
+	out, err := exec.Command("git", "-C", mirrorPath, "remote", "set-url", "origin", "/nonexistent/path").CombinedOutput()
+	assert.NoError(t, err, string(out))
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// A want the mirror does not have; the incremental fetch will fail to reach the
+	// (now broken) origin, so the request must fall back to upstream.
+	const absentSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	body := buildCompleteUploadPackBody(absentSHA)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, body)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.True(t, hits.Load() >= 1, "fake upstream should receive the forwarded POST when the incremental fetch fails")
+	assert.True(t, strings.Contains(string(respBody), fakeUpstreamMarker),
+		"client should receive the fake upstream marker body")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "fallback_fetch_failed", host+"/"+repoPath, true)
+}
+
+func TestIncrementalUploadPackConcurrentRequestsCoalesce(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/concurrentrepo"
+	const numClients = 8
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// Advance upstream after warm-up, so the mirror does not yet have newSHA.
+	newSHA := pushCommitToUpstream(t, upstreamPath)
+
+	// Sanity check: mirror does not have the new commit yet.
+	// #nosec G204 - mirrorPath is a t.TempDir() path and newSHA is rev-parse output from the local upstream
+	catFile := exec.Command("git", "-C", mirrorPath, "cat-file", "-e", newSHA)
+	assert.Error(t, catFile.Run(), "mirror should not have newSHA before the requests")
+
+	body := buildCompleteUploadPackBody(newSHA)
+
+	var wg sync.WaitGroup
+	errs := make([]error, numClients)
+	statuses := make([]int, numClients)
+	bodies := make([]string, numClients)
+	for i := range numClients {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			resp, postErr := postUploadPack(ctx, cachewSrv.URL, repoPath, body)
+			if postErr != nil {
+				errs[i] = postErr
+				return
+			}
+			defer resp.Body.Close()
+			b, readErr := io.ReadAll(resp.Body)
+			errs[i] = readErr
+			statuses[i] = resp.StatusCode
+			bodies[i] = string(b)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range numClients {
+		assert.NoError(t, errs[i], "client %d request body read", i)
+		assert.Equal(t, http.StatusOK, statuses[i], "client %d status", i)
+		assert.True(t, strings.Contains(bodies[i], "PACK"), "client %d response should contain PACK", i)
+	}
+
+	// All clients were served locally: the fake upstream proxy was never hit.
+	assert.Equal(t, int32(0), hits.Load(), "no client should have been forwarded to upstream")
+
+	// The mirror now contains the new commit, proving the delta fetch ran.
+	// #nosec G204 - mirrorPath is a t.TempDir() path and newSHA is rev-parse output from the local upstream
+	catFileAfter := exec.Command("git", "-C", mirrorPath, "cat-file", "-e", newSHA)
+	assert.NoError(t, catFileAfter.Run(), "mirror should contain newSHA after concurrent incremental fetch")
+
+	// Exactly numClients incremental serve events were recorded, as a mix of
+	// "fetched" (the client that ran the fetch) and "local_hit" (clients that
+	// found the want already present from a concurrent client's fetch).
+	// No fallback_* outcomes should appear.
+	rm := collectMetrics(ctx, t, reader)
+	fetchedAttrs := attribute.NewSet(
+		attribute.String("outcome", "fetched"),
+		attribute.String("repository", host+"/"+repoPath),
+	)
+	localHitAttrs := attribute.NewSet(
+		attribute.String("outcome", "local_hit"),
+		attribute.String("repository", host+"/"+repoPath),
+	)
+	fetchedPts := counterPoints(rm, incrementalServesMetric, fetchedAttrs)
+	localHitPts := counterPoints(rm, incrementalServesMetric, localHitAttrs)
+	var fetchedCount, localHitCount int64
+	if len(fetchedPts) > 0 {
+		fetchedCount = fetchedPts[0].Value
+	}
+	if len(localHitPts) > 0 {
+		localHitCount = localHitPts[0].Value
+	}
+	assert.Equal(t, int64(numClients), fetchedCount+localHitCount,
+		"all %d clients should be served via incremental (fetched=%d local_hit=%d)", numClients, fetchedCount, localHitCount)
+	assert.True(t, fetchedCount >= 1, "at least one client must have triggered the fetch")
+}
+
+func TestIncrementalUploadPackServedLocallyGzipBody(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/gziprepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	headSHA := setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// gzip-encode the upload-pack body; incrementalParse must transparently
+	// decompress it to extract the wants.
+	body := gzipBody(buildCompleteUploadPackBody(headSHA))
+	url := fmt.Sprintf("%s/git/%s/%s/git-upload-pack", cachewSrv.URL, e2eUpstreamHost, repoPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	req.Header.Set("Content-Encoding", "gzip")
+	client := &http.Client{Transport: http.DefaultTransport}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, strings.Contains(string(respBody), "PACK"), "response body should contain PACK magic bytes")
+	assert.Equal(t, int32(0), hits.Load(), "fake upstream should not be contacted when mirror is in sync")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "local_hit", host+"/"+repoPath, false)
+}
+
+func TestIncrementalUploadPackServedLocallyV2FetchBody(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/v2repo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	headSHA := setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// Build a protocol v2 command=fetch body with a want line. incrementalParse
+	// must parse it and engage the incremental path.
+	v2Body := buildBody(
+		pkt("command=fetch\n"),
+		delimPkt,
+		pkt("want "+headSHA+"\n"),
+		pkt("done\n"),
+		flushPkt,
+	)
+	url := fmt.Sprintf("%s/git/%s/%s/git-upload-pack", cachewSrv.URL, e2eUpstreamHost, repoPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(v2Body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	req.Header.Set("Git-Protocol", "version=2")
+	client := &http.Client{Transport: http.DefaultTransport}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, strings.Contains(string(respBody), "PACK"), "response body should contain PACK magic bytes")
+	assert.Equal(t, int32(0), hits.Load(), "fake upstream should not be contacted when mirror is in sync")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "local_hit", host+"/"+repoPath, false)
+}
+
+func TestIncrementalLsRefsRecordsNotEngaged(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/lsrefsrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, buildLsRefsBody())
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	rm := collectMetrics(ctx, t, reader)
+	assertIncrementalEligible(t, rm, host+"/"+repoPath, false)
+	assert.Equal(t, 0, metricPointCount(rm, incrementalServesMetric),
+		"%s must only fire for engaged requests", incrementalServesMetric)
+	assert.Equal(t, 0, metricPointCount(rm, incrementalDurationMetric),
+		"%s must only fire for engaged requests", incrementalDurationMetric)
+}
+
+func TestIncrementalWantRefForwardedToUpstream(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/wantrefrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// A v2 want-ref body asks the mirror to resolve refs/heads/main by name.
+	// The mirror holds that ref, so this would be a local hit if cachew tried;
+	// it must be forwarded instead.
+	wantRefBody := []byte(pkt("command=fetch\n") + delimPkt + pkt("want-ref refs/heads/main\n") + flushPkt)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, wantRefBody)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.True(t, hits.Load() >= 1, "fake upstream should receive the forwarded want-ref POST")
+	assert.True(t, strings.Contains(string(respBody), fakeUpstreamMarker),
+		"client should receive the fake upstream marker body")
+
+	rm := collectMetrics(ctx, t, reader)
+	assertIncrementalEligible(t, rm, host+"/"+repoPath, false)
+	assert.Equal(t, 0, metricPointCount(rm, incrementalServesMetric),
+		"%s must not fire for forwarded want-ref requests", incrementalServesMetric)
+}
+
+func TestIncrementalWantRefUnknownRefServedFromUpstream(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	t.Setenv("GIT_SSL_NO_VERIFY", "1")
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	run := func(args ...string) {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+
+	workPath := filepath.Join(tmpDir, "work")
+	assert.NoError(t, os.MkdirAll(workPath, 0o755))
+	run("git", "-c", "init.defaultBranch=main", "-C", workPath, "init")
+	run("git", "-C", workPath, "config", "user.email", "test@example.com")
+	run("git", "-C", workPath, "config", "user.name", "Test")
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "file.txt"), []byte("initial"), 0o600))
+	run("git", "-C", workPath, "add", ".")
+	run("git", "-C", workPath, "commit", "-m", "initial")
+
+	upstreamRoot := filepath.Join(tmpDir, "upstream-root")
+	upstreamPath := filepath.Join(upstreamRoot, "org", "tag-repo")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(upstreamPath), 0o755))
+	run("git", "clone", "--bare", workPath, upstreamPath)
+	run("git", "-C", upstreamPath, "config", "uploadpack.allowRefInWant", "true")
+
+	gitSrv := serveGitOverTLS(t, upstreamRoot)
+	hostPort := strings.TrimPrefix(gitSrv.URL, "https://")
+	upstreamURL := gitSrv.URL + "/org/tag-repo"
+
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	mirrorPath := filepath.Join(mirrorRoot, hostPort, "org", "tag-repo")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(mirrorPath), 0o755))
+	run("git", "clone", "--mirror", upstreamURL, mirrorPath)
+	// The mirror deliberately keeps ref-in-want unadvertised (git's default);
+	// upstream, configured above, is the only side that must accept want-ref.
+
+	var hits atomic.Int32
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+	s.SetHTTPTransport(&countingTLSTransport{
+		inner: &http.Transport{TLSClientConfig: hermeticTLSConfig(gitSrv)},
+		hits:  &hits,
+	})
+
+	client := &http.Client{Transport: http.DefaultTransport}
+
+	// Push tag v9 to upstream without moving main, so mirror heads stay fresh.
+	run("git", "-C", workPath, "tag", "v9")
+	run("git", "-C", workPath, "push", upstreamPath, "refs/tags/v9:refs/tags/v9")
+
+	wantRefBody := []byte(pkt("command=fetch\n") + delimPkt + pkt("want-ref refs/tags/v9\n") + pkt("done\n") + flushPkt)
+	postURL := fmt.Sprintf("%s/git/%s/org/tag-repo/git-upload-pack", cachewSrv.URL, hostPort)
+	postReq, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, bytes.NewReader(wantRefBody))
+	assert.NoError(t, err)
+	postReq.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	postReq.Header.Set("Git-Protocol", "version=2")
+	postResp, err := client.Do(postReq)
+	assert.NoError(t, err)
+	defer postResp.Body.Close()
+	postRespBody, err := io.ReadAll(postResp.Body)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, postResp.StatusCode)
+	assert.True(t, hits.Load() >= 1, "want-ref for a tag the mirror lacks must be forwarded to upstream")
+	assert.True(t, len(postRespBody) > 0 && !strings.Contains(string(postRespBody), "unknown ref"),
+		"forwarded response should come from upstream, not a local unknown-ref error; got %q", string(postRespBody[:min(80, len(postRespBody))]))
+}
+
+func TestIncrementalDisabledFallsBackViaNotOurRef(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/disabledrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  false, // the old path must be taken
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// Advance upstream, so the mirror is one commit behind.
+	newSHA := pushCommitToUpstream(t, upstreamPath)
+
+	body := buildCompleteUploadPackBody(newSHA)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, body)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.True(t, hits.Load() >= 1, "fake upstream should receive the forwarded POST when incremental is disabled")
+	assert.True(t, strings.Contains(string(respBody), fakeUpstreamMarker),
+		"client should receive the fake upstream marker body")
+
+	// Mirror must NOT contain newSHA: no incremental fetch ran.
+	// #nosec G204 - mirrorPath is a t.TempDir() path and newSHA is rev-parse output from the local upstream
+	catFile := exec.Command("git", "-C", mirrorPath, "cat-file", "-e", newSHA)
+	assert.Error(t, catFile.Run(), "mirror should not contain newSHA when incremental pull-through is disabled")
+
+	rm := collectMetrics(ctx, t, reader)
+	assertIncrementalEligible(t, rm, host+"/"+repoPath, true)
+	assert.Equal(t, 0, metricPointCount(rm, incrementalServesMetric),
+		"incremental disabled: no serve outcomes should be recorded")
+}
+
+// countingTLSTransport counts upstream round trips made through the strategy's
+// reverse proxy.
+type countingTLSTransport struct {
+	inner http.RoundTripper
+	hits  *atomic.Int32
+}
+
+func (rt *countingTLSTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.hits.Add(1)
+	return rt.inner.RoundTrip(req)
+}
+
+// serveGitOverTLS exposes root via git http-backend on a TLS httptest server,
+// so hermetic tests can exercise paths that require ls-remote/fetch to succeed
+// over HTTPS (the strategy hardcodes the https scheme for upstream URLs).
+// Callers must set GIT_SSL_NO_VERIFY=1 (via t.Setenv) for git CLI operations
+// against the server, and use hermeticTLSConfig(srv) for proxied requests.
+func serveGitOverTLS(t *testing.T, root string) *httptest.Server {
+	t.Helper()
+	gitPath, err := exec.LookPath("git")
+	assert.NoError(t, err)
+	handler := &cgi.Handler{
+		Path: gitPath,
+		Args: []string{"http-backend"},
+		Env: []string{
+			"GIT_PROJECT_ROOT=" + root,
+			"GIT_HTTP_EXPORT_ALL=1",
+			"PATH=" + os.Getenv("PATH"),
+		},
+	}
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// hermeticTLSConfig trusts srv's own leaf certificate instead of skipping
+// verification, so proxied requests to a serveGitOverTLS server perform real
+// certificate validation.
+func hermeticTLSConfig(srv *httptest.Server) *tls.Config {
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	return &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+}
+
+func TestIncrementalStaleInfoRefsForwardedThenBackgroundFetch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	// The hermetic upstream uses a self-signed certificate; git CLI operations
+	// (clone, ls-remote, background fetch) inherit this from the test process.
+	t.Setenv("GIT_SSL_NO_VERIFY", "1")
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	run := func(args ...string) {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		assert.NoError(t, err, string(out))
+	}
+	revParse := func(dir string) string {
+		out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+		assert.NoError(t, err)
+		return strings.TrimSpace(string(out))
+	}
+
+	// Work repo with one commit, bare-cloned into the served root.
+	workPath := filepath.Join(tmpDir, "work")
+	assert.NoError(t, os.MkdirAll(workPath, 0o755))
+	run("git", "-c", "init.defaultBranch=main", "-C", workPath, "init")
+	run("git", "-C", workPath, "config", "user.email", "test@example.com")
+	run("git", "-C", workPath, "config", "user.name", "Test")
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "file.txt"), []byte("initial content"), 0o600))
+	run("git", "-C", workPath, "add", ".")
+	run("git", "-C", workPath, "commit", "-m", "initial commit")
+	headSHA := revParse(workPath)
+
+	upstreamRoot := filepath.Join(tmpDir, "upstream-root")
+	upstreamPath := filepath.Join(upstreamRoot, "org", "stale-repo")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(upstreamPath), 0o755))
+	run("git", "clone", "--bare", workPath, upstreamPath)
+
+	gitSrv := serveGitOverTLS(t, upstreamRoot)
+	hostPort := strings.TrimPrefix(gitSrv.URL, "https://")
+	upstreamURL := gitSrv.URL + "/org/stale-repo"
+
+	// Mirror cloned over HTTPS so its origin matches the strategy's upstream URL.
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	mirrorPath := filepath.Join(mirrorRoot, hostPort, "org", "stale-repo")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(mirrorPath), 0o755))
+	run("git", "clone", "--mirror", upstreamURL, mirrorPath)
+
+	var hits atomic.Int32
+	reader := setupMetricsReader(t)
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+	s.SetHTTPTransport(&countingTLSTransport{
+		inner: &http.Transport{TLSClientConfig: hermeticTLSConfig(gitSrv)},
+		hits:  &hits,
+	})
+
+	// SetHTTPTransport mutates http.DefaultClient, so test client requests must
+	// use a dedicated transport to avoid polluting the proxy hit counter.
+	client := &http.Client{Transport: http.DefaultTransport}
+
+	// Advance upstream after warm-up so the mirror is stale.
+	assert.NoError(t, os.WriteFile(filepath.Join(workPath, "file2.txt"), []byte("delta content"), 0o600))
+	run("git", "-C", workPath, "add", ".")
+	run("git", "-C", workPath, "commit", "-m", "delta")
+	run("git", "-C", workPath, "push", upstreamPath, "HEAD:main")
+	newSHA := revParse(workPath)
+
+	// Stale info/refs: forwarded to upstream so the client sees fresh refs,
+	// and a background fetch is scheduled to catch the mirror up.
+	infoRefsURL := fmt.Sprintf("%s/git/%s/org/stale-repo/info/refs?service=git-upload-pack", cachewSrv.URL, hostPort)
+	infoReq, err := http.NewRequestWithContext(ctx, http.MethodGet, infoRefsURL, nil)
+	assert.NoError(t, err)
+	resp, err := client.Do(infoReq)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, strings.Contains(string(respBody), newSHA), "forwarded info/refs must carry the fresh upstream tip")
+	assert.True(t, hits.Load() >= 1, "stale info/refs must be forwarded to upstream")
+
+	// The background fetch triggered by the stale info/refs brings the delta in.
+	deadline := time.Now().Add(30 * time.Second)
+	// #nosec G204 - mirrorPath is a t.TempDir() path and newSHA is rev-parse output from the local upstream
+	for exec.Command("git", "-C", mirrorPath, "cat-file", "-e", newSHA).Run() != nil {
+		if time.Now().After(deadline) {
+			t.Fatal("background fetch did not bring newSHA into the mirror")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// An upload-pack POST for objects the mirror has is served locally, with no
+	// upstream round trip.
+	before := hits.Load()
+	body := buildCompleteUploadPackBody(headSHA)
+	postURL := fmt.Sprintf("%s/git/%s/org/stale-repo/git-upload-pack", cachewSrv.URL, hostPort)
+	postReq, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, bytes.NewReader(body))
+	assert.NoError(t, err)
+	postReq.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	postResp, err := client.Do(postReq)
+	assert.NoError(t, err)
+	defer postResp.Body.Close()
+	postRespBody, err := io.ReadAll(postResp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, postResp.StatusCode)
+	assert.True(t, strings.Contains(string(postRespBody), "PACK"), "response body should contain PACK magic bytes")
+	assert.Equal(t, before, hits.Load(), "upload-pack for present wants must be served locally")
+
+	assertIncrementalServeMetrics(ctx, t, reader, "local_hit", hostPort+"/org/stale-repo", false)
+}
+
+func TestWantRefForwardedIncrementalDisabled(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const host = "127.0.0.1"
+	const repoPath = "org/wantrefdisabledrepo"
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorPath := filepath.Join(mirrorRoot, host, repoPath)
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	fakeSrv, hits := countingFakeUpstream(t)
+
+	s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  false, // the want-ref guard must still hold
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	s.SetHTTPTransport(&redirectToFakeTransport{
+		fakeBaseURL: fakeSrv.URL,
+		inner:       http.DefaultTransport,
+		hits:        hits,
+	})
+
+	// The mirror holds refs/heads/main, but it does not advertise ref-in-want and
+	// resolving the ref name locally could serve a stale tip, so the request must
+	// be forwarded even with incremental disabled.
+	wantRefBody := []byte(pkt("command=fetch\n") + delimPkt + pkt("want-ref refs/heads/main\n") + flushPkt)
+	resp, err := postUploadPack(ctx, cachewSrv.URL, repoPath, wantRefBody)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	assert.True(t, hits.Load() >= 1, "fake upstream should receive the forwarded want-ref POST")
+	assert.True(t, strings.Contains(string(respBody), fakeUpstreamMarker),
+		"client should receive the fake upstream marker body")
+}
+
+func TestSubmitFetchForceBypassesFetchCooldown(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const upstreamURL = "https://example.com/org/repo"
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	mirrorPath := filepath.Join(mirrorRoot, "example.com", "org", "repo")
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	// A long cooldown leaves the warm-up fetch's timestamp inside the window,
+	// which is the state a just-failed incremental fetch also leaves behind.
+	const cooldown = time.Hour
+	s, manager := newTestStrategyForMirrorWithRefCheck(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	}, cooldown)
+	waitForReady(t, s)
+
+	repo, err := manager.GetOrCreate(ctx, upstreamURL)
+	assert.NoError(t, err)
+
+	// Advance upstream after warm-up so convergence can only come from a fetch
+	// that runs now.
+	newSHA := pushCommitToUpstream(t, upstreamPath)
+	assert.False(t, repo.NeedsFetch(cooldown), "warm-up fetch must leave the cooldown active")
+
+	// The cooldown makes the unforced submission a no-op, so the mirror stays behind.
+	git.SubmitFetch(s, repo)
+	time.Sleep(500 * time.Millisecond)
+	assert.False(t, repo.HasCommit(ctx, newSHA), "submitFetch must not fetch inside the cooldown")
+
+	git.SubmitFetchForce(s, repo)
+	deadline := time.Now().Add(30 * time.Second)
+	for !repo.HasCommit(ctx, newSHA) {
+		if time.Now().After(deadline) {
+			t.Fatal("forced background fetch did not bring newSHA into the mirror")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestSubmitFetchForceFetchesPastSemaphoreHolder(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	_, ctx := logging.Configure(context.Background(), logging.Config{})
+	tmpDir := t.TempDir()
+
+	const upstreamURL = "https://example.com/org/repo"
+	upstreamPath := filepath.Join(tmpDir, "upstream")
+	mirrorRoot := filepath.Join(tmpDir, "mirrors")
+	mirrorPath := filepath.Join(mirrorRoot, "example.com", "org", "repo")
+	assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+	setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+	s, manager := newTestStrategyForMirror(ctx, t, mirrorRoot, git.Config{
+		IncrementalPullthrough:  true,
+		IncrementalFetchTimeout: 30 * time.Second,
+	})
+	waitForReady(t, s)
+
+	repo, err := manager.GetOrCreate(ctx, upstreamURL)
+	assert.NoError(t, err)
+
+	// Advance upstream after warm-up so convergence can only come from the
+	// recovery fetch.
+	newSHA := pushCommitToUpstream(t, upstreamPath)
+
+	// A non-fetch holder, a snapshot tar say, occupies the fetch semaphore while
+	// the recovery job runs. A coalescing fetch would count the holder's work as
+	// its own and leave the mirror exactly as cold as before.
+	release := make(chan struct{})
+	acquired := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- repo.WithFetchExclusion(ctx, func() error {
+			close(acquired)
+			<-release
+			return nil
+		})
+	}()
+	<-acquired
+
+	git.SubmitFetchForce(s, repo)
+	time.Sleep(time.Second)
+	assert.False(t, repo.HasCommit(ctx, newSHA), "the holder blocks the fetch, so the mirror is still behind")
+
+	close(release)
+	assert.NoError(t, <-holderDone)
+
+	deadline := time.Now().Add(30 * time.Second)
+	for !repo.HasCommit(ctx, newSHA) {
+		if time.Now().After(deadline) {
+			t.Fatal("forced fetch did not bring newSHA into the mirror")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestShallowCloneDefaultProtocolSucceeds(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	for _, incremental := range []bool{true, false} {
+		t.Run(fmt.Sprintf("IncrementalPullthrough=%v", incremental), func(t *testing.T) {
+			t.Setenv("GIT_SSL_NO_VERIFY", "1")
+			_, ctx := logging.Configure(context.Background(), logging.Config{})
+			tmpDir := t.TempDir()
+
+			run := func(args ...string) {
+				out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+				assert.NoError(t, err, string(out))
+			}
+
+			// Several commits so --depth 1 is genuinely shallower than the repo.
+			workPath := filepath.Join(tmpDir, "work")
+			assert.NoError(t, os.MkdirAll(workPath, 0o755))
+			run("git", "-c", "init.defaultBranch=main", "-C", workPath, "init")
+			run("git", "-C", workPath, "config", "user.email", "test@example.com")
+			run("git", "-C", workPath, "config", "user.name", "Test")
+			for i := range 5 {
+				assert.NoError(t, os.WriteFile(filepath.Join(workPath, "file.txt"),
+					fmt.Appendf(nil, "rev%d", i), 0o600))
+				run("git", "-C", workPath, "add", "file.txt")
+				run("git", "-C", workPath, "commit", "-m", fmt.Sprintf("commit%d", i))
+			}
+
+			upstreamRoot := filepath.Join(tmpDir, "upstream-root")
+			upstreamPath := filepath.Join(upstreamRoot, "org", "shallow-repo")
+			assert.NoError(t, os.MkdirAll(filepath.Dir(upstreamPath), 0o755))
+			run("git", "clone", "--bare", workPath, upstreamPath)
+
+			gitSrv := serveGitOverTLS(t, upstreamRoot)
+			hostPort := strings.TrimPrefix(gitSrv.URL, "https://")
+			upstreamURL := gitSrv.URL + "/org/shallow-repo"
+
+			mirrorRoot := filepath.Join(tmpDir, "mirrors")
+			mirrorPath := filepath.Join(mirrorRoot, hostPort, "org", "shallow-repo")
+			assert.NoError(t, os.MkdirAll(filepath.Dir(mirrorPath), 0o755))
+			run("git", "clone", "--mirror", upstreamURL, mirrorPath)
+
+			var hits atomic.Int32
+			s, cachewSrv := setupE2EStrategy(ctx, t, mirrorRoot, git.Config{
+				IncrementalPullthrough:  incremental,
+				IncrementalFetchTimeout: 30 * time.Second,
+			})
+			waitForReady(t, s)
+			s.SetHTTPTransport(&countingTLSTransport{
+				inner: &http.Transport{TLSClientConfig: hermeticTLSConfig(gitSrv)},
+				hits:  &hits,
+			})
+
+			// No protocol.version override: the client negotiates v2, which is
+			// the only configuration that reproduces the regression.
+			cloneURL := fmt.Sprintf("%s/git/%s/org/shallow-repo", cachewSrv.URL, hostPort)
+			dest := filepath.Join(tmpDir, "shallow")
+			out, err := exec.Command("git", "clone", "--depth", "1", cloneURL, dest).CombinedOutput()
+			assert.NoError(t, err, "shallow clone through cachew must succeed: %s", string(out))
+
+			// A pack that parsed as intended yields a usable one-commit repo.
+			depthOut, err := exec.Command("git", "-C", dest, "rev-list", "--count", "HEAD").CombinedOutput()
+			assert.NoError(t, err, string(depthOut))
+			assert.Equal(t, "1", strings.TrimSpace(string(depthOut)),
+				"clone should be shallow with a single commit")
+			fsckOut, err := exec.Command("git", "-C", dest, "fsck", "--connectivity-only").CombinedOutput()
+			assert.NoError(t, err, string(fsckOut))
+			revParse := func(dir string) string {
+				revOut, revErr := exec.Command("git", "-C", dir, "rev-parse", "HEAD").CombinedOutput()
+				assert.NoError(t, revErr, string(revOut))
+				return strings.TrimSpace(string(revOut))
+			}
+			assert.Equal(t, revParse(workPath), revParse(dest), "clone should land on the upstream tip")
+
+			// The mirror has every wanted object, so the clone must be served
+			// locally rather than proxied upstream.
+			assert.Equal(t, int32(0), hits.Load(), "shallow clone should be served from the mirror")
+		})
+	}
+}

--- a/internal/strategy/git/incremental_test.go
+++ b/internal/strategy/git/incremental_test.go
@@ -736,6 +736,68 @@ func TestEnsureWantsAvailable(t *testing.T) {
 		assert.Equal(t, before, repo.LastFetch(), "cooldown must skip the fetch")
 	})
 
+	t.Run("CooldownSkippedWhenFetchInFlight", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		upstreamPath := filepath.Join(tmpDir, "upstream")
+		mirrorRoot := filepath.Join(tmpDir, "mirrors")
+		mirrorPath := filepath.Join(mirrorRoot, relMirrorPath)
+		assert.NoError(t, os.MkdirAll(mirrorPath, 0o755))
+
+		setupMirrorWithUpstream(t, upstreamPath, mirrorPath)
+
+		// Long RefCheckInterval keeps NeedsFetch false once the fetch below
+		// stamps lastFetchAttempt. Tests the in-flight case, not the recent one.
+		s, manager := newTestStrategyForMirrorWithRefCheck(ctx, t, mirrorRoot, git.Config{
+			IncrementalPullthrough:  true,
+			IncrementalFetchTimeout: 30 * time.Second,
+		}, time.Hour)
+		waitForReady(t, s)
+
+		repo, err := manager.GetOrCreate(ctx, fakeUpstreamURL)
+		assert.NoError(t, err)
+
+		// Advance upstream so newSHA is missing. Stall upload-pack so the fetch
+		// below stays running until released.
+		newSHA := pushCommitToUpstream(t, upstreamPath)
+		startedMarker, releaseFetch := stallUpstream(t, mirrorPath)
+
+		fetchDone := make(chan error, 1)
+		go func() {
+			fetchDone <- repo.Fetch(ctx)
+		}()
+		waitForFile(t, startedMarker)
+
+		// Fetch is in flight and lastFetchAttempt is fresh: the case the old
+		// guard short-circuited on without checking FetchInFlight.
+		assert.False(t, repo.NeedsFetch(time.Hour), "cooldown must be active")
+		assert.True(t, repo.FetchInFlight(), "fetch must be in flight")
+
+		type result struct {
+			outcome string
+			err     error
+		}
+		done := make(chan result, 1)
+		start := time.Now()
+		go func() {
+			outcome, err := git.EnsureWantsAvailable(ctx, s, repo, []string{newSHA})
+			done <- result{outcome, err}
+		}()
+
+		// Let the request reach the coalescing wait before releasing. Otherwise a
+		// broken guard could return fallback_missing before this fires.
+		time.Sleep(50 * time.Millisecond)
+		releaseFetch()
+		assert.NoError(t, <-fetchDone, "background fetch must succeed")
+
+		res := <-done
+		elapsed := time.Since(start)
+		assert.NoError(t, res.err)
+		assert.Equal(t, "fetched", res.outcome,
+			"a request arriving while a fetch is in flight must wait for it instead of falling back")
+		assert.True(t, elapsed >= 50*time.Millisecond,
+			"outcome must come from waiting on the in-flight fetch, not an instant fallback (elapsed %v)", elapsed)
+	})
+
 	t.Run("PullRefOnlyFetches", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		upstreamPath := filepath.Join(tmpDir, "upstream")

--- a/internal/strategy/git/integration_test.go
+++ b/internal/strategy/git/integration_test.go
@@ -96,6 +96,10 @@ func TestIntegrationGitCloneViaProxy(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping: requires real network access to github.com, unavailable from CI runners")
+	}
+
 	// Check if git is available
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found in PATH")
@@ -175,6 +179,10 @@ func TestIntegrationGitCloneViaProxy(t *testing.T) {
 func TestIntegrationGitFetchViaProxy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
+	}
+
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping: requires real network access to github.com, unavailable from CI runners")
 	}
 
 	if _, err := exec.LookPath("git"); err != nil {

--- a/internal/strategy/git/metrics.go
+++ b/internal/strategy/git/metrics.go
@@ -13,55 +13,65 @@ import (
 )
 
 type gitMetrics struct {
-	operationDuration      metric.Float64Histogram
-	operationTotal         metric.Int64Counter
-	requestTotal           metric.Int64Counter
-	snapshotServeTotal     metric.Int64Counter
-	snapshotServeSize      metric.Float64Histogram
-	snapshotServeDuration  metric.Float64Histogram
-	bundleServeTotal       metric.Int64Counter
-	bundleServeSize        metric.Float64Histogram
-	bundleServeDuration    metric.Float64Histogram
-	ensureRefsTotal        metric.Int64Counter
-	ensureRefsDuration     metric.Float64Histogram
-	spoolWriterDuration    metric.Float64Histogram
-	spoolFollowerWaitTotal metric.Int64Counter
-	spoolFollowerWait      metric.Float64Histogram
-	repackPackCount        metric.Float64Histogram
-	snapshotServeBandwidth metric.Float64Histogram
-	lfsPhaseDuration       metric.Float64Histogram
-	lfsPhaseBytes          metric.Float64Histogram
+	operationDuration        metric.Float64Histogram
+	operationTotal           metric.Int64Counter
+	requestTotal             metric.Int64Counter
+	snapshotServeTotal       metric.Int64Counter
+	snapshotServeSize        metric.Float64Histogram
+	snapshotServeDuration    metric.Float64Histogram
+	bundleServeTotal         metric.Int64Counter
+	bundleServeSize          metric.Float64Histogram
+	bundleServeDuration      metric.Float64Histogram
+	ensureRefsTotal          metric.Int64Counter
+	ensureRefsDuration       metric.Float64Histogram
+	spoolWriterDuration      metric.Float64Histogram
+	spoolFollowerWaitTotal   metric.Int64Counter
+	spoolFollowerWait        metric.Float64Histogram
+	repackPackCount          metric.Float64Histogram
+	snapshotServeBandwidth   metric.Float64Histogram
+	lfsPhaseDuration         metric.Float64Histogram
+	lfsPhaseBytes            metric.Float64Histogram
+	incrementalServeTotal    metric.Int64Counter
+	incrementalFetchDuration metric.Float64Histogram
+	incrementalEligibleTotal metric.Int64Counter
 }
 
 func newGitMetrics() *gitMetrics {
 	meter := otel.Meter("cachew.git")
 	return &gitMetrics{
-		operationDuration:      metrics.NewHistogram(meter, "cachew.git.operation_duration_seconds", "s", "Duration of git operations (clone, fetch, repack, snapshot)", metrics.LatencyBuckets()),
-		operationTotal:         metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.operations_total", "{operations}", "Total number of git operations"),
-		requestTotal:           metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.requests_total", "{requests}", "Total number of git HTTP requests by type"),
-		snapshotServeTotal:     metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.snapshot_serves_total", "{serves}", "Snapshot serve events by source (cache, spool, cold_cache, generated) and repository"),
-		snapshotServeSize:      metrics.NewHistogram(meter, "cachew.git.snapshot_serve_bytes", "By", "Size of served snapshots in bytes", metrics.ByteBuckets()),
-		snapshotServeDuration:  metrics.NewHistogram(meter, "cachew.git.snapshot_serve_duration_seconds", "s", "Wall-clock duration of snapshot serves, from handler entry to last byte sent", metrics.LatencyBuckets()),
-		bundleServeTotal:       metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.bundle_serves_total", "{serves}", "Bundle serve events by source (cache, generated, up_to_date, miss_bad_base, miss) and repository"),
-		bundleServeSize:        metrics.NewHistogram(meter, "cachew.git.bundle_serve_bytes", "By", "Size of served bundles in bytes", metrics.ByteBuckets()),
-		bundleServeDuration:    metrics.NewHistogram(meter, "cachew.git.bundle_serve_duration_seconds", "s", "Wall-clock duration of bundle serves, including any on-demand generation", metrics.LatencyBuckets()),
-		ensureRefsTotal:        metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.ensure_refs_total", "{requests}", "EnsureRefs requests by fetched and status"),
-		ensureRefsDuration:     metrics.NewHistogram(meter, "cachew.git.ensure_refs_duration_seconds", "s", "Duration of EnsureRefs requests, including any upstream fetch", metrics.FastLatencyBuckets()),
-		spoolWriterDuration:    metrics.NewHistogram(meter, "cachew.git.spool_writer_duration_seconds", "s", "Time the snapshot spool writer spent producing the stream", metrics.LatencyBuckets()),
-		spoolFollowerWaitTotal: metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.spool_follower_waits_total", "{waits}", "Snapshot spool follower events, by outcome (served, writer_failed)"),
-		spoolFollowerWait:      metrics.NewHistogram(meter, "cachew.git.spool_follower_wait_seconds", "s", "Time a snapshot spool follower spent waiting for the writer to publish headers", metrics.FastLatencyBuckets()),
-		repackPackCount:        metrics.NewHistogram(meter, "cachew.git.repack_pack_count", "{packs}", "Pack file count observed before and after repack, by stage (before, after)", metrics.SmallCountBuckets()),
-		snapshotServeBandwidth: metrics.NewHistogram(meter, "cachew.git.snapshot_serve_bandwidth_mbps", "MiBy/s", "Per-request snapshot serve throughput in MiB/s, by source and repository", metrics.BandwidthMbpsBuckets()),
-		lfsPhaseDuration:       metrics.NewHistogram(meter, "cachew.git.lfs_phase_duration_seconds", "s", "Duration of an LFS-snapshot generation phase (discover, clone, fetch, archive_upload), by status and repository", metrics.LatencyBuckets()),
-		lfsPhaseBytes:          metrics.NewHistogram(meter, "cachew.git.lfs_phase_bytes", "By", "Bytes processed in an LFS-snapshot generation phase, by phase and repository (e.g. .git/lfs size after fetch)", metrics.ByteBuckets()),
+		operationDuration:        metrics.NewHistogram(meter, "cachew.git.operation_duration_seconds", "s", "Duration of git operations (clone, fetch, repack, snapshot) by operation, status and trigger (background|incremental)", metrics.LatencyBuckets()),
+		operationTotal:           metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.operations_total", "{operations}", "Total number of git operations by operation, status and trigger (background|incremental; incremental marks fetches issued synchronously on the request path by incremental pull-through)"),
+		requestTotal:             metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.requests_total", "{requests}", "Total number of git HTTP requests by type"),
+		snapshotServeTotal:       metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.snapshot_serves_total", "{serves}", "Snapshot serve events by source (cache, spool, cold_cache, generated) and repository"),
+		snapshotServeSize:        metrics.NewHistogram(meter, "cachew.git.snapshot_serve_bytes", "By", "Size of served snapshots in bytes", metrics.ByteBuckets()),
+		snapshotServeDuration:    metrics.NewHistogram(meter, "cachew.git.snapshot_serve_duration_seconds", "s", "Wall-clock duration of snapshot serves, from handler entry to last byte sent", metrics.LatencyBuckets()),
+		bundleServeTotal:         metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.bundle_serves_total", "{serves}", "Bundle serve events by source (cache, generated, up_to_date, miss_bad_base, miss) and repository"),
+		bundleServeSize:          metrics.NewHistogram(meter, "cachew.git.bundle_serve_bytes", "By", "Size of served bundles in bytes", metrics.ByteBuckets()),
+		bundleServeDuration:      metrics.NewHistogram(meter, "cachew.git.bundle_serve_duration_seconds", "s", "Wall-clock duration of bundle serves, including any on-demand generation", metrics.LatencyBuckets()),
+		ensureRefsTotal:          metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.ensure_refs_total", "{requests}", "EnsureRefs requests by fetched and status"),
+		ensureRefsDuration:       metrics.NewHistogram(meter, "cachew.git.ensure_refs_duration_seconds", "s", "Duration of EnsureRefs requests, including any upstream fetch", metrics.FastLatencyBuckets()),
+		spoolWriterDuration:      metrics.NewHistogram(meter, "cachew.git.spool_writer_duration_seconds", "s", "Time the snapshot spool writer spent producing the stream", metrics.LatencyBuckets()),
+		spoolFollowerWaitTotal:   metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.spool_follower_waits_total", "{waits}", "Snapshot spool follower events, by outcome (served, writer_failed)"),
+		spoolFollowerWait:        metrics.NewHistogram(meter, "cachew.git.spool_follower_wait_seconds", "s", "Time a snapshot spool follower spent waiting for the writer to publish headers", metrics.FastLatencyBuckets()),
+		repackPackCount:          metrics.NewHistogram(meter, "cachew.git.repack_pack_count", "{packs}", "Pack file count observed before and after repack, by stage (before, after)", metrics.SmallCountBuckets()),
+		snapshotServeBandwidth:   metrics.NewHistogram(meter, "cachew.git.snapshot_serve_bandwidth_mbps", "MiBy/s", "Per-request snapshot serve throughput in MiB/s, by source and repository", metrics.BandwidthMbpsBuckets()),
+		lfsPhaseDuration:         metrics.NewHistogram(meter, "cachew.git.lfs_phase_duration_seconds", "s", "Duration of an LFS-snapshot generation phase (discover, clone, fetch, archive_upload), by status and repository", metrics.LatencyBuckets()),
+		lfsPhaseBytes:            metrics.NewHistogram(meter, "cachew.git.lfs_phase_bytes", "By", "Bytes processed in an LFS-snapshot generation phase, by phase and repository (e.g. .git/lfs size after fetch)", metrics.ByteBuckets()),
+		incrementalServeTotal:    metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.incremental_serves_total", "{serves}", "Incremental pull-through upload-pack serve events by outcome (local_hit, fetched, fallback_fetch_failed, fallback_missing, fallback_local_error, client_gone, client_gone_after_fetch, fallback_not_our_ref) and repository"),
+		incrementalFetchDuration: metrics.NewHistogram(meter, "cachew.git.incremental_fetch_duration_seconds", "s", "Wall-clock time from upload-pack handler entry through making wanted objects available for an incremental pull-through serve, by outcome and repository", metrics.LatencyBuckets()),
+		incrementalEligibleTotal: metrics.NewMetric[metric.Int64Counter](meter, "cachew.git.incremental_eligible_total", "{requests}", "Upload-pack POSTs against a ready mirror reaching the incremental pull-through decision, by engaged and repository; engaged=true matches an incremental_serves_total increment when the feature is enabled, except for a body mixing want and want-ref, which is forwarded before any serve is recorded; engaged=false means the request bypassed the incremental path (ls-refs, want-ref only, no wants, parse failure)"),
 	}
 }
 
-// recordOperation records the duration and outcome of a git operation (clone, fetch, repack, snapshot).
-func (m *gitMetrics) recordOperation(ctx context.Context, operation, status string, duration time.Duration) {
+// recordOperation records the duration and outcome of a git operation (clone,
+// fetch, repack, snapshot). trigger is "background" for scheduled-job work and
+// "incremental" for fetches issued on the request path by incremental
+// pull-through, so the fetch SLO can separate the two.
+func (m *gitMetrics) recordOperation(ctx context.Context, operation, status, trigger string, duration time.Duration) {
 	attrs := metric.WithAttributes(
 		attribute.String("operation", operation),
 		attribute.String("status", status),
+		attribute.String("trigger", trigger),
 	)
 	m.operationTotal.Add(ctx, 1, attrs)
 	m.operationDuration.Record(ctx, duration.Seconds(), attrs)
@@ -181,5 +191,42 @@ func (m *gitMetrics) recordLFSPhaseBytes(ctx context.Context, repo, phase string
 	m.lfsPhaseBytes.Record(ctx, float64(sizeBytes), metric.WithAttributes(
 		attribute.String("repository", repo),
 		attribute.String("phase", phase),
+	))
+}
+
+// recordIncrementalServe records an incremental pull-through upload-pack serve event.
+// Outcome is one of: "local_hit", "fetched", "fallback_fetch_failed",
+// "fallback_missing", "fallback_local_error", "client_gone",
+// "client_gone_after_fetch", "fallback_not_our_ref". It is called once the serve
+// outcome is known, so a local serve that ended in an upstream passthrough is not
+// counted as a hit.
+func (m *gitMetrics) recordIncrementalServe(ctx context.Context, outcome, repo string) {
+	m.incrementalServeTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("outcome", outcome),
+		attribute.String("repository", repo),
+	))
+}
+
+// recordIncrementalEligible records an upload-pack POST that reached the incremental
+// pull-through decision point. Engaged is true when wants were extracted, so
+// the incremental path applies; false when the request bypassed it (ls-refs,
+// want-ref, no wants, parse failure). Recorded even when the feature is
+// config-disabled, so the ratio shows how much traffic would take the path
+// independently of the kill switch.
+func (m *gitMetrics) recordIncrementalEligible(ctx context.Context, engaged bool, repo string) {
+	m.incrementalEligibleTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.Bool("engaged", engaged),
+		attribute.String("repository", repo),
+	))
+}
+
+// recordIncrementalFetchDuration records how long the incremental pull-through
+// path took, from upload-pack handler entry through making the wanted objects
+// available. Recorded for every outcome, so local_hit gives the baseline for the
+// no-fetch-needed case.
+func (m *gitMetrics) recordIncrementalFetchDuration(ctx context.Context, outcome, repo string, duration time.Duration) {
+	m.incrementalFetchDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(
+		attribute.String("outcome", outcome),
+		attribute.String("repository", repo),
 	))
 }

--- a/internal/strategy/git/repack.go
+++ b/internal/strategy/git/repack.go
@@ -46,7 +46,7 @@ func (s *Strategy) scheduleRepackJobs(repo *gitclone.Repository) {
 		if err != nil {
 			status = "error"
 		}
-		s.metrics.recordOperation(ctx, "repack", status, time.Since(start))
+		s.metrics.recordOperation(ctx, "repack", status, "background", time.Since(start))
 
 		if after, countErr := countPackFiles(repo.Path()); countErr == nil {
 			s.metrics.recordRepackPackCount(ctx, upstream, "after", after)

--- a/internal/strategy/git/repocounts.go
+++ b/internal/strategy/git/repocounts.go
@@ -70,6 +70,12 @@ var (
 // Detection: POST /git-upload-pack whose pkt-line body contains no "have <oid>"
 // line. v2 command=ls-refs (discovery) is also rejected. The body is buffered
 // and replayed via io.NopCloser.
+//
+// ParseUploadPackRequest in uploadpack.go fully parses the body for incremental
+// pull-through. Both exist on purpose: RequestIsClone only needs a prefix to
+// detect haves, while the incremental path needs the full want list. If you
+// change pkt-line handling here, check whether uploadpack.go needs the same
+// fix.
 func RequestIsClone(pathValue string, r *http.Request) (bool, error) {
 	if r.Method != http.MethodPost || !strings.HasSuffix(pathValue, "/git-upload-pack") {
 		return false, nil

--- a/internal/strategy/git/snapshot.go
+++ b/internal/strategy/git/snapshot.go
@@ -183,7 +183,7 @@ func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone
 
 	cacheKey := snapshotCacheKey(upstream)
 	if head := s.getMirrorHead(ctx, repo); s.snapshotUnchanged(ctx, snapshotJobBase, cacheKey, upstream, head) {
-		s.metrics.recordOperation(ctx, "snapshot", "unchanged", time.Since(start))
+		s.metrics.recordOperation(ctx, "snapshot", "unchanged", "background", time.Since(start))
 		logger.InfoContext(ctx, "Snapshot unchanged, skipping generation", "upstream", upstream, "commit", head)
 		return "", nil
 	}
@@ -203,7 +203,7 @@ func (s *Strategy) generateAndUploadSnapshot(ctx context.Context, repo *gitclone
 		return "", errors.Wrap(err, "create snapshot")
 	}
 
-	s.metrics.recordOperation(ctx, "snapshot", "success", time.Since(start))
+	s.metrics.recordOperation(ctx, "snapshot", "success", "background", time.Since(start))
 	logger.InfoContext(ctx, "Snapshot generation completed", "upstream", upstream)
 	return commit, nil
 }
@@ -664,7 +664,7 @@ func (s *Strategy) handleBundleRequest(w http.ResponseWriter, r *http.Request, h
 		// An up-to-date verdict tells clients to skip their fallback freshen
 		// entirely, so it must be backed by a fetch this call actually ran —
 		// not the rate-limited skip or a coalesced concurrent holder.
-		freshenErr = s.doFetchVerified(ctx, repo)
+		freshenErr = s.doFetchVerified(ctx, repo, "background")
 	case !repo.HasCommit(ctx, base):
 		// Rate-limited so client-supplied bogus bases cannot hammer upstream;
 		// a 404 here only sends the client to its safe fallback freshen.
@@ -1334,11 +1334,11 @@ func (s *Strategy) generateAndUploadLFSSnapshot(ctx context.Context, repo *gitcl
 		if !cloneRecorded {
 			s.metrics.recordLFSPhase(ctx, upstream, "clone", "error", time.Since(cloneStart))
 		}
-		s.metrics.recordOperation(ctx, "lfs-snapshot", "error", time.Since(start))
+		s.metrics.recordOperation(ctx, "lfs-snapshot", "error", "background", time.Since(start))
 		return "", errors.Wrap(err, "create LFS snapshot")
 	}
 
-	s.metrics.recordOperation(ctx, "lfs-snapshot", "success", time.Since(start))
+	s.metrics.recordOperation(ctx, "lfs-snapshot", "success", "background", time.Since(start))
 	logger.InfoContext(ctx, "LFS snapshot generation completed", "upstream", upstream)
 	return commit, nil
 }

--- a/internal/strategy/git/uploadpack.go
+++ b/internal/strategy/git/uploadpack.go
@@ -1,0 +1,150 @@
+package git
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"io"
+
+	"github.com/alecthomas/errors"
+
+	"github.com/block/cachew/internal/gitclone"
+)
+
+// uploadPackParseLimit bounds CPU and memory spent on hostile request bodies.
+// Real upload-pack bodies are tiny (a few want lines plus optional haves), so
+// 4 MiB covers monorepo fetches and still bounds crafted input.
+const uploadPackParseLimit = 4 * 1024 * 1024
+
+// There is deliberately no separate cap on the number of want OIDs.
+// uploadPackParseLimit already bounds the want count: a want line is ~50 bytes
+// on the wire, so 4 MiB admits at most ~84k wants, which bounds both the map
+// here and the cat-file stdin the incremental path builds from it. An explicit
+// count cap only ever fired on legitimate traffic: repos with many refs
+// (tt-metal advertises ~38k) silently skipped the incremental path. cachew is a
+// trusted-environment cache, not a security boundary.
+
+// errBodyTooLarge is returned when a body exceeds uploadPackParseLimit. It is a
+// sentinel so callers can tell a declined but otherwise legitimate fetch from an
+// ordinary malformed body.
+var errBodyTooLarge = errors.Errorf("upload-pack body exceeds parse limit of %d bytes", uploadPackParseLimit)
+
+// UploadPackRequest is the parsed form of a git-upload-pack request body.
+type UploadPackRequest struct {
+	Wants    []string // unique want object IDs (40- or 64-char lower hex), in order of appearance
+	HasHaves bool     // body contains at least one "have <oid>" line. Informational only: incremental pull-through does not gate on it, because a fetch with haves may still need objects the mirror lacks. RequestIsClone in repocounts.go is the path that does gate on haves.
+	LsRefs   bool     // protocol v2 command=ls-refs (ref discovery, not a fetch)
+	WantRefs bool     // body contains protocol v2 "want-ref <ref>" lines
+}
+
+// ParseUploadPackRequest parses a git-upload-pack request body (pkt-line format,
+// protocol v0/v1 or v2). gzipEncoded indicates the body is gzip compressed
+// (Content-Encoding: gzip). A malformed or oversized body returns an error so
+// callers can skip incremental handling.
+func ParseUploadPackRequest(body []byte, gzipEncoded bool) (UploadPackRequest, error) {
+	data := body
+	if gzipEncoded {
+		gr, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return UploadPackRequest{}, errors.Wrap(err, "gzip reader")
+		}
+		decoded, err := io.ReadAll(io.LimitReader(gr, uploadPackParseLimit+1))
+		_ = gr.Close() //nolint:errcheck // best-effort
+		if err != nil {
+			return UploadPackRequest{}, errors.Wrap(err, "decompress upload-pack body")
+		}
+		data = decoded
+	}
+
+	if int64(len(data)) > uploadPackParseLimit {
+		return UploadPackRequest{}, errBodyTooLarge
+	}
+
+	return parsePktLines(data)
+}
+
+// parsePktLines decodes a pkt-line stream and extracts upload-pack semantics.
+func parsePktLines(data []byte) (UploadPackRequest, error) {
+	var result UploadPackRequest
+	seen := make(map[string]struct{})
+
+	for len(data) > 0 {
+		if len(data) < 4 {
+			return UploadPackRequest{}, errors.New("truncated pkt-line length")
+		}
+
+		lenHex := data[:4]
+		pktLen, err := parseHex4(lenHex)
+		if err != nil {
+			return UploadPackRequest{}, errors.Wrap(err, "invalid pkt-line length")
+		}
+
+		// pktLen 0 = flush-pkt, 1 = delim-pkt (v2), 2 = response-end. None carry a
+		// payload. The pkt-line spec reserves 0, 1 and 2; 3 is invalid.
+		if pktLen == 3 {
+			return UploadPackRequest{}, errors.New("invalid pkt-line length value 3")
+		}
+		if pktLen <= 2 {
+			data = data[4:]
+			continue
+		}
+
+		if pktLen > len(data) {
+			return UploadPackRequest{}, errors.Errorf("pkt-line length %d exceeds remaining data %d", pktLen, len(data))
+		}
+
+		payload := data[4:pktLen]
+		data = data[pktLen:]
+
+		payload = bytes.TrimSuffix(payload, []byte("\n"))
+
+		if err := handleLine(payload, &result, seen); err != nil {
+			return UploadPackRequest{}, err
+		}
+	}
+
+	return result, nil
+}
+
+// handleLine processes a single decoded pkt-line payload.
+func handleLine(line []byte, r *UploadPackRequest, seen map[string]struct{}) error {
+	switch {
+	case bytes.HasPrefix(line, []byte("want ")):
+		// First want line may carry capabilities after the OID. Protocol v0
+		// separates them with a NUL (gitprotocol-pack(5)); some clients and
+		// fixtures use a space. Truncate at the first of either.
+		rest := line[5:]
+		if i := bytes.IndexAny(rest, " \x00"); i >= 0 {
+			rest = rest[:i]
+		}
+		oid := string(rest)
+		if err := gitclone.ValidateOID(oid); err != nil {
+			return errors.Errorf("malformed want OID: %q", oid)
+		}
+		if _, dup := seen[oid]; !dup {
+			seen[oid] = struct{}{}
+			r.Wants = append(r.Wants, oid)
+		}
+
+	case bytes.HasPrefix(line, []byte("have ")):
+		r.HasHaves = true
+
+	case bytes.HasPrefix(line, []byte("command=ls-refs")):
+		r.LsRefs = true
+
+	case bytes.HasPrefix(line, []byte("want-ref ")):
+		r.WantRefs = true
+	}
+
+	return nil
+}
+
+// parseHex4 converts 4 ASCII hex bytes to an integer.
+func parseHex4(b []byte) (int, error) {
+	dst := make([]byte, 2)
+	n, err := hex.Decode(dst, b)
+	if err != nil || n != 2 {
+		return 0, errors.Errorf("invalid hex pkt-line length %q", b)
+	}
+	return int(dst[0])<<8 | int(dst[1]), nil
+}

--- a/internal/strategy/git/uploadpack_test.go
+++ b/internal/strategy/git/uploadpack_test.go
@@ -1,0 +1,229 @@
+package git_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/block/cachew/internal/strategy/git"
+)
+
+// pkt formats a single pkt-line with the length prefix.
+func pkt(s string) string {
+	n := len(s) + 4
+	return fmt.Sprintf("%04x%s", n, s)
+}
+
+const (
+	flushPkt = "0000"
+	delimPkt = "0001"
+)
+
+func sha1OID(prefix string) string {
+	s := prefix + strings.Repeat("0", 40-len(prefix))
+	return s
+}
+
+func sha256OID(prefix string) string {
+	s := prefix + strings.Repeat("0", 64-len(prefix))
+	return s
+}
+
+func buildBody(lines ...string) []byte {
+	return []byte(strings.Join(lines, ""))
+}
+
+func gzipBody(b []byte) []byte {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, _ = w.Write(b)
+	_ = w.Close()
+	return buf.Bytes()
+}
+
+func TestParseUploadPackRequest(t *testing.T) {
+	oid1 := sha1OID("aabbcc")
+	oid2 := sha1OID("ddeeff")
+	oid3 := sha256OID("112233")
+
+	tests := []struct {
+		name        string
+		body        []byte
+		gzip        bool
+		expected    git.UploadPackRequest
+		errContains string
+	}{
+		{
+			name: "V0FirstWantNULCapabilities",
+			// Real protocol v0 first-want: PKT-LINE("want" SP obj-id NUL capability-list LF).
+			body: buildBody(
+				pkt("want "+oid1+"\x00multi_ack side-band-64k agent=git/2.45\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{Wants: []string{oid1}},
+		},
+		{
+			name: "V0SubsequentWantSpaceCapabilities",
+			// Some fixtures and non-git clients separate capabilities with a space;
+			// accept either delimiter so incremental engages for both.
+			body: buildBody(
+				pkt("want "+oid1+" multi_ack side-band-64k agent=git/2.45\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{Wants: []string{oid1}},
+		},
+		{
+			name: "V0MultipleWantsAndHavesAndDone",
+			body: buildBody(
+				pkt("want "+oid1+"\x00multi_ack side-band-64k\n"),
+				pkt("want "+oid2+"\n"),
+				flushPkt,
+				pkt("have "+oid1+"\n"),
+				pkt("done\n"),
+			),
+			expected: git.UploadPackRequest{Wants: []string{oid1, oid2}, HasHaves: true},
+		},
+		{
+			name: "V1IgnoresUnknownLines",
+			body: buildBody(
+				pkt("version=1\n"),
+				pkt("want "+oid1+"\n"),
+				pkt("want "+oid2+"\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{Wants: []string{oid1, oid2}},
+		},
+		{
+			name: "V2CommandFetchWithWantsAndHaves",
+			body: buildBody(
+				pkt("command=fetch\n"),
+				pkt("agent=git/2.45\n"),
+				delimPkt,
+				pkt("want "+oid1+"\n"),
+				pkt("want "+oid2+"\n"),
+				pkt("have "+oid1+"\n"),
+				pkt("done\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{Wants: []string{oid1, oid2}, HasHaves: true},
+		},
+		{
+			name: "V2CommandLsRefs",
+			body: buildBody(
+				pkt("command=ls-refs\n"),
+				pkt("agent=git/2.45\n"),
+				delimPkt,
+				pkt("peel\n"),
+				pkt("symrefs\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{LsRefs: true},
+		},
+		{
+			name: "V2WantRef",
+			body: buildBody(
+				pkt("command=fetch\n"),
+				delimPkt,
+				pkt("want-ref refs/heads/main\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{WantRefs: true},
+		},
+		{
+			name: "DuplicateWantsDeduped",
+			body: buildBody(
+				pkt("want "+oid1+"\n"),
+				pkt("want "+oid1+"\n"),
+				pkt("want "+oid2+"\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{Wants: []string{oid1, oid2}},
+		},
+		{
+			name: "SHA256Wants",
+			body: buildBody(
+				pkt("want "+oid3+"\n"),
+				flushPkt,
+			),
+			expected: git.UploadPackRequest{Wants: []string{oid3}},
+		},
+		{
+			name: "GzipEncodedBody",
+			body: gzipBody(buildBody(
+				pkt("want "+oid1+"\n"),
+				pkt("have "+oid2+"\n"),
+				flushPkt,
+			)),
+			gzip:     true,
+			expected: git.UploadPackRequest{Wants: []string{oid1}, HasHaves: true},
+		},
+		{
+			name:     "EmptyBody",
+			body:     []byte{},
+			expected: git.UploadPackRequest{},
+		},
+		{
+			name:        "GarbageNonPktBody",
+			body:        []byte("not a pkt-line body at all!!"),
+			errContains: "invalid",
+		},
+		{
+			name:        "TruncatedPktLength",
+			body:        []byte("001"),
+			errContains: "truncated",
+		},
+		{
+			name:        "MalformedWantOID",
+			body:        buildBody(pkt("want ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ\n")),
+			errContains: "malformed want OID",
+		},
+		{
+			name: "BodyExceedingParseLimit",
+			// Build a body that just exceeds the 4 MiB limit using repeated tiny pkt-lines.
+			body: func() []byte {
+				chunk := []byte(pkt("have " + oid1 + "\n"))
+				repeat := (git.UploadPackParseLimit / len(chunk)) + 1
+				return bytes.Repeat(chunk, repeat)
+			}(),
+			errContains: "exceeds parse limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := git.ParseUploadPackRequest(tt.body, tt.gzip)
+			if tt.errContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Zero(t, got, "a parse failure must not return a partially populated request")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestParseUploadPackRequestManyWants pins the absence of a want-count cap:
+// repos with thousands of refs (tt-metal advertises ~38k) must keep their full
+// want list so the incremental path stays engaged. The only bound is
+// uploadPackParseLimit, which admits ~84k want lines.
+func TestParseUploadPackRequestManyWants(t *testing.T) {
+	const wantCount = 20000
+
+	var b strings.Builder
+	for i := range wantCount {
+		b.WriteString(pkt(fmt.Sprintf("want %040x\n", i)))
+	}
+	b.WriteString(flushPkt)
+
+	got, err := git.ParseUploadPackRequest([]byte(b.String()), false)
+	assert.NoError(t, err)
+	assert.Equal(t, wantCount, len(got.Wants))
+	assert.Equal(t, fmt.Sprintf("%040x", 0), got.Wants[0])
+	assert.Equal(t, fmt.Sprintf("%040x", wantCount-1), got.Wants[wantCount-1])
+}


### PR DESCRIPTION
Closes #399. Requesting Comments.

## Notes for reviewers

- AI was used to do some organization, review, generated most of the test code, and the helper script to show the incremental pullthrough metrics.
- Commits are organized atomically and can be individually dropped with no hard feelings. I planned on dropping the metrics script at the very least.
- For the implementation I took inspiration from how [git_cdn](https://gitlab.com/grouperenault/git_cdn) (MIT License) does it.
- I've been experimenting with deploying cachew on an internal CI cluster and the results have been promising.

## Summary

Adds incremental pull-through for git mirrors: when a client fetch can be satisfied by objects already in the local mirror, serve it directly instead of falling back to a full upstream fetch. When it cannot, fetch the missing delta, coalescing with any concurrent fetch and verifying the objects arrived.

- Batch missing-object detection (`internal/gitclone/objects.go`)
- Upload-pack request body parsing for v0/v2, including want-ref and haves
- Fetch coalescing and verified-if-absent fetch paths
- A standalone fix for a pre-existing race in the upstream ref-freshness check (singleflight plus a cached verdict), landed separately because the new request-path usage is what surfaces it
- Incremental pull-through metrics (hit rate, fallback reasons, fetch latency, upstream requests avoided)
- The core serving path: satisfy fetches from the mirror when possible, forward otherwise
- A size cap on buffered upload-pack request bodies, with a 413 response above it
- README documentation
- An operator script for querying the new metrics from Prometheus

Each commit builds and passes its package's tests independently.

## New metrics

Three new metrics from incremental pull-through, plus a new label on an existing one.

| Metric | Type | Labels | What it measures |
|---|---|---|---|
| `cachew_git_incremental_serves_total` | counter | outcome, repository | How each request finished: served from the mirror, fetched then served, or a fallback reason |
| `cachew_git_incremental_eligible_total` | counter | engaged, repository | How many upload-pack requests reached the incremental check, and whether they used it |
| `cachew_git_incremental_fetch_duration_seconds` | histogram | outcome, repository | How long each request took, from handler start to the objects being ready |

`cachew_git_operation_duration_seconds` and `cachew_git_operations_total` also gained a new `trigger` label (`background` or `incremental`), so fetches this feature triggers can be told apart from the existing scheduled background fetches.

## Benchmark: tenstorrent/tt-metal through cachew, cold vs. hot mirror

Six clones on one sandbox host, using this branch's cachewd with incremental pull-through on. The client ran `git clone [--depth N] http://127.0.0.1:<port>/git/github.com/tenstorrent/tt-metal <dir>` and measured wall time.

Cold: the repo has never been mirrored, so the request forwards to upstream while a mirror builds in the background.
Hot: the mirror is already built and the pack comes from it. Each run was checked against the log to confirm which path it actually took.

| Scenario | Depth | Cache state | Wall time | Notes |
|---|---|---|---|---|
| Full clone | full | cold | **76.8 s** | re-run 72.8 s. Forwarded to upstream while the mirror builds. |
| Full clone | full | hot | **53.3 s** | re-run 53.3 s. Served entirely from the mirror. |
| Shallow clone | `--depth 1` | cold | **11.0 s** | Forwarded to upstream. Still starts a full background mirror build. |
| Shallow clone | `--depth 1` | hot | **7.6 s** | No upstream contact. Refs and pack both from the mirror. |
| Shallow clone | `--depth 500` | cold | **13.4 s** | Forwarded to upstream. Full background mirror build. |
| Shallow clone | `--depth 500` | hot | **8.1 s** | Pack from the mirror. One upstream refs check, age based, not depth based. |

For comparison, cloning tt-metal directly from GitHub on the same host took 56.0 s and 60.5 s (average 58.3 s). So a hot full clone through cachew is a bit faster than cloning directly, and a cold full clone is about 28% slower.

Resulting client repos, for comparison:

| Depth | Size (total / `.git`) | Objects | Commits | Refs | Shallow |
|---|---|---|---|---|---|
| full | 2.4 G / 2.0 G | 1,365,716 | 132,178 | 7,291 | no |
| `--depth 500` | 604 M / 194 M | 34,334 | 500 | 15 | yes |
| `--depth 1` | 600 M / 190 M | 23,315 | 1 | 3 | yes |

The mirror itself is 2.5 G with 37,103 refs, more than a client clone gets since the mirror also keeps the full `refs/pull/*` namespace.

### Caveats

- Cold numbers only cover what the client waited for. The mirror keeps building in the background well after that, sometimes for several minutes, regardless of what depth the client asked for. Cold clones also compete with that build for network and disk, which is part of why cold is slower than a direct clone.
- Full clones were run twice each and agreed closely. The four shallow numbers are single runs.
- GitHub's tt-metal HEAD moved during the session, so the full clones do not all point at the same commit. This was intentional.
- The proxy and client ran on the same host, so these numbers do not include a real network hop between them.

