### PR TITLE
fix(gitclone): keep Git credentials out of process arguments

### DIFF
--- a/internal/gitclone/command.go
+++ b/internal/gitclone/command.go
@@ -5,7 +5,10 @@ package gitclone
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
+	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/alecthomas/errors"
@@ -35,18 +38,48 @@ func (r *Repository) GitCommand(ctx context.Context, args ...string) (*exec.Cmd,
 		allArgs = append(allArgs, configArgs...)
 	}
 
-	// Add credential helper configuration if we have a token
-	// This ensures git uses the GitHub App token for authentication
-	// for all operations (clone, fetch, remote update, etc.)
+	var credentialConfigKey string
+	var credentialConfigValue string
 	if token != "" {
-		escapedToken := strings.ReplaceAll(token, "'", "'\\''")
-		credHelper := "!f() { test \"$1\" = get && echo username=x-access-token && printf 'password=%s\\n' '" + escapedToken + "'; }; f"
-		allArgs = append(allArgs, "-c", "credential.helper="+credHelper)
+		credentialConfigKey = "http." + repoURL + ".extraHeader"
+		basicToken := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+		credentialConfigValue = "Authorization: Basic " + basicToken
 	}
 
 	allArgs = append(allArgs, args...)
 
-	return exec.CommandContext(ctx, "git", allArgs...), nil
+	cmd := exec.CommandContext(ctx, "git", allArgs...)
+	if credentialConfigKey != "" {
+		cmd.Env = appendGitConfigEnv(os.Environ(), credentialConfigKey, credentialConfigValue)
+	}
+	return cmd, nil
+}
+
+func appendGitConfigEnv(env []string, key, value string) []string {
+	index := 0
+	result := make([]string, 0, len(env)+3)
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		if name == "GIT_CONFIG_COUNT" {
+			continue
+		}
+		result = append(result, entry)
+		for _, prefix := range []string{"GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_"} {
+			suffix, ok := strings.CutPrefix(name, prefix)
+			if !ok {
+				continue
+			}
+			candidate, err := strconv.Atoi(suffix)
+			if err == nil && candidate >= index {
+				index = candidate + 1
+			}
+		}
+	}
+	return append(result,
+		"GIT_CONFIG_COUNT="+strconv.Itoa(index+1),
+		"GIT_CONFIG_KEY_"+strconv.Itoa(index)+"="+key,
+		"GIT_CONFIG_VALUE_"+strconv.Itoa(index)+"="+value,
+	)
 }
 
 func getInsteadOfDisableArgsForURL(ctx context.Context, targetURL string) ([]string, error) {

--- a/internal/gitclone/command_test.go
+++ b/internal/gitclone/command_test.go
@@ -2,6 +2,7 @@ package gitclone //nolint:testpackage // Internal functions need to be tested
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -91,27 +92,24 @@ func TestGitCommandWithCredentialProvider(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name          string
-		token         string
-		expectHelper  bool
-		expectedToken string
+		name             string
+		token            string
+		expectCredential bool
 	}{
 		{
-			name:          "WithValidToken",
-			token:         "ghp_test123456",
-			expectHelper:  true,
-			expectedToken: "ghp_test123456",
+			name:             "WithValidToken",
+			token:            "ghp_test123456",
+			expectCredential: true,
 		},
 		{
-			name:          "WithTokenContainingSingleQuote",
-			token:         "token'with'quotes",
-			expectHelper:  true,
-			expectedToken: "token'with'quotes",
+			name:             "WithTokenContainingSingleQuote",
+			token:            "token'with'quotes",
+			expectCredential: true,
 		},
 		{
-			name:         "WithEmptyToken",
-			token:        "",
-			expectHelper: false,
+			name:             "WithEmptyToken",
+			token:            "",
+			expectCredential: false,
 		},
 	}
 
@@ -128,19 +126,55 @@ func TestGitCommandWithCredentialProvider(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotZero(t, cmd)
 
-			if tt.expectHelper {
-				found := false
-				for i, arg := range cmd.Args {
-					if arg == "-c" && i+1 < len(cmd.Args) {
-						if strings.Contains(cmd.Args[i+1], "credential.helper=") {
-							found = true
-							assert.True(t, strings.Contains(cmd.Args[i+1], "username=x-access-token"))
-							break
-						}
-					}
+			for _, arg := range cmd.Args {
+				assert.False(t, strings.Contains(arg, "extraHeader"))
+				if tt.token != "" {
+					assert.False(t, strings.Contains(arg, tt.token))
 				}
-				assert.True(t, found, "expected credential.helper to be configured")
 			}
+			found := false
+			for _, entry := range cmd.Env {
+				if strings.HasPrefix(entry, "GIT_CONFIG_KEY_") && strings.HasSuffix(entry, ".extraHeader") {
+					found = true
+				}
+			}
+			assert.Equal(t, tt.expectCredential, found)
 		})
 	}
+}
+
+func TestGitCommandCredentialEnvironmentConfiguresGit(t *testing.T) {
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "protocol.version")
+	t.Setenv("GIT_CONFIG_VALUE_0", "2")
+	repo := &Repository{
+		upstreamURL:        "https://github.com/org/repo",
+		credentialProvider: &mockCredentialProvider{token: "test-token"},
+	}
+	cmd, err := repo.GitCommand(t.Context(), "config", "--get-urlmatch", "http.extraHeader", repo.upstreamURL)
+	assert.NoError(t, err)
+	output, err := cmd.Output()
+	assert.NoError(t, err)
+	basicToken := base64.StdEncoding.EncodeToString([]byte("x-access-token:test-token"))
+	assert.Equal(t, "Authorization: Basic "+basicToken+"\n", string(output))
+}
+
+func TestAppendGitConfigEnvUsesNextIndex(t *testing.T) {
+	env := appendGitConfigEnv([]string{
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=protocol.version",
+		"GIT_CONFIG_VALUE_0=2",
+		"GIT_CONFIG_KEY_1=http.version",
+		"GIT_CONFIG_VALUE_1=HTTP/2",
+	}, "http.https://github.com/org/repo.extraHeader", "Authorization: Basic secret")
+	countEntries := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "GIT_CONFIG_COUNT=") {
+			countEntries++
+		}
+	}
+	assert.Equal(t, 1, countEntries)
+	assert.Equal(t, "GIT_CONFIG_COUNT=3", env[len(env)-3])
+	assert.Equal(t, "GIT_CONFIG_KEY_2=http.https://github.com/org/repo.extraHeader", env[len(env)-2])
+	assert.Equal(t, "GIT_CONFIG_VALUE_2=Authorization: Basic secret", env[len(env)-1])
 }


### PR DESCRIPTION
## Summary

- replace the shell-form credential helper with a repository-scoped HTTP `Authorization` header
- pass the sensitive Git configuration through `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`, and `GIT_CONFIG_VALUE_*` instead of `-c`
- keep GitHub App installation tokens out of Git and credential-helper subprocess command lines
- preserve inherited environment-based Git configuration, append the authorization at the next index, and replace the old count
- add coverage proving the token is absent from arguments and the environment configuration is honored by Git

Fixes #402.

## Testing

- `just lint`
- `go test -race -timeout 180s ./internal/gitclone ./internal/strategy/git ./internal/githubapp`
- `just test` runs successfully outside the S3 suites; the S3 tests could not start MinIO because Docker is not installed in the local environment
