### PR TITLE
docs: correct github-releases URL pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ git {
 
 Caches public and private GitHub release assets. Private orgs use a token or GitHub App for authentication.
 
-**URL pattern:** `/github-releases/{owner}/{repo}/{tag}/{asset}`
+**URL pattern:** `/github.com/{owner}/{repo}/releases/download/{tag}/{asset}`
+
+The path mirrors the upstream GitHub download URL, so clients only need the cache host prefixed.
 
 ```hcl
 github-releases {


### PR DESCRIPTION
The README documents the github-releases strategy as `/github-releases/{owner}/{repo}/{tag}/{asset}`, but no such route is registered.

The strategy registers `GET /github.com/{org}/{repo}/releases/download/{rest...}` (`internal/strategy/github_releases.go:75`), mirroring the upstream GitHub download path — which is also how the hermit strategy redirects into it.

Docs-only change.